### PR TITLE
Added CLI for ChanceJS

### DIFF
--- a/bin/chance.js
+++ b/bin/chance.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+var Chance = require('../chance.js');
+
+// Check which generator the user wants to invoke.
+var generator = process.argv[2];
+var options = (process.argv[3]) ? JSON.parse(process.argv[3]) : {};
+// Use .toString() until #121 is merged.
+var chance = new Chance(new Date().getTime().toString());
+// Does the given generator exist in Chance?
+if(generator && chance[generator]) {
+    // Invoke the generator on our Chance instance and print the result.
+    process.stdout.write(chance[generator]() + '\n');
+} else {
+    process.stderr.write('Unknown generator "' + generator + '"\n');
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "test": "./node_modules/mocha-phantomjs/bin/mocha-phantomjs test/runner.html"
   },
+  "bin": "./bin/chance.js",
   "keywords": [
     "chance",
     "random",


### PR DESCRIPTION
Allows you to invoke any generator from the command line. Like so:

``` shell
$ chance name
Ruby Cannon
```

Options can be set by providing them as a JSON-formatted parameter. Like so:

``` shell
$ chance color {\"middle\":true}
rgb(84,26,130)
```

Not the greatest way to pass options, but it's a start ;D
