### PR TITLE
📞 Phone number can now be generated for South Africa

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1646,7 +1646,7 @@
                        '04' + this.pick(['1', '2', '3', '4', '5','6','7', '8','9']) + self.string({ pool: '0123456789', length: 7}),
                        '05' + this.pick(['1', '3', '4', '6', '7', '8']) + self.string({ pool: '0123456789', length: 7}),
                     ]);
-                    phone = options.formatted || numPick;
+                    phone = numPick;
                 } else {
                     numPick = this.pick([
                         '060' + this.pick(['3','4','5','6','7','8','9']) + self.string({ pool: '0123456789', length: 6}),
@@ -1656,7 +1656,7 @@
                         '07'  + this.pick(['2','3','4','6','7','8','9']) + self.string({ pool: '0123456789', length: 7}),
                         '08'  + this.pick(['0','1','2','3','4','5']) + self.string({ pool: '0123456789', length: 7}),
                     ]);
-                    phone = options.formatted || numPick;
+                    phone = numPick;
                 }
                 break;
             case 'us':

--- a/docs/location/phone.md
+++ b/docs/location/phone.md
@@ -31,9 +31,9 @@ chance.phone({ country: 'fr' });
 => '01 60 44 92 67'
 ```
 
-Note, at current we only have support for `'us'`, `'uk'`, or `'fr'` for countries.
+Note, at current we only have support for `'us'`, `'uk'`, `'fr'` or `'za'` for countries.
 
-For `uk` and `fr`, optionally specify a mobile phone.
+For `uk`, `fr` and `za`, optionally specify a mobile phone.
 
 ```js
 chance.phone({ country: 'uk', mobile: true });

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -386,6 +386,46 @@ test('phone() with br country, formatted and mobile option apply the correct mas
     })))
 })
 
+test('phone() with za country option works', t => {
+    t.true(_.isString(chance.phone({ country: 'za' })))
+})
+
+test('phone() with za country and mobile option works', t => {
+    t.true(_.isString(chance.phone({ country: 'za', mobile: true })))
+})
+
+test('phone() with za country and formatted false option return a correct format', t => {
+    t.true(/([0])([1-5]{1})([0-9]{1})([0-9]{7})/.test(chance.phone({
+        country: 'za',
+        mobile: false,
+        formatted: false
+    })))
+})
+
+test('phone() with za country, formatted false and mobile option return a correct format', t => {
+    t.true(/([0]{1})([0-9]{2})([0-9]{6,8})/.test(chance.phone({
+        country: 'za',
+        mobile: true,
+        formatted: false
+    })))
+})
+
+test('phone() with za country and formatted option apply the correct mask', t => {
+    t.true(/([0]{1})([0-9]{2})([0-9]{6,8})/.test(chance.phone({
+        country: 'za',
+        mobile: false,
+        formatted: true
+    })))
+})
+
+test('phone() with za country, formatted and mobile option apply the correct mask', t => {
+    t.true(/([0]{1})([0-9]{2})([0-9]{6,8})/.test(chance.phone({
+        country: 'za',
+        mobile: true,
+        formatted: true
+    })))
+})
+
 // chance.postal()
 test('postal() returns a valid basic postal code', t => {
     _.times(1000, () => {


### PR DESCRIPTION
Hi @all,

I discovered a little bug in the code. It was already possible to generate random phone numbers for South Africa (`{ country: 'za' }`) but only with `{ formatted: false }`. Otherwise the function just returned `true`. Here is my proposal to fix it 😉.

Additionally I wrote some tests for it and mentioned the `{ country: 'za' }` option in the documentation 👍

It's a great lib. Really! Thanks for sharing this with us!!!

Greetings,
Sewas