### PR TITLE
Remove extraneous period

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -6598,7 +6598,7 @@
             "Civil Engineer",
             "Claims Manager",
             "Clinical Research Assistant",
-            "Collections Manager.",
+            "Collections Manager",
             "Compliance Manager",
             "Comptroller",
             "Computer Manager",


### PR DESCRIPTION
Delete `.` from the end of `Collections Manager`