### PR TITLE
Canada

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -499,6 +499,16 @@
         return zip;
     };
 
+    Chance.prototype.postal = function(options) {
+        // Postal District
+        var pd = this.character({pool:"XVTSRPNKLMHJGECBA"});
+        // Forward Sortation Area (FSA)
+        var fsa = pd + this.natural({max: 9}) + this.character({alpha: true, casing: "upper"});
+        // Local Delivery Unut (LDU)
+        var ldu = this.natural({max: 9}) + this.character({alpha: true, casing: "upper"}) + this.natural({max: 9}); 
+
+        return fsa + " " + ldu;
+    };
     // -- End Address --
 
     // -- Miscellaneous --


### PR DESCRIPTION
I added the Canadian provinces with their two digit standard abbreviations as well as Canadian postal codes. The postal code is valid in that it follows the correct structure and includes only valid postal district indicators (first character). Other than that, they are purely cosmetic.
