### PR TITLE
Add missing usage examples for url method

### DIFF
--- a/docs/web/url.md
+++ b/docs/web/url.md
@@ -35,7 +35,7 @@ Optionally specify a domain prefix and domain will be random, and domain prefix 
 
 ```js
 chance.url({domain_prefix: 'docs'})
-=> '"http://docs.tuos.ni/itecabup'
+=> 'http://docs.tuos.ni/itecabup'
 ```
 
 Optionally specify a path and it will be obeyed.

--- a/docs/web/url.md
+++ b/docs/web/url.md
@@ -5,7 +5,7 @@
 chance.url()
 chance.url({protocol: 'ftp'})
 chance.url({domain: 'www.socialradar.com'})
-chance.url({domain_profix: 'docs'})
+chance.url({domain_prefix: 'docs'})
 chance.url({path: 'images'})
 chance.url({extensions: ['gif', 'jpg', 'png']})
 ```

--- a/docs/web/url.md
+++ b/docs/web/url.md
@@ -3,7 +3,9 @@
 ```js
 // usage
 chance.url()
+chance.url({protocol: 'ftp'})
 chance.url({domain: 'www.socialradar.com'})
+chance.url({domain_profix: 'docs'})
 chance.url({path: 'images'})
 chance.url({extensions: ['gif', 'jpg', 'png']})
 ```
@@ -15,11 +17,25 @@ chance.url()
 => 'http://vanogsi.io/pateliivi'
 ```
 
+Optionally specify a protocol and the url will be random but the protocol will not.
+
+```js
+chance.url({protocol: 'ftp'})
+=> 'ftp://mibfu.nr/kardate'
+```
+
 Optionally specify a domain and the url will be random but the domain will not.
 
 ```js
 chance.url({domain: 'www.socialradar.com'})
 => 'http://www.socialradar.com/hob'
+```
+
+Optionally specify a domain prefix and domain will be random, and domain prefix will not.
+
+```js
+chance.url({domain_prefix: 'docs'})
+=> '"http://docs.tuos.ni/itecabup'
 ```
 
 Optionally specify a path and it will be obeyed.


### PR DESCRIPTION
Usage examples for protocol and domain_prefix are missing.