### PR TITLE
allow combination of alpha, numeric and symbols

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -167,17 +167,12 @@
     /**
      *  Return a random character.
      *
-     *  @param {Object} [options={}] can specify a character pool, only alpha,
-     *    only symbols, and casing (lower or upper)
+     *  @param {Object} [options={}] can specify a character pool or alpha,
+     *    numeric, symbols and casing (lower or upper)
      *  @returns {String} a single random character
-     *  @throws {RangeError} Can only specify alpha or symbols, not both
      */
     Chance.prototype.character = function (options) {
         options = initOptions(options);
-        testRange(
-            options.alpha && options.symbols,
-            "Chance: Cannot specify both alpha and symbols."
-        );
 
         var symbols = "!@#$%^&*()[]",
             letters, pool;
@@ -192,12 +187,20 @@
 
         if (options.pool) {
             pool = options.pool;
-        } else if (options.alpha) {
-            pool = letters;
-        } else if (options.symbols) {
-            pool = symbols;
         } else {
-            pool = letters + NUMBERS + symbols;
+            pool = '';
+            if (options.alpha) {
+                pool += letters;
+            }
+            if (options.numeric) {
+                pool += NUMBERS;
+            }
+            if (options.symbols) {
+                pool += symbols;
+            }
+            if (!pool) {
+                pool = letters + NUMBERS + symbols;
+            }
         }
 
         return pool.charAt(this.natural({max: (pool.length - 1)}));

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -163,9 +163,11 @@ test('character() allows only alpha', t => {
     })
 })
 
-test('character() throws when specifying both alpha and symbols', t => {
-    const fn = () => chance.character({alpha: true, symbols: true})
-    t.throws(fn, 'Chance: Cannot specify both alpha and symbols.')
+test('character() allows only alphanumeric', t => {
+    _.times(1000, () => {
+        let char = chance.character({ alpha: true, numeric: true })
+        t.true(/[a-zA-Z0-9]/.test(char))
+    })
 })
 
 test('character() obeys upper case', t => {


### PR DESCRIPTION
Allows you to combine  `alpha`, `numeric` and `symbols` options.

```js
let token = chance.string({length: 64, alpha: true, numeric: true});
```