### PR TITLE
Added script to convert Social Security data dumps to JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,15 @@
   ],
   "devDependencies": {
     "grunt": "0.4.5",
+    "grunt-bump": "0.0.11",
     "grunt-contrib-jshint": "0.10.0",
-    "grunt-mocha-phantomjs": "0.5.0",
     "grunt-contrib-uglify": "0.5.0",
     "grunt-contrib-watch": "0.6.1",
+    "grunt-mocha-phantomjs": "0.5.0",
     "grunt-shell": "0.7.0",
+    "line-by-line": "^0.1.3",
     "mocha-phantomjs": "3.5.0",
-    "uglify-js": "1.2.6",
-    "grunt-bump": "0.0.11"
+    "uglify-js": "1.2.6"
   },
   "scripts": {
     "test": "./node_modules/mocha-phantomjs/bin/mocha-phantomjs test/runner.html"

--- a/util/yob-to-json.js
+++ b/util/yob-to-json.js
@@ -1,0 +1,44 @@
+var LineByLineReader = require("line-by-line");
+
+var args = process.argv.slice(2);
+if(!args || !args.length) {
+    process.stderr.write("Missing filename\n");
+}
+
+var filename = args[0];
+var threshold = parseInt(args[1]) || 0;
+var inputFile = new LineByLineReader(filename);
+
+var result = {
+    firstNames: {
+        male: [],
+        female: []
+    }
+};
+
+inputFile.on("error", process.stderr.write);
+inputFile.on("line", function parseLine(line) {
+    var elements = line.split(",");
+    if(elements.length < 3) {
+        return;
+    }
+
+    var name = elements[0];
+    var gender = elements[1];
+    var count = elements[2];
+
+    if(count < threshold) {
+        return;
+    }
+
+    if("M" == gender) {
+        result.firstNames.male.push(name);
+    } else if("F" == gender) {
+        result.firstNames.female.push(name);
+    } else {
+        process.stderr.write("Invalid gender '" + gender + "' for name '" + name + "'!\n");
+    }
+});
+inputFile.on("end", function parsingComplete() {
+    process.stdout.write(JSON.stringify(result));
+});


### PR DESCRIPTION
This tackles the "Better names" point from the todo list.

How to use:
1. Go to http://www.ssa.gov/oact/babynames/limits.html, download and unzip the dumps.
2. Convert to JSON with the following syntax: `node yob-to-json.js <filename> [threshold]`

Example output:

``` shell
$ node yob-to-json.js yob2013.txt 10000
{"firstNames":{"male":["Noah","Liam","Jacob","Mason","William","Ethan","Michael","Alexander","Jayden","Daniel","Elijah","Aiden","James","Benjamin","Matthew","Jackson","Logan","David","Anthony","Joseph","Joshua","Andrew","Lucas","Gabriel","Samuel","Christopher","John","Dylan","Isaac"],"female":["Sophia","Emma","Olivia","Isabella","Ava","Mia","Emily","Abigail","Madison"]}}
```

`threshold` is the number of times the name must be used, so that it is included in the output.
The generated JSON data can directly be pasted into ChanceJS source.
