### PR TITLE
Use more realistic GCM registration ID

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -551,7 +551,7 @@
     // -- Web --
     // Android GCM Registration ID
     Chance.prototype.android_id = function (options) {
-        return this.string({ pool: "0123456789abcefghijklmnopqrstuvwxyz", length: 64 });
+        return "APA91" + this.string({ pool: "0123456789abcefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_", length: 178 });
     };
 
     // Apple Push Token

--- a/test/test.misc.js
+++ b/test/test.misc.js
@@ -124,7 +124,7 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
         it("returns a proper android id", function () {
             _(1000).times(function () {
                 android_id = chance.android_id();
-                expect(android_id).to.match(/([0-9a-zA-Z]){64}/);
+                expect(android_id).to.match(/APA91([0-9a-zA-Z-_]){178}/);
             });
         });
     });


### PR DESCRIPTION
Upon closer inspection, our old placeholders were far from realistic. I've reviewed some actual IDs from our database now, which are much longer and contain uppercase letters. It also seems like all IDs start with "APA91", which I've now taken into account.
