### PR TITLE
Fix name({prefix:true}) always generating gender-neutral prefixes

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -535,6 +535,7 @@
     // Return the list of available name prefixes based on supplied gender.
     Chance.prototype.name_prefixes = function (gender) {
         gender = gender || "all";
+        gender = gender.toLowerCase();
 
         var prefixes = [
             { name: 'Doctor', abbreviation: 'Dr.' }


### PR DESCRIPTION
The generated gender, passed to `name_prefixes` would not be all lower-case, this causes only "Dr." to be used as an available prefix.

This problem could also be fixed by converting the gender in `name()` to lower case, but I chose to fix it in `name_prefixes` to also allow different casing for `gender` to be supplied in that generator.

Fixes #117
