### PR TITLE
weighted with NaN weight returns unexpected results

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -433,6 +433,10 @@
         var val;
         for (var weightIndex = 0; weightIndex < weights.length; ++weightIndex) {
             val = weights[weightIndex];
+            if (isNaN(val)) {
+                throw new RangeError("all weights must be numbers");
+            }
+
             if (val > 0) {
                 sum += val;
             }

--- a/test/test.helpers.js
+++ b/test/test.helpers.js
@@ -176,6 +176,12 @@ describe("Helpers", function () {
             }).to.throw(RangeError, /length of array and weights must match/);
         });
 
+        it("throws an Error if weights contain NaN", function() {
+            expect(function () {
+                chance.weighted(['a', 'b', 'c', 'd'], [1, NaN, 1, 1]);
+            }).to.throw(RangeError, /all weights must be numbers/);
+        });
+
         it("returns with results properly weighted", function() {
             // Use Math.random as the random function rather than our Mersenne twister just to
             //   speed things up here because this test takes awhile to gather enough data to


### PR DESCRIPTION
chance.weighted(['a','b','c','d'],[NaN, 100, 1, 1]) always returns 'd'. 
fixed by throwing an error if any weight is NaN