### PR TITLE
Adding brazilian (br) phones support

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1534,9 +1534,7 @@
                     ]);
                     phone = options.formatted || numPick;
                 }
-
                 break;
-
             case 'us':
                 var areacode = this.areacode(options).toString();
                 var exchange = this.natural({ min: 2, max: 9 }).toString() +
@@ -1544,6 +1542,20 @@
                     this.natural({ min: 0, max: 9 }).toString();
                 var subscriber = this.natural({ min: 1000, max: 9999 }).toString(); // this could be random [0-9]{4}
                 phone = options.formatted ? areacode + ' ' + exchange + '-' + subscriber : areacode + exchange + subscriber;
+                break;
+            case 'br':
+                const areaCode = this.pick(["11", "12", "13", "14", "15", "16", "17", "18", "19", "21", "22", "24", "27", "28", "31", "32", "33", "34", "35", "37", "38", "41", "42", "43", "44", "45", "46", "47", "48", "49", "51", "53", "54", "55", "61", "62", "63", "64", "65", "66", "67", "68", "69", "71", "73", "74", "75", "77", "79", "81", "82", "83", "84", "85", "86", "87", "88", "89", "91", "92", "93", "94", "95", "96", "97", "98", "99"]);
+                let prefix;
+                if (options.mobile) {
+                    // Brasilian official reference (mobile): http://www.anatel.gov.br/setorregulado/plano-de-numeracao-brasileiro?id=330
+                    prefix = '9' + self.string({ pool: '0123456789', length: 4});
+                } else {
+                    // Brasilian official reference: http://www.anatel.gov.br/setorregulado/plano-de-numeracao-brasileiro?id=331
+                    prefix = this.natural({ min: 2000, max: 5999 }).toString();
+                }
+                const mcdu = self.string({ pool: '0123456789', length: 4});
+                phone = options.formatted ? '(' + areaCode + ') ' + prefix + '-' + mcdu : areaCode + prefix + mcdu;
+                break;
         }
         return phone;
     };

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -346,6 +346,46 @@ test('phone() with fr country on mobile, unformatted looks right', t => {
     })
 })
 
+test('phone() with br country option works', t => {
+    t.true(_.isString(chance.phone({ country: 'br' })))
+})
+
+test('phone() with br country and mobile option works', t => {
+    t.true(_.isString(chance.phone({ country: 'br', mobile: true })))
+})
+
+test('phone() with br country and formatted false option return a correct format', t => {
+    t.true(/([0-9]{2})([2-5]{1})([0-9]{3})([0-9]{4})/.test(chance.phone({
+        country: 'br',
+        mobile: false,
+        formatted: false
+    })))
+})
+
+test('phone() with br country, formatted false and mobile option return a correct format', t => {
+    t.true(/([0-9]{2})\9([0-9]{4})([0-9]{4})/.test(chance.phone({
+        country: 'br',
+        mobile: true,
+        formatted: false
+    })))
+})
+
+test('phone() with br country and formatted option apply the correct mask', t => {
+    t.true(/\(([0-9]{2})\) ([2-5]{1})([0-9]{3})\-([0-9]{4})/.test(chance.phone({
+        country: 'br',
+        mobile: false,
+        formatted: true
+    })))
+})
+
+test('phone() with br country, formatted and mobile option apply the correct mask', t => {
+    t.true(/\(([0-9]{2})\) 9([0-9]{4})\-([0-9]{4})/.test(chance.phone({
+        country: 'br',
+        mobile: true,
+        formatted: true
+    })))
+})
+
 // chance.postal()
 test('postal() returns a valid basic postal code', t => {
     _.times(1000, () => {


### PR DESCRIPTION
This pull request adds to the chance.phone() method the option to generate numbers in brazilian format (br). The implementation was based on official documentation from **Brazil** that can be found on the **Anatel** website:
Mobile phone: http://www.anatel.gov.br/setorregulado/plano-de-numeraca-euileiro?id=330
Telephone: http://www.anatel.gov.br/setorregulado/plano-de-numeraca-brasileiro?id=331
I hope this can be useful.