### PR TITLE
feature(paragraph): add line break option

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -782,9 +782,10 @@
         options = initOptions(options);
 
         var sentences = options.sentences || this.natural({min: 3, max: 7}),
-            sentence_array = this.n(this.sentence, sentences);
+            sentence_array = this.n(this.sentence, sentences),
+            separator = options.linebreak === true ? '\n' : ' ';
 
-        return sentence_array.join(' ');
+        return sentence_array.join(separator);
     };
 
     // Could get smarter about this than generating random words and

--- a/docs/text/paragraph.md
+++ b/docs/text/paragraph.md
@@ -4,6 +4,7 @@
 // usage
 chance.paragraph()
 chance.paragraph({ sentences: 1 })
+chance.paragraph({ linebreak: true })
 ```
 
 Return a random paragraph generated from sentences populated by semi-pronounceable
@@ -23,6 +24,16 @@ Optionally specify the number of sentences in the paragraph.
   => 'Idefeulo foc omoemowa wahteze liv juvde puguprof epehuji upuga zige odfe igo sit pilamhul oto ukurecef.'
 ```
 
+Optionally specify if each sentence in the paragraph should start a new line.
+
+```js
+  chance.paragraph({ linebreak: true });
+  => `
+      Moku kazkubib adi apo bebiw movarne rab tusa vura nok ji iv otukib dewut.
+      Tiwlo orojel vuhhet emluliv loha ma rulical fokuv re dob fabup bit.
+      Veza ermethit osgues dohjeci pezlal su ibi cib zerezci bode ca hopmub gigwosut culhoca nubu.
+     `
+```
 
 
 

--- a/test/test.text.js
+++ b/test/test.text.js
@@ -110,3 +110,14 @@ test('paragraph() will obey bounds', t => {
         t.is(len, 6)
     })
 })
+
+test('paragraph) will obey line breaks', t => {
+    _.times(100, () => {
+        let rand = _.random(1, 50);
+        let paragraph = chance.paragraph({ sentences: rand, linebreak: true })
+        t.true(_.isString(paragraph))
+
+        let len = paragraph.split('\n').length
+        t.is(len, rand);
+    })
+})


### PR DESCRIPTION
Closes [Issue #338](https://github.com/chancejs/chancejs/issues/338).

Added the option of line break to chance.paragraph();
Now it is possible to pass **{ linebreak: true }** as an option.
`chance.paragraph({ linebreak: true })`

The output:
> Teve mowohfu lopmaha iw za utacas mat ko muoka de olidaw fabolpo me.
Utecozo dauturap mudwij fefofkij mijvooce gazgab ju nezil uh eri ru binombaj.
Fugesbo ru vi nirab bo uruviv uwiwe upmubuso zoasa naguoci eske iledowva barawajip.  

Instead of:
> Teve mowohfu lopmaha iw za utacas mat ko muoka de olidaw fabolpo me. Utecozo dauturap mudwij fefofkij mijvooce gazgab ju nezil uh eri ru binombaj. Fugesbo ru vi nirab bo uruviv uwiwe upmubuso zoasa naguoci eske iledowva barawajip.

My first contribution and pull request :+1: 

@victorquinn 