### PR TITLE
refactoring and test color method

### DIFF
--- a/test/test.web.js
+++ b/test/test.web.js
@@ -73,5 +73,74 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
                 expect(twitter).to.match(/\@[A-Za-z]+/m);
             });
         });
+
+        describe('color', function () {
+
+            it("({format: 'hex'}) returns what looks a hex color", function () {
+                _(1000).times(function () {
+                    var color = chance.color({format: 'hex'});
+                    expect(color).to.be.a('string');
+                    expect(color).to.have.length(7);
+                    expect(color).to.match(/#[a-z0-9]+/m);
+                });
+            });
+
+            it("({format: 'hex', grayScale: true}) returns what looks a gray scale hex color", function () {
+                _(1000).times(function () {
+                    var color = chance.color({format: 'hex', grayscale: true});
+                    expect(color).to.be.a('string');
+                    expect(color).to.have.length(7);
+                    expect(color).to.match(/#[a-z0-9]+/m);
+                    expect(color.slice(1, 3)).to.equal(color.slice(3, 5));
+                    expect(color.slice(1, 3)).to.equal(color.slice(5, 7));
+                });
+            });
+
+            it("({format: 'shorthex'}) returns what looks a short hex color", function () {
+                _(1000).times(function () {
+                    var color = chance.color({format: 'shorthex'});
+                    expect(color).to.be.a('string');
+                    expect(color).to.have.length(4);
+                    expect(color).to.match(/#[a-z0-9]+/m);
+                });
+            });
+
+            it("({format: 'shorthex', grayScale: true}) returns what looks a gray scale short hex color", function () {
+                _(1000).times(function () {
+                    var color = chance.color({format: 'shorthex', grayscale: true});
+                    expect(color).to.be.a('string');
+                    expect(color).to.have.length(4);
+                    expect(color).to.match(/#[a-z0-9]+/m);
+                    expect(color.slice(1, 2)).to.equal(color.slice(2, 3));
+                    expect(color.slice(1, 2)).to.equal(color.slice(3, 4));
+                });
+            });
+
+            it("({format: 'rgb'}) returns what looks a rgb color", function () {
+                _(1000).times(function () {
+                    var color = chance.color({format: 'rgb'});
+                    expect(color).to.be.a('string');
+                    var matchColors = /rgb\((\d{1,3}),(\d{1,3}),(\d{1,3})\)/;
+                    var match = matchColors.exec(color);
+                    expect(match).to.have.length.of(4);
+                    expect(match[1]).to.be.within(0, 255);
+                    expect(match[2]).to.be.within(0, 255);
+                    expect(match[3]).to.be.within(0, 255);
+                });
+            });
+
+            it("({format: 'rgb', grayScale: true}) returns what looks a gray scale rgb color", function () {
+                _(1000).times(function () {
+                    var color = chance.color({format: 'rgb', grayscale: true});
+                    expect(color).to.be.a('string');
+                    var matchColors = /rgb\((\d{1,3}),(\d{1,3}),(\d{1,3})\)/;
+                    var match = matchColors.exec(color);
+                    expect(match).to.have.length.of(4);
+                    expect(match[1]).to.be.within(0, 255);
+                    expect(match[1]).to.equal(match[2]);
+                    expect(match[1]).to.equal(match[3]);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
- change `hash` method to support lower and uppercase, so it can used by `color` or `guid` as well
- change color method to use `hash` method and make it bit simpler
- put common chars, numbers into global static variables
- remove unused arguments and variables
- remove `min:0` as option for `natural` as this is the default option
- add tests for color
