### PR TITLE
Adds length support for email string + tests

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -549,7 +549,7 @@
 
     Chance.prototype.email = function (options) {
         options = initOptions(options);
-        return this.word() + '@' + (options.domain || this.domain());
+        return this.word({length: options.length}) + '@' + (options.domain || this.domain());
     };
 
     Chance.prototype.fbid = function () {

--- a/test/test.web.js
+++ b/test/test.web.js
@@ -44,6 +44,13 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
             });
         });
 
+        it("email() has a length specified, it should generate a string before the domain with an equal length", function () {
+            _(1000).times(function () {
+                email = chance.email({length: 5});
+                expect(email.split('@')[0].length).to.equal(5);
+            });
+        });
+
         it("fbid() returns what looks like a Facebook id", function () {
             _(1000).times(function () {
                 expect(chance.fbid()).to.be.a('number');


### PR DESCRIPTION
When using a predefined domain, sometimes the word generated before @ has already been generated before. 

This adds a length support to decrease the chance of having two same emails when calling the method repeatedly (tests). 
