### PR TITLE
Corrected display of negative min dollar.

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -964,7 +964,11 @@
             dollar = dollar + '0';
         }
 
-        return '$' + dollar;
+        if (dollar < 0) {
+            return '-$' + dollar.replace('-', '');
+        } else {
+            return '$' + dollar;
+        }
     };
 
     Chance.prototype.exp = function (options) {


### PR DESCRIPTION
Ran into this issue while trying to show negative gain. Format should be -$x.xx instead of $-x.xx for currency if it's a negative value.
