### PR TITLE
Allow CLI options to be passed in a more traditional format

### DIFF
--- a/bin/chance.js
+++ b/bin/chance.js
@@ -1,16 +1,17 @@
 #!/usr/bin/env node
 
 var Chance = require('../chance.js');
+var argv = require('minimist')(process.argv.slice(2));
 
 // Check which generator the user wants to invoke.
 var generator = process.argv[2];
-var options = (process.argv[3]) ? JSON.parse(process.argv[3]) : {};
+var options = argv;
 // Use .toString() until #121 is merged.
 var chance = new Chance(new Date().getTime().toString());
 // Does the given generator exist in Chance?
 if(generator && chance[generator]) {
     // Invoke the generator on our Chance instance and print the result.
-    process.stdout.write(chance[generator]() + '\n');
+    process.stdout.write(chance[generator](options) + '\n');
 } else {
     process.stderr.write('Unknown generator "' + generator + '"\n');
 }

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "ignore": [
       "test"
     ]
+  },
+  "dependencies": {
+    "minimist": "^1.1.0"
   }
 }


### PR DESCRIPTION
Now using minimist to parse command line options to pass to the generator.
Examples:

``` shell
$ chance name --middle --prefix --gender=female
Mrs. Madge Hilda Conner

$ chance state --full
North Dakota
```
