### PR TITLE
Change Facebook ids format from integer to string

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1234,8 +1234,25 @@
         return this.word({length: options.length}) + '@' + (options.domain || this.domain());
     };
 
+    /**
+     * #Description:
+     * ===============================================
+     * Generate a random Facebook id, aka fbid.
+     *
+     * NOTE: At the moment (Sep 2017), Facebook ids are
+     * "numeric strings" of length 16.
+     * However, Facebook Graph API documentation states that
+     * "it is extremely likely to change over time".
+     * @see https://developers.facebook.com/docs/graph-api/overview/
+     *
+     * #Examples:
+     * ===============================================
+     * chance.fbid() => '1000035231661304'
+     *
+     * @return [string] facebook id
+     */
     Chance.prototype.fbid = function () {
-        return parseInt('10000' + this.natural({max: 100000000000}), 10);
+        return '10000' + this.string({pool: "1234567890", length: 11});
     };
 
     Chance.prototype.google_analytics = function () {

--- a/test/test.web.js
+++ b/test/test.web.js
@@ -316,7 +316,9 @@ test('email() has a leng specified, should generate string before domain with eq
 // chance.fbid()
 test('fbid() returns what looks like a Facebook id', t => {
     _.times(1000, () => {
-        t.true(_.isNumber(chance.fbid()))
+        let fbid = chance.fbid()
+        t.true(_.isString(fbid))
+        t.is(fbid.length, 16)
     })
 })
 


### PR DESCRIPTION
#### What's this PR do?
Changes `chance.fbid()` so it returns a "numeric string".

#### How should this be tested?
- `yarn install`
- `yarn test`

#### Any background context you want to provide?
- This is a breaking change as it irreversibly alters existing functionality.
- This makes return type of `chance.fbid()` both consistent with [chance.js's documentation](http://chancejs.com/#fbid) and [Facebook Graph API ](https://developers.facebook.com/docs/graph-api/reference/user/) documentation.

#### What are the relevant tickets?
Fixes #328 