### PR TITLE
Added Android GCM Registration ID

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -549,6 +549,10 @@
     // -- End Person --
 
     // -- Web --
+    // Android GCM Registration ID
+    Chance.prototype.android_id = function (options) {
+        return this.string({ pool: "0123456789abcefghijklmnopqrstuvwxyz", length: 64 });
+    };
 
     // Apple Push Token
     Chance.prototype.apple_token = function (options) {

--- a/test/test.misc.js
+++ b/test/test.misc.js
@@ -118,6 +118,17 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
 
     });
 
+    describe("Android Registration ID", function(){
+        var android_id, chance = new Chance();
+
+        it("returns a proper android id", function () {
+            _(1000).times(function () {
+                android_id = chance.android_id();
+                expect(android_id).to.match(/([0-9a-zA-Z]){64}/);
+            });
+        });
+    });
+
     describe("Apple Token", function(){
         var apple_token, chance = new Chance();
 


### PR DESCRIPTION
The Android equivalent of the iOS push token is the GCM registration ID.

As a side note, I found it a bit weird that `apple_token` is defined in the `-- Web --` section in `chance.js`, but the _tests_ are in `test.misc.js` instead of `test.web.js`.

Cheers
