### PR TITLE
add chance.object()

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -546,6 +546,22 @@
         return Buffer.from(content);
     };
 
+    /**
+     * Return a random object
+     *
+     *  @param {Object} [options={}]
+     *  @returns {Object} an object with a random key/value
+     */
+    Chance.prototype.object = function(options) {
+        options = initOptions(options, {
+            key: this.word(),
+            value: this.word()
+        });
+        const obj = {[options.key]: options.value}
+
+        return obj;
+    }
+
     // -- End Basics --
 
     // -- Helpers --

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
   * [natural](basics/natural.md)
   * [prime](basics/prime.md)
   * [string](basics/string.md)
+  * [string](basics/object.md)
 * Text
   * [paragraph](text/paragraph.md)
   * [sentence](text/sentence.md)

--- a/docs/basics/object.md
+++ b/docs/basics/object.md
@@ -1,0 +1,32 @@
+# object
+
+```js
+// usages
+chance.object()
+chance.object({ key: 'food' })
+chance.object({ value: ['apples', 'oranges', 'pickles'] })
+```
+
+Return an object with a random key/value
+```js
+chance.object()
+=> { zutuc: 'ko' }
+```
+
+Optionally include a key
+```js
+chance.object({ key: 'food' })
+=> { food: 'vuj'}
+```
+
+Optionally include a value
+```js
+chance.object({ value: ['apples', 'oranges', 'pickles'] })
+=> { trup: ['apples', 'oranges', 'pickles'] }
+
+chance.object({ value: 3.14159 })
+=> { qwop: 3.14159 }
+
+chance.object({ value: chance.object() })
+=> { svit: { kozra: 'ciknebaz' } }
+```

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -546,3 +546,35 @@ test('template() cannot be undefined', t => {
 test('template() cannot be empty', t => {
     t.throws(() => chance.template(''), 'Template string is required')
 })
+
+test('object() returns an object', t => {
+    t.is(typeof chance.object(), 'object')
+    t.true(chance.object() instanceof Object)
+})
+
+test('object() has a single key/value', t => {
+    t.is(Object.keys(chance.object()).length, 1)
+})
+
+test('object() return object with specified key', t => {
+    const key = chance.word();
+    const obj = chance.object({key})
+
+    t.is(Object.keys(obj)[0], key)
+})
+
+test('object() return object with specified value', t => {
+    const value = chance.word();
+    const obj = chance.object({value})
+
+    t.is(obj[Object.keys(obj)[0]], value)
+})
+
+test('object() return object with specified key and value', t => {
+    const key = chance.word();
+    const value = chance.word();
+    const obj = chance.object({key, value})
+
+    t.is(Object.keys(obj)[0], key)
+    t.is(obj[key], value)
+})


### PR DESCRIPTION
There have been a few requests for generating a random object #82 #194 #406.
I am proposing a very simple version that generates an object with a random key/value. If it needs to grow in functionality, let it start here and evolve. 

When testing, I've found I have a need for declaring I have an object with values I don't care about, and sometimes I will spread it with a value I do care about. `chance.object()` allows me to save lines and generate more complex formats in more concise way. It also acts as a building block (like many other chance functions) to create more complex or specific generators.