### PR TITLE
More accurate random birthday when using the type option

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -591,7 +591,7 @@
 
         switch (options.type) {
             case 'child':
-                ageRange = {min: 1, max: 12};
+                ageRange = {min: 0, max: 12};
                 break;
             case 'teen':
                 ageRange = {min: 13, max: 19};
@@ -603,7 +603,7 @@
                 ageRange = {min: 65, max: 100};
                 break;
             case 'all':
-                ageRange = {min: 1, max: 100};
+                ageRange = {min: 0, max: 100};
                 break;
             default:
                 ageRange = {min: 18, max: 65};

--- a/chance.js
+++ b/chance.js
@@ -614,9 +614,24 @@
     };
 
     Chance.prototype.birthday = function (options) {
-        options = initOptions(options, {
-            year: (new Date().getFullYear() - this.age(options))
-        });
+        var age = this.age(options);
+        var currentYear = new Date().getFullYear();
+
+        if (options && options.type) {
+            var min = new Date();
+            var max = new Date();
+            min.setFullYear(currentYear - age - 1);
+            max.setFullYear(currentYear - age);
+
+            options = initOptions(options, {
+                min: min,
+                max: max
+            });
+        } else {
+            options = initOptions(options, {
+                year: currentYear - age
+            });
+        }
 
         return this.date(options);
     };
@@ -1440,7 +1455,7 @@
             // 100,000,000 days measured relative to midnight at the beginning of 01 January, 1970 UTC. http://es5.github.io/#x15.9.1.1
             var max = typeof options.max !== "undefined" ? options.max.getTime() : 8640000000000000;
 
-            date = new Date(this.natural({min: min, max: max}));
+            date = new Date(this.integer({min: min, max: max}));
         } else {
             var m = this.month({raw: true});
             var daysInMonth = m.days;

--- a/test/test.person.js
+++ b/test/test.person.js
@@ -89,9 +89,53 @@ describe("Person", function () {
             });
         });
 
-        it("can have an age range specified", function () {
-            _(1000).times(function () {
-                expect(chance.birthday({type: 'child'}).getFullYear()).to.be.within((new Date().getFullYear() - CHILD_AGE_MAX), (new Date().getFullYear()));
+        describe("can have an age range specified", function () {
+            var currentYear = new Date().getFullYear();
+
+            it("for an adult", function () {
+                _(1000).times(function () {
+                    // "Age" is the floor of someone's decimal age - if you are 65.75 years old, you are considered "65"
+                    // Someone who is "65" was born between 66 and 65 years ago
+                    var min = (new Date().setFullYear(currentYear - ADULT_AGE_MAX - 1));
+                    var max = (new Date().setFullYear(currentYear - ADULT_AGE_MIN));
+
+                    expect(chance.birthday({
+                        type: 'adult'
+                    }).getTime()).to.be.within(min, max);
+                });
+            });
+
+            it("for a teen", function () {
+                _(1000).times(function () {
+                    var min = (new Date().setFullYear(currentYear - TEEN_AGE_MAX - 1));
+                    var max = (new Date().setFullYear(currentYear - TEEN_AGE_MIN));
+
+                    expect(chance.birthday({
+                        type: 'teen'
+                    }).getTime()).to.be.within(min, max);
+                });
+            });
+
+            it("for a child", function () {
+                _(1000).times(function () {
+                    var min = (new Date().setFullYear(currentYear - CHILD_AGE_MAX - 1));
+                    var max = (new Date().setFullYear(currentYear - CHILD_AGE_MIN));
+
+                    expect(chance.birthday({
+                        type: 'child'
+                    }).getTime()).to.be.within(min, max);
+                });
+            });
+
+            it("for a senior", function () {
+                _(1000).times(function () {
+                    var min = (new Date().setFullYear(currentYear - SENIOR_AGE_MAX - 1));
+                    var max = (new Date().setFullYear(currentYear - SENIOR_AGE_MIN));
+
+                    expect(chance.birthday({
+                        type: 'senior'
+                    }).getTime()).to.be.within(min, max);
+                });
             });
         });
     });

--- a/test/test.person.js
+++ b/test/test.person.js
@@ -4,13 +4,23 @@
 var expect = chai.expect;
 
 describe("Person", function () {
-    var name, first, last, nationality, prefix, suffix, ssn, chance = new Chance();
+    var name, first, last, nationality, prefix, suffix, ssn, chance = new Chance(),
+    CHILD_AGE_MIN = 0,
+    CHILD_AGE_MAX = 12,
+    TEEN_AGE_MIN = 13,
+    TEEN_AGE_MAX = 19,
+    ADULT_AGE_MIN = 18,
+    ADULT_AGE_MAX = 65,
+    SENIOR_AGE_MIN = 65,
+    SENIOR_AGE_MAX = 100,
+    AGE_MIN = 0,
+    AGE_MAX = 100;
 
     describe("age()", function () {
         it("returns a random age within expected bounds", function () {
             _(1000).times(function () {
                 expect(chance.age()).to.be.a('number');
-                expect(chance.age()).to.be.within(1, 100);
+                expect(chance.age()).to.be.within(AGE_MIN, AGE_MAX);
             });
         });
 
@@ -21,7 +31,7 @@ describe("Person", function () {
                 _(1000).times(function () {
                     age = chance.age({ type: 'child' });
                     expect(age).to.be.a('number');
-                    expect(age).to.be.within(1, 12);
+                    expect(age).to.be.within(CHILD_AGE_MIN, CHILD_AGE_MAX);
                 });
             });
 
@@ -29,7 +39,7 @@ describe("Person", function () {
                 _(1000).times(function () {
                     age = chance.age({ type: 'teen' });
                     expect(age).to.be.a('number');
-                    expect(age).to.be.within(13, 19);
+                    expect(age).to.be.within(TEEN_AGE_MIN, TEEN_AGE_MAX);
                 });
             });
 
@@ -37,7 +47,7 @@ describe("Person", function () {
                 _(1000).times(function () {
                     age = chance.age({ type: 'adult' });
                     expect(age).to.be.a('number');
-                    expect(age).to.be.within(18, 65);
+                    expect(age).to.be.within(ADULT_AGE_MIN, ADULT_AGE_MAX);
                 });
             });
 
@@ -45,15 +55,15 @@ describe("Person", function () {
                 _(1000).times(function () {
                     age = chance.age({ type: 'senior' });
                     expect(age).to.be.a('number');
-                    expect(age).to.be.within(65, 100);
+                    expect(age).to.be.within(SENIOR_AGE_MIN, SENIOR_AGE_MAX);
                 });
             });
         });
 
         it("can have the type specified", function () {
             _(1000).times(function () {
-                expect(chance.age({type: 'child'})).to.be.within(1, 13);
-                expect(chance.age({type: 'senior'})).to.be.within(65, 120);
+                expect(chance.age({type: 'child'})).to.be.within(CHILD_AGE_MIN, CHILD_AGE_MAX);
+                expect(chance.age({type: 'senior'})).to.be.within(SENIOR_AGE_MIN, SENIOR_AGE_MAX);
             });
         });
     });
@@ -62,7 +72,7 @@ describe("Person", function () {
         it("returns a random birthday", function () {
             _(1000).times(function () {
                 expect(chance.birthday()).to.be.a('Date');
-                expect(chance.birthday().getFullYear()).to.be.within((new Date().getFullYear() - 120), (new Date().getFullYear()));
+                expect(chance.birthday().getFullYear()).to.be.within((new Date().getFullYear() - AGE_MAX), (new Date().getFullYear()));
             });
         });
 
@@ -81,7 +91,7 @@ describe("Person", function () {
 
         it("can have an age range specified", function () {
             _(1000).times(function () {
-                expect(chance.birthday({type: 'child'}).getFullYear()).to.be.within((new Date().getFullYear() - 13), (new Date().getFullYear()));
+                expect(chance.birthday({type: 'child'}).getFullYear()).to.be.within((new Date().getFullYear() - CHILD_AGE_MAX), (new Date().getFullYear()));
             });
         });
     });


### PR DESCRIPTION
Fix for #255, the issue I just opened. Instead of generating a random year, month, and day, this change generates a random number of milliseconds since 1970/01/01 such that the resulting birthday is within the specified age range. I also fixed/changed some of the age ranges.