### PR TITLE
alert users that can get cpf without formatting

### DIFF
--- a/docs/person/cpf.md
+++ b/docs/person/cpf.md
@@ -2,7 +2,7 @@
 
 ```js
 // usage
-chance.cpf()
+chance.cpf();
 ```
 
 Generate a random Brazilian tax id.
@@ -10,4 +10,11 @@ Generate a random Brazilian tax id.
 ```js
 chance.cpf();
 => '607.116.899-62'
+```
+
+Default cpf is formatted, to get only numbers:
+
+```js
+chance.cpf({ formatted: false });
+=> '60711689962'
 ```


### PR DESCRIPTION
I was generating a regex to get only numbers, but this option already exists, so it is only a documentation update.