### PR TITLE
feat(Chance.weighted): throw explicit error when provided array is empty

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -715,6 +715,10 @@
         if (arr.length !== weights.length) {
             throw new RangeError("Chance: Length of array and weights must match");
         }
+        
+        if (arr.length === 0) {
+            throw new RangeError("Chance: Cannot weighted() from an empty array");
+        }
 
         // scan weights array and sum valid entries
         var sum = 0;


### PR DESCRIPTION
Before this commit, if `Chance.weighted` is provided an empty array, it throws `Chance: No valid entries in array weights` which is misleading. Now, explicitly throwing error saying that can't do so for an empty array.