### PR TITLE
fix: make chance js work in es5 environment

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -306,13 +306,14 @@
         if (options.exclude) {
             testRange(!Array.isArray(options.exclude), "Chance: exclude must be an array.")
 
-            for (const exclusion of options.exclude) {
-                testRange(!Number.isInteger(exclusion), "Chance: exclude must be numbers.")
+            for (var exclusionIndex in options.exclude) {
+                testRange(!Number.isInteger(options.exclude[exclusionIndex]), "Chance: exclude must be numbers.")
             }
 
             let random = options.min + this.natural({max: options.max - options.min - options.exclude.length})
-            for (const exclusion of options.exclude.sort()) {
-                if (random < exclusion) {
+            var sortedExclusions = options.exclude.sort();
+            for (var exclusionIndex in sortedExclusions) {
+                if (random < sortedExclusions[exclusionIndex]) {
                     break
                 }
                 random++


### PR DESCRIPTION
Chance currently does not work in ie 11 because it uses const and for of
These usages can be replaced by var and for in