### PR TITLE
make `new` optional

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -15,6 +15,10 @@
 
     // Constructor
     var Chance = function (seed) {
+        if (!(this instanceof Chance)) {
+            return new Chance(seed);
+        }
+
         if (seed !== undefined) {
             // If we were passed a generator rather than a seed, use it.
             if (typeof seed === 'function') {


### PR DESCRIPTION
Alternate solution for issue #37, allows one-line require and initialization:

``` javascript
var chance = require('chance').Chance();
```
