### PR TITLE
Ignore leftovers from develop/master branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 public
+
+# Ignore leftovers from develop/master branches
+node_modules
+.idea
+test/lib


### PR DESCRIPTION
When switching between branches, some folders from the code branches are often left behind and pollute the staging area.
This change ignores those folders.
