### PR TITLE
Adds note that dice methods have a min. value of 1

### DIFF
--- a/docs/miscellaneous/dice.md
+++ b/docs/miscellaneous/dice.md
@@ -26,3 +26,4 @@ chance.d6();
 
 These are just wrappers around natural() but are convenient for use by games.
 
+They return values between 1 and the number after the `d`, so `chance.d4()` returns 1, 2, 3, or 4, just like a 4 sided die would.


### PR DESCRIPTION
Makes it explicit that the dice methods return a minimum of 1 since several developers on my team thought we had to guard against these methods returning 0 with patterns like `chance.d6() + 1`.