### PR TITLE
improving pickset performance while returning unique values

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -487,7 +487,15 @@
         if (!count || count === 1) {
             return [ this.pickone(arr) ];
         } else {
-            return this.shuffle(arr).slice(0, count);
+            var array = arr.slice(0);
+            var end = array.length;
+
+            return this.n(() => {
+                var index = this.natural({max: --end});
+                var value = array[index];
+                array[index] = array[end];
+                return value;
+            }, Math.min(end, count));
         }
     };
 

--- a/test/test.helpers.js
+++ b/test/test.helpers.js
@@ -144,6 +144,14 @@ test('pickset() returns multiple elements when called with count > 1', t => {
     })
 })
 
+test('pickset() returns no more values than the size of the array', t => {
+    let arr = ['a', 'b', 'c', 'd']
+    _.times(1000, () => {
+        let picked = chance.pickset(arr, 5)
+        t.is(picked.length, 4)
+    })
+})
+
 test('pickset() does not destroy the original array', t => {
     let arr = ['a', 'b', 'c', 'd', 'e', 'f'];
     _.times(1000, () => {


### PR DESCRIPTION
This improves the performance of `pickset` while continuing to provide a unique pick of elements from the array.

`pickset` in the console on the [website](http://chancejs.com) (currently v1.0.13) would not return more items than the length of the array, so I created a test for that restriction to avoid errors with this implementation.

Fixes #335 #336 

![image](https://user-images.githubusercontent.com/7218853/39326582-1bb38888-495b-11e8-8a16-5658dfff5912.png)