### PR TITLE
Adds 0x format and casing option for color()

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -616,26 +616,33 @@
             return [value, value, value].join(delimiter || '');
         }
 
-        options = initOptions(options, {format: this.pick(['hex', 'shorthex', 'rgb']), grayscale: false});
+        options = initOptions(options, {format: this.pick(['hex', 'shorthex', 'rgb', '0x']), grayscale: false, casing: 'lower'});
         var isGrayscale = options.grayscale;
+        var colorValue;
 
         if (options.format === 'hex') {
-            return '#' + (isGrayscale ? gray(this.hash({length: 2})) : this.hash({length: 6}));
-        }
+            colorValue = '#' + (isGrayscale ? gray(this.hash({length: 2})) : this.hash({length: 6}));
 
-        if (options.format === 'shorthex') {
-            return '#' + (isGrayscale ? gray(this.hash({length: 1})) : this.hash({length: 3}));
-        }
+        } else if (options.format === 'shorthex') {
+            colorValue = '#' + (isGrayscale ? gray(this.hash({length: 1})) : this.hash({length: 3}));
 
-        if (options.format === 'rgb') {
+        } else if (options.format === 'rgb') {
             if (isGrayscale) {
-                return 'rgb(' + gray(this.natural({max: 255}), ',') + ')';
+                colorValue = 'rgb(' + gray(this.natural({max: 255}), ',') + ')';
             } else {
-                return 'rgb(' + this.natural({max: 255}) + ',' + this.natural({max: 255}) + ',' + this.natural({max: 255}) + ')';
+                colorValue = 'rgb(' + this.natural({max: 255}) + ',' + this.natural({max: 255}) + ',' + this.natural({max: 255}) + ')';
             }
+        } else if (options.format === '0x') {
+            colorValue = '0x' + (isGrayscale ? gray(this.hash({length: 2})) : this.hash({length: 6}));
+        } else {
+            throw new Error('Invalid format provided. Please provide one of "hex", "shorthex", "rgb" or "0x".');
         }
 
-        throw new Error('Invalid format provided. Please provide one of "hex", "shorthex", or "rgb"');
+        if (options.casing === 'upper' ) {
+            colorValue = colorValue.toUpperCase();
+        }
+
+        return colorValue;
     };
 
     Chance.prototype.domain = function (options) {

--- a/test/test.web.js
+++ b/test/test.web.js
@@ -172,6 +172,15 @@ define(['Chance', 'mocha', 'chai', 'underscore'], function (Chance, mocha, chai,
                     expect(match[1]).to.equal(match[3]);
                 });
             });
+
+            it("({format: '0x'}) returns what looks a 0x color", function () {
+                _(1000).times(function () {
+                    var color = chance.color({format: '0x'});
+                    expect(color).to.be.a('string');
+                    expect(color).to.have.length(8);
+                    expect(color).to.match(/0x[a-z0-9]+/m);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Allows colors in the format of 0xab1209 to be generated.
Additionally adds casing option to allow generation of #abcdef and #ABCDEF
Closes #93
