### PR TITLE
Added Altitude, depth, and geoJson

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -551,6 +551,21 @@
         return this.latitude(options) + ', ' + this.longitude(options);
     };
 
+    Chance.prototype.geoJson = function (options) {
+        options = initOptions(options);
+        return this.latitude(options) + ', ' + this.longitude(options) + ', ' + this.altitude(options) ;
+    };
+    
+    Chance.prototype.altitude = function (options) {
+        options = initOptions(options, {fixed : 5});
+        return this.floating({min: 0, max: 32736000, fixed: options.fixed});
+    };
+    
+    Chance.prototype.depth = function (options) {
+        options = initOptions(options, {fixed : 5});
+        return this.floating({min: -35994, max: 0, fixed: options.fixed});
+    };
+    
     Chance.prototype.latitude = function (options) {
         options = initOptions(options, {fixed : 5});
         return this.floating({min: -90, max: 90, fixed: options.fixed});


### PR DESCRIPTION
geoJson and KML have options to include altitude, so why not.
Altitude is given from ground or 0 (rel or abs) to the approx Exosphere (6200mi). 
Depth is given from sea level to -35994 (deep as the Pacific Ocean goes).
