### PR TITLE
Middle_initial option is wrongly demoed

### DIFF
--- a/name/_posts/1900-01-01-name.md
+++ b/name/_posts/1900-01-01-name.md
@@ -25,7 +25,7 @@ Optionally include the middle name
 Optionally include the middle initial
 
 {% highlight js %}
-  Chance.name({middle: true});
+  Chance.name({middle_initial: true});
   => 'Ezme I Iza'
 {% endhighlight %}
 


### PR DESCRIPTION
Fix for a wrong example for middle_initial option in the name function
