### PR TITLE
Adds support for generating realistic looking UK landline and mobile phone numbers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,23 +1,26 @@
 {
-    "name": "chance",
-    "version": "0.6.1",
-    "main": "chance.js",
-    "ignore": ["node_modules"],
-    "description": "Chance - Utility library to generate anything random",
-    "homepage": "http://chancejs.com",
-    "keywords": [
-        "chance",
-        "random",
-        "generator"
-    ],
-    "author": {
-        "name": "Victor Quinn",
-        "web": "http://victorquinn.com"
-    },
-    "devDependencies": {
-        "mocha": "1.18.0",
-        "chai": "~1.9.0",
-        "requirejs": "~2.1.11",
-        "lodash": "~2.4.1"
-    }
+  "name": "chance",
+  "version": "0.6.1",
+  "main": "chance.js",
+  "ignore": [
+    "node_modules"
+  ],
+  "description": "Chance - Utility library to generate anything random",
+  "homepage": "http://chancejs.com",
+  "keywords": [
+    "chance",
+    "random",
+    "generator"
+  ],
+  "author": {
+    "name": "Victor Quinn",
+    "web": "http://victorquinn.com"
+  },
+  "devDependencies": {
+    "mocha": "1.18.0",
+    "chai": "~1.9.0",
+    "requirejs": "~2.1.11",
+    "lodash": "~2.4.1",
+    "phone_number_js": "~1.0.0"
+  }
 }

--- a/chance.js
+++ b/chance.js
@@ -697,18 +697,56 @@
     };
 
     Chance.prototype.phone = function (options) {
-        options = initOptions(options, {formatted : true});
+        var self = this,
+            numPick,
+            ukNum = function (parts) {
+                var section = [];
+                //fills the section part of the phone number with random numbers.
+                parts.sections.forEach(function(n) {
+                    section.push(self.string({ pool: '0123456789', length: n}));
+                });
+                return parts.area + section.join(' ');
+            };
+        options = initOptions(options, {
+            formatted: true,
+            ukPhone: false,
+            ukMobile: false
+        });
         if (!options.formatted) {
             options.parens = false;
         }
-        var areacode = this.areacode(options).toString();
-        var exchange = this.natural({min: 2, max: 9}).toString() +
-                this.natural({min: 0, max: 9}).toString() +
-                this.natural({min: 0, max: 9}).toString();
-
-        var subscriber = this.natural({min: 1000, max: 9999}).toString(); // this could be random [0-9]{4}
-
-        return options.formatted ? areacode + ' ' + exchange + '-' + subscriber : areacode + exchange + subscriber;
+        if (options.ukPhone) {
+            numPick = chance.pick([
+                //valid area codes of major cities/counties followed by random numbers in required format.
+                { area: '01' + this.character({ pool: '234569' }) + '1 ', sections: [3,4] },
+                { area: '020 ' + this.character({ pool: '378' }), sections: [3,4] },
+                { area: '023 ' + this.character({ pool: '89' }), sections: [3,4] },
+                { area: '024 7', sections: [3,4] },
+                { area: '028 ' + this.pick(['25','28','37','71','82','90','92','95']), sections: [2,4] },
+                { area: '012' + this.pick(['04','08','54','76','97','98']) + ' ', sections: [5] },
+                { area: '013' + this.pick(['63','64','84','86']) + ' ', sections: [5] },
+                { area: '014' + this.pick(['04','20','60','61','80','88']) + ' ', sections: [5] },
+                { area: '015' + this.pick(['24','27','62','66']) + ' ', sections: [5] },
+                { area: '016' + this.pick(['06','29','35','47','59','95']) + ' ', sections: [5] },
+                { area: '017' + this.pick(['26','44','50','68']) + ' ', sections: [5] },
+                { area: '018' + this.pick(['27','37','84','97']) + ' ', sections: [5] },
+                { area: '019' + this.pick(['00','05','35','46','49','63','95']) + ' ', sections: [5] }
+            ]);
+            return options.formatted ? ukNum(numPick) : ukNum(numPick).replace(' ', '', 'g');
+        } else if (options.ukMobile) {
+            numPick = chance.pick([
+                { area: '07' + this.pick(['4','5','7','8','9']), sections: [2,6] },
+                { area: '07624 ', sections: [6] }
+            ]);
+            return options.formatted ? ukNum(numPick) : ukNum(numPick).replace(' ', '');
+        } else {
+            var areacode = this.areacode(options).toString();
+            var exchange = this.natural({ min: 2, max: 9 }).toString() +
+                this.natural({ min: 0, max: 9 }).toString() +
+                this.natural({ min: 0, max: 9 }).toString();
+            var subscriber = this.natural({ min: 1000, max: 9999 }).toString(); // this could be random [0-9]{4}
+            return options.formatted ? areacode + ' ' + exchange + '-' + subscriber : areacode + exchange + subscriber;
+        }
     };
 
     Chance.prototype.postal = function () {

--- a/test/base.js
+++ b/test/base.js
@@ -3,7 +3,8 @@ require.config({
         'Chance': '../chance',
         'chai': 'lib/chai/chai',
         'mocha': 'lib/mocha/mocha',
-        'underscore': 'lib/lodash/dist/lodash'
+        'underscore': 'lib/lodash/dist/lodash',
+        'phoneTest': 'lib/phone_number_js/dist/phoneNumber.min'
     },
     shim: {
         'underscore': {
@@ -18,6 +19,9 @@ require.config({
                 });
                 return this.mocha;
             }
+        },
+        'phoneTest': {
+            exports: 'phoneNumber'
         }
     }
 });

--- a/test/bower.json
+++ b/test/bower.json
@@ -5,6 +5,7 @@
     "mocha": "1.18.0",
     "chai": "~1.9.0",
     "requirejs": "~2.1.11",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "phone_number_js": "~1.0.0"
   }
 }

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -1,4 +1,4 @@
-define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai, _) {
+define(['Chance', 'mocha', 'chai', 'underscore', 'phoneTest'], function (Chance, mocha, chai, _, phoneTest) {
     var assert = chai.assert,
         expect = chai.expect;
 
@@ -166,6 +166,38 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
                 _(1000).times(function () {
                     expect(chance.phone({formatted : false, parens: true})).to.be.a('string');
                     expect(chance.phone({formatted : false, parens: true})).to.match(/^[2-9][0-8]\d[2-9]\d{6,6}$/);
+                });
+            });
+
+            it("phone({ukPhone: true}) returns a string", function () {
+                expect(chance.phone({ukPhone: true})).to.be.a('string');
+            });
+
+            it("phone({ukMobile: true}) returns a string", function () {
+                expect(chance.phone({ukMobile: true})).to.be.a('string');
+            });
+
+            it('phone({ukPhone: true}) looks right', function () {
+                _(1000).times(function () {
+                    expect(phoneTest.isValid(chance.phone({ukPhone: true}))).to.be.true;
+                });
+            });
+
+            it('phone({ukPhone: true, formatted: false}) looks right', function () {
+                _(1000).times(function () {
+                    expect(phoneTest.isValid(phoneTest.format(chance.phone({ukPhone: true, formatted: false})))).to.be.true;
+                });
+            });
+
+            it('phone({ukMobile: true}) looks right', function () {
+                _(1000).times(function () {
+                    expect(phoneTest.isValid(chance.phone({ukMobile: true}))).to.be.true;
+                });
+            });
+
+            it('phone({ukMobile: true, formatted: false}) looks right', function () {
+                _(1000).times(function () {
+                    expect(phoneTest.isValid(phoneTest.format(chance.phone({ukMobile: true, formatted: false})))).to.be.true;
                 });
             });
         });


### PR DESCRIPTION
Adds the options ukPhone and ukMobile to phone() method. Landline area codes for major cities and counties in the UK (including Scotland and Northern Ireland). Only 2, 3 and 4 digit area codes generated (excluding premium codes such as 08xx, 09xx) - http://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom#Four-digit_area_codes used as reference.
