### PR TITLE
Allow pick to return multiple elements

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -199,8 +199,12 @@
         return word.charAt(0).toUpperCase() + word.substr(1);
     };
 
-    Chance.prototype.pick = function (arr) {
-        return arr[this.natural({max: arr.length - 1})];
+    Chance.prototype.pick = function (arr, count) {
+        if (!count || count === 1) {
+            return arr[this.natural({max: arr.length - 1})];
+        } else {
+            return this.shuffle(arr).slice(0, count);
+        }
     };
 
     Chance.prototype.shuffle = function (arr) {

--- a/test/test.helpers.js
+++ b/test/test.helpers.js
@@ -15,11 +15,19 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
         });
 
         describe("pick()", function () {
-            it("returns a single element", function () {
+            it("returns a single element when called without a count argument", function () {
                 arr = ['a', 'b', 'c', 'd'];
                 _(1000).times(function () {
                     picked = chance.pick(arr);
                     expect(picked).to.have.length(1);
+                });
+            });
+
+            it("returns multiple elements when called with a count argument", function () {
+                arr = ['a', 'b', 'c', 'd'];
+                _(1000).times(function () {
+                    picked = chance.pick(arr, 3);
+                    expect(picked).to.have.length(3);
                 });
             });
         });


### PR DESCRIPTION
Similar to jashkenas/underscore#963 and Ruby's [sample](http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-sample), allow `pick` to take a count argument that will return that many random elements.

``` javascript
var suits = ['spades', 'hearts', 'clubs', 'diamonds'];
var deck = _.times(52, function(n) {
  return { value: n % 13, suit: suits[Math.floor(n / 13)] }; 
});

var hand  = chance.pick(deck, 7);
```
