### PR TITLE
Let Chance.integer max or min equal zero

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -44,8 +44,8 @@
         var num, range;
 
         options = options || {};
-        options.min = options.min || -9007199254740992;
-        options.max = options.max || 9007199254740992;
+        options.min = (typeof options.max !== "undefined") ? options.min : -9007199254740992;
+        options.max = (typeof options.max !== "undefined") ? options.max : 9007199254740992;
 
         // Greatest of absolute value of either max or min so we know we're
         // including the entire search domain.


### PR DESCRIPTION
Currently, setting the max or the min for an integer to be zero will instead set that end of the range to the default.
