### PR TITLE
Fixed "Extension" Typos for chance.file

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -2151,58 +2151,58 @@
     /**
      * #Description:
      * =====================================================
-     * Generate random file name with extention
+     * Generate random file name with extension
      *
-     * The argument provide extention type
+     * The argument provide extension type
      * -> raster
      * -> vector
      * -> 3d
      * -> document
      *
-     * If noting is provided the function return random file name with random
-     * extention type of any kind
+     * If nothing is provided the function return random file name with random
+     * extension type of any kind
      *
      * The user can validate the file name length range
-     * If noting provided the generated file name is radom
+     * If nothing provided the generated file name is random
      *
-     * #Extention Pool :
-     * * Currently the supported extentions are
-     *  -> some of the most popular raster image extentions
-     *  -> some of the most popular vector image extentions
-     *  -> some of the most popular 3d image extentions
-     *  -> some of the most popular document extentions
+     * #Extension Pool :
+     * * Currently the supported extensions are
+     *  -> some of the most popular raster image extensions
+     *  -> some of the most popular vector image extensions
+     *  -> some of the most popular 3d image extensions
+     *  -> some of the most popular document extensions
      *
      * #Examples :
      * =====================================================
      *
-     * Return random file name with random extention. The file extention
-     * is provided by a predifined collection of extentions. More abouth the extention
-     * pool can be fond in #Extention Pool section
+     * Return random file name with random extension. The file extension
+     * is provided by a predefined collection of extensions. More about the extension
+     * pool can be found in #Extension Pool section
      *
      * chance.file()
      * => dsfsdhjf.xml
      *
-     * In order to generate a file name with sspecific length, specify the
-     * length property and integer value. The extention is going to be random
+     * In order to generate a file name with specific length, specify the
+     * length property and integer value. The extension is going to be random
      *
      * chance.file({length : 10})
      * => asrtineqos.pdf
      *
-     * In order to geerate file with extention form some of the predifined groups
-     * of the extention pool just specify the extenton pool category in fileType property
+     * In order to generate file with extension from some of the predefined groups
+     * of the extension pool just specify the extension pool category in fileType property
      *
      * chance.file({fileType : 'raster'})
      * => dshgssds.psd
      *
-     * You can provide specific extention for your files
-     * chance.file({extention : 'html'})
+     * You can provide specific extension for your files
+     * chance.file({extension : 'html'})
      * => djfsd.html
      *
-     * Or you could pass custom collection of extentons bt array or by object
-     * chance.file({extentions : [...]})
+     * Or you could pass custom collection of extensions by array or by object
+     * chance.file({extensions : [...]})
      * => dhgsdsd.psd
      *
-     * chance.file({extentions : { key : [...], key : [...]}})
+     * chance.file({extensions : { key : [...], key : [...]}})
      * => djsfksdjsd.xml
      *
      * @param  [collection] options
@@ -2215,54 +2215,54 @@
         var poolCollectionKey = "fileExtension";
         var typeRange   = Object.keys(this.get("fileExtension"));//['raster', 'vector', '3d', 'document'];
         var fileName;
-        var fileExtention;
+        var fileExtension;
 
         // Generate random file name
         fileName = this.word({length : fileOptions.length});
 
-        // Generate file by specific extention provided by the user
-        if(fileOptions.extention) {
+        // Generate file by specific extension provided by the user
+        if(fileOptions.extension) {
 
-            fileExtention = fileOptions.extention;
-            return (fileName + '.' + fileExtention);
+            fileExtension = fileOptions.extension;
+            return (fileName + '.' + fileExtension);
         }
 
-        // Generate file by specific axtention collection
-        if(fileOptions.extentions) {
+        // Generate file by specific extension collection
+        if(fileOptions.extensions) {
 
-            if(Array.isArray(fileOptions.extentions)) {
+            if(Array.isArray(fileOptions.extensions)) {
 
-                fileExtention = this.pickone(fileOptions.extentions);
-                return (fileName + '.' + fileExtention);
+                fileExtension = this.pickone(fileOptions.extensions);
+                return (fileName + '.' + fileExtension);
             }
-            else if(fileOptions.extentions.constructor === Object) {
+            else if(fileOptions.extensions.constructor === Object) {
 
-                var extentionObjectCollection = fileOptions.extentions;
-                var keys = Object.keys(extentionObjectCollection);
+                var extensionObjectCollection = fileOptions.extensions;
+                var keys = Object.keys(extensionObjectCollection);
 
-                fileExtention = this.pickone(extentionObjectCollection[this.pickone(keys)]);
-                return (fileName + '.' + fileExtention);
+                fileExtension = this.pickone(extensionObjectCollection[this.pickone(keys)]);
+                return (fileName + '.' + fileExtension);
             }
 
             throw new Error("Expect collection of type Array or Object to be passed as an argument ");
         }
 
-        // Generate file extention based on specific file type
+        // Generate file extension based on specific file type
         if(fileOptions.fileType) {
 
             var fileType = fileOptions.fileType;
             if(typeRange.indexOf(fileType) !== -1) {
 
-                fileExtention = this.pickone(this.get(poolCollectionKey)[fileType]);
-                return (fileName + '.' + fileExtention);
+                fileExtension = this.pickone(this.get(poolCollectionKey)[fileType]);
+                return (fileName + '.' + fileExtension);
             }
 
             throw new Error("Expect file type value to be 'raster', 'vector', '3d' or 'document' ");
         }
 
-        // Generate random file name if no extenton options are passed
-        fileExtention = this.pickone(this.get(poolCollectionKey)[this.pickone(typeRange)]);
-        return (fileName + '.' + fileExtention);
+        // Generate random file name if no extension options are passed
+        fileExtension = this.pickone(this.get(poolCollectionKey)[this.pickone(typeRange)]);
+        return (fileName + '.' + fileExtension);
     };
 
     var data = {

--- a/test/test.file.js
+++ b/test/test.file.js
@@ -8,19 +8,19 @@ describe("File", function () {
     var file,
         chance = new Chance();
 
-    var fileExtension = {
+    var fileExtensions = {
         "raster"    : ["bmp", "gif", "gpl", "ico", "jpeg", "psd", "png", "psp", "raw", "tiff"],
         "vector"    : ["3dv", "amf", "awg", "ai", "cgm", "cdr", "cmx", "dxf", "e2d", "egt", "eps", "fs", "odg", "svg", "xar"],
         "3d"        : ["3dmf", "3dm", "3mf", "3ds", "an8", "aoi", "blend", "cal3d", "cob", "ctm", "iob", "jas", "max", "mb", "mdx", "obj", "x", "x3d"],
         "document"  : ["doc", "docx", "dot", "html", "xml", "odt", "odm", "ott", "csv", "rtf", "tex", "xhtml", "xps"]
     };
 
-    var arrayExtentionCollection = ["bmp", "3dv", "3dmf", "doc"];
+    var arrayExtensionCollection = ["bmp", "3dv", "3dmf", "doc"];
 
-    var objectExtentionCollection = {
-        "one"   : ["extention_one_1", "extention_one_2", "extention_one_3"],
-        "two"   : ["extention_two_1", "extention_two_2", "extention_two_3" ],
-        "three" : ["extention_three_1", "extention_three_2", "extention_three_3"]
+    var objectExtensionCollection = {
+        "one"   : ["extension_one_1", "extension_one_2", "extension_one_3"],
+        "two"   : ["extension_two_1", "extension_two_2", "extension_two_3" ],
+        "three" : ["extension_three_1", "extension_three_2", "extension_three_3"]
     };
 
 
@@ -59,29 +59,29 @@ describe("File", function () {
 
             _(1000).times(function() {
 
-                var extentionTypeCollection = ['raster', 'vector', '3d', ''];
-                var firstExtentionType = extentionTypeCollection[0];
+                var extensionTypeCollection = ['raster', 'vector', '3d', ''];
+                var firstExtensionType = extensionTypeCollection[0];
 
-                file = chance.file({fileType : firstExtentionType});
+                file = chance.file({fileType : firstExtensionType});
                 expect(file).to.be.a('string');
-                var fileExtention = file.split('.')[1];
+                var fileExtension = file.split('.')[1];
 
-                expect(fileExtension[firstExtentionType]).to.contain(fileExtention);
+                expect(fileExtensions[firstExtensionType]).to.contain(fileExtension);
             });
         });
 
         it("returns filename with specific extension", function () {
             _(1000).times(function () {
 
-                var specificExtention = 'doc';
-                var failTestExtention = 'xml';
+                var specificExtension = 'doc';
+                var failTestExtension = 'xml';
 
-                file = chance.file({extention : specificExtention});
-                var fileExtention = file.split('.')[1];
+                file = chance.file({extension : specificExtension});
+                var fileExtension = file.split('.')[1];
 
-                expect(fileExtention).to.be.a('string');
-                expect(fileExtention).to.equal(specificExtention);
-                expect(fileExtention).to.not.equal(failTestExtention);
+                expect(fileExtension).to.be.a('string');
+                expect(fileExtension).to.equal(specificExtension);
+                expect(fileExtension).to.not.equal(failTestExtension);
             });
         });
 
@@ -100,15 +100,15 @@ describe("File", function () {
             });
         });
 
-        it("returns filename with random extention provided by external array collection", function() {
+        it("returns filename with random extension provided by external array collection", function() {
             
             _(1000).times(function() {
                 
-                var arrayExtentionCollection = ["bmp", "3dv", "3dmf", "doc"];
-                file = chance.file({ extentions : arrayExtentionCollection});
-                var fileExtention = file.split('.')[1];
+                var arrayExtensionCollection = ["bmp", "3dv", "3dmf", "doc"];
+                file = chance.file({ extensions : arrayExtensionCollection});
+                var fileExtension = file.split('.')[1];
 
-                expect(arrayExtentionCollection).to.include(fileExtention);
+                expect(arrayExtensionCollection).to.include(fileExtension);
             });
         });
 
@@ -117,54 +117,54 @@ describe("File", function () {
             
             _(1000).times(function() {
 
-                file = chance.file({ extentions : objectExtentionCollection});
-                var fileExtention = file.split('.')[1];
+                file = chance.file({ extensions : objectExtensionCollection});
+                var fileExtension = file.split('.')[1];
 
-                var extentionCount = 0;
-                for(var index in objectExtentionCollection) {
+                var extensionCount = 0;
+                for(var index in objectExtensionCollection) {
                     
-                    var collection = objectExtentionCollection[index];
+                    var collection = objectExtensionCollection[index];
                     var length     = collection.length;
                     var i = 0;
 
                     for(i; i < length; i++) {
-                        if(collection[i] === fileExtention) {
-                            extentionCount++;    
+                        if(collection[i] === fileExtension) {
+                            extensionCount++;
                         }
                     }
                 }
 
-                expect(fileExtention).to.be.a('string');
-                expect(extentionCount).to.be.equal(1);
+                expect(fileExtension).to.be.a('string');
+                expect(extensionCount).to.be.equal(1);
             });
         });
 
-        it("returns error if user provides wrong argument type to extentions property", function() {
+        it("returns error if user provides wrong argument type to extensions property", function() {
             
             _(1000).times(function() {
                 
                 expect(function() {
-                    chance({ extentions : 10});    
+                    chance({ extensions : 10});
                 }).to.throw(Error);
             });  
         });
 
-        it("doesnot returns error if user provides correct array argument type to extentions property", function() {
+        it("doesnot returns error if user provides correct array argument type to extensions property", function() {
             
             _(1000).times(function() {
                 
                 expect(function() {
-                    chance.file({ extentions : arrayExtentionCollection});
+                    chance.file({ extensions : arrayExtensionCollection});
                 }).to.not.throw(Error);
             });  
         });        
 
-        it("doesnot returns error if user provides correct object argument type to extentions property", function() {
+        it("doesnot returns error if user provides correct object argument type to extensions property", function() {
             
             _(1000).times(function() {
                 
                 expect(function() {
-                    chance.file({ extentions : objectExtentionCollection});
+                    chance.file({ extensions : objectExtensionCollection});
                 }).to.not.throw(Error);
             });  
         });                


### PR DESCRIPTION
One of the options for `chance.file()` is to specify the extension of the file, either via a single string or an array or object of strings. However, these were referenced as "extention" and it made it very confusing to use. This set of changes fixes this and updates the corresponding tests.