### PR TITLE
Added Mac Address Generation.

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1055,6 +1055,32 @@
         return guid;
     };
 
+    //Mac Address
+    Chance.prototype.mac_address = function(options){
+        // typically mac addresses are separated by ":"
+        // however they can also be separated by "-"
+        // the network variant uses a dot every fourth byte
+        
+        options = initOptions(options);
+        if(!options.separator) options.separator =  options.networkVersion ? "." : ":";
+        
+        var mac_pool="ABCDEF1234567890",
+            mac = "";
+        if(!options.networkVersion){
+            mac = this.string({pool: mac_pool, length:2}) + options.separator +
+              this.string({pool: mac_pool, length:2}) + options.separator +
+              this.string({pool: mac_pool, length:2}) + options.separator +
+              this.string({pool: mac_pool, length:2}) + options.separator +
+              this.string({pool: mac_pool, length:2}) + options.separator +
+              this.string({pool: mac_pool, length:2});
+        }else{
+            mac = this.string({pool: mac_pool, length:4}) + options.separator +
+                this.string({pool: mac_pool, length:4}) + options.separator + 
+                this.string({pool: mac_pool, length:4});
+        }
+        return mac;
+    };
+    
     // Hash
     Chance.prototype.hash = function (options) {
         options = initOptions(options, {length : 40, casing: 'lower'});

--- a/test/test.misc.js
+++ b/test/test.misc.js
@@ -85,6 +85,39 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
         });
     });
 
+      describe("Mac Address", function () {
+        var mac, chance = new Chance();
+
+        it("returns a proper mac address", function () {
+            _(1000).times(function () {
+                mac = chance.mac_address();
+                expect(mac).to.match(/([0-9a-fA-F]){2}:([0-9a-fA-F]){2}:([0-9a-fA-F]){2}:([0-9a-fA-F]){2}:([0-9a-fA-F]){2}:([0-9a-fA-F]){2}/);
+            });
+        });
+
+        it("returns a proper colon separated mac address", function () {
+            _(1000).times(function () {
+                mac = chance.mac_address({separator: ":"});
+                expect(mac).to.match(/([0-9a-fA-F]){2}:([0-9a-fA-F]){2}:([0-9a-fA-F]){2}:([0-9a-fA-F]){2}:([0-9a-fA-F]){2}:([0-9a-fA-F]){2}/);
+            });
+        });
+
+        it("returns a proper hyphen separated mac address", function () {
+            _(1000).times(function () {
+                mac = chance.mac_address({separator:"-"});
+                expect(mac).to.match(/([0-9a-fA-F]){2}-([0-9a-fA-F]){2}-([0-9a-fA-F]){2}-([0-9a-fA-F]){2}-([0-9a-fA-F]){2}-([0-9a-fA-F]){2}/);
+            });
+        });
+
+        it("returns a proper network version mac address", function () {
+            _(1000).times(function () {
+                mac = chance.mac_address({networkVersion:true});
+                expect(mac).to.match(/([0-9a-fA-F]){4}.([0-9a-fA-F]){4}.([0-9a-fA-F]){4}/);
+            });
+        });
+
+    });
+
     describe("Guid", function () {
         var guid, chance = new Chance();
 


### PR DESCRIPTION
Take 2 with a fresh copy ;)

Added Mac Addresses.
Mac Addresses are generally hex strings in 6 groups of 2. It can be separated by a user defined separated , defaults to colon. Network version, when set to true, will give 3 groups of four which is a common format on network equipment. Default separator is a dot (although it can be specified otherwise).

Added code to chance.js and to test\test.misc.js
