### PR TITLE
use "twentyfour" hour option when generating dates

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1472,7 +1472,7 @@
                 // for some reason.
                 month: m.numeric - 1,
                 day: this.natural({min: 1, max: daysInMonth}),
-                hour: this.hour(),
+                hour: this.hour({twentyfour: true}),
                 minute: this.minute(),
                 second: this.second(),
                 millisecond: this.millisecond(),


### PR DESCRIPTION
When generating random dates without any options via `chance.date()`, the hour value is created with `this.hour()`, which by default generates an 12h value between 1 and 12. 

The expectation for date is (presumably) that it can generate any random date and time, not just times limited to AM hours. Note that this is already the behavior when providing `min` and `max` options, because it picks a random integer epoch within the bounds.

Distribution of hours before the fix (100k dates generated):

![screen shot 2016-05-29 at 1 24 44 pm](https://cloud.githubusercontent.com/assets/99221/15631253/9dd77baa-25a2-11e6-8501-ac3e659dbd71.png)

Distribution of hours after the fix (100k dates generated): 

![screen shot 2016-05-29 at 1 26 27 pm](https://cloud.githubusercontent.com/assets/99221/15631254/a68813e0-25a2-11e6-9518-4c19326245fc.png)
