### PR TITLE
Fix incorrect random integer when min and max are equal

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -280,7 +280,7 @@
         options = initOptions(options, {min: MIN_INT, max: MAX_INT});
         testRange(options.min > options.max, "Chance: Min cannot be greater than Max.");
 
-        return Math.floor(this.random() * (options.max - options.min + 1) + options.min);
+        return Math.floor(this.random() * (options.max - options.min + 1)) + options.min;
     };
 
     /**

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -293,6 +293,14 @@ test('integer() can take a min with absolute value less than max and return in r
     t.true(count < 900)
 })
 
+test('integer() returns the exact number when min and max are equal', t => {
+    _.times(1000, () => {
+        let border = chance.integer()
+        let integer = chance.integer({ min: border, max: border })
+        t.true(integer === border)
+    })
+})
+
 test('integer() throws an error when min > max', t => {
     const fn = () => chance.integer({ min: 1000, max: 500 })
     t.throws(fn, 'Chance: Min cannot be greater than Max.')


### PR DESCRIPTION
When `this.random()` returns value close to 1 the concatenation with `options.min` can round the value which provides incorrect result (looks like because of the float number operation).

Example:
```
const min = max = 1583211693930;
const random = 0.9999402815010399;

// This returns 1583211693931
console.log(Math.floor(this.random() * (options.max - options.min + 1) + options.min));
```