### PR TITLE
feat(latitude-longitude): add format option

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1721,13 +1721,11 @@
 
         switch (format) {
             case DDM: {
-                return 'N ' + 
-                        this.integer({min: options.min, max: options.max}) + '°' + 
+                return  this.integer({min: options.min, max: options.max}) + '°' + 
                         this.floating({min: 0, max: 59, fixed: options.fixed});
             }
             case DMS: {
-                return 'N ' + 
-                        this.integer({min: options.min, max: options.max}) + '°' + 
+                return  this.integer({min: options.min, max: options.max}) + '°' + 
                         this.integer({min: 0, max: 59}) + '’' + 
                         this.floating({min: 0, max: 59, fixed: options.fixed}) + '”';
             }
@@ -1757,13 +1755,11 @@
 
         switch (format) {
             case DDM: {
-                return 'W ' + 
-                        this.integer({min: options.min, max: options.max}) + '°' + 
+                return  this.integer({min: options.min, max: options.max}) + '°' + 
                         this.floating({min: 0, max: 59.9999, fixed: options.fixed})
             }
             case DMS: {
-                return 'W ' +
-                        this.integer({min: options.min, max: options.max}) + '°' +
+                return  this.integer({min: options.min, max: options.max}) + '°' +
                         this.integer({min: 0, max: 59}) + '’' +
                         this.floating({min: 0, max: 59.9999, fixed: options.fixed}) + '”';
             }

--- a/chance.js
+++ b/chance.js
@@ -1703,13 +1703,75 @@
     };
 
     Chance.prototype.latitude = function (options) {
-        options = initOptions(options, {fixed: 5, min: -90, max: 90});
-        return this.floating({min: options.min, max: options.max, fixed: options.fixed});
+        // Constants - Formats
+        const [DDM, DMS, DD] = ['ddm', 'dms', 'dd'];
+
+        options = initOptions(options, 
+            options && options.format && [DDM, DMS].includes(options.format.toLowerCase()) ?
+            {min: 0, max: 89, fixed: 4} :
+            {fixed: 5, min: -90, max: 90, format: DD});
+
+        const format = options.format.toLowerCase();
+        
+        if (format === DDM || format === DMS) {
+            testRange(options.min < 0 || options.min > 89, "Chance: Min specified is out of range. Should be between 0 - 89");
+            testRange(options.max < 0 || options.max > 89, "Chance: Max specified is out of range. Should be between 0 - 89");
+            testRange(options.fixed > 4, 'Chance: Fixed specified should be below or equal to 4');
+        }
+
+        switch (format) {
+            case DDM: {
+                return 'N ' + 
+                        this.integer({min: options.min, max: options.max}) + '°' + 
+                        this.floating({min: 0, max: 59, fixed: options.fixed});
+            }
+            case DMS: {
+                return 'N ' + 
+                        this.integer({min: options.min, max: options.max}) + '°' + 
+                        this.integer({min: 0, max: 59}) + '’' + 
+                        this.floating({min: 0, max: 59, fixed: options.fixed}) + '”';
+            }
+            case DD:
+            default: {    
+                return this.floating({min: options.min, max: options.max, fixed: options.fixed});
+            }
+        }
     };
 
     Chance.prototype.longitude = function (options) {
-        options = initOptions(options, {fixed: 5, min: -180, max: 180});
-        return this.floating({min: options.min, max: options.max, fixed: options.fixed});
+        // Constants - Formats
+        const [DDM, DMS, DD] = ['ddm', 'dms', 'dd'];
+
+        options = initOptions(options, 
+            options && options.format && [DDM, DMS].includes(options.format.toLowerCase()) ?
+            {min: 0, max: 179, fixed: 4} :
+            {fixed: 5, min: -180, max: 180, format: DD});
+
+        const format = options.format.toLowerCase();
+
+        if (format === DDM || format === DMS) {
+            testRange(options.min < 0 || options.min > 179, "Chance: Min specified is out of range. Should be between 0 - 179");
+            testRange(options.max < 0 || options.max > 179, "Chance: Max specified is out of range. Should be between 0 - 179");
+            testRange(options.fixed > 4, 'Chance: Fixed specified should be below or equal to 4');
+        }
+
+        switch (format) {
+            case DDM: {
+                return 'W ' + 
+                        this.integer({min: options.min, max: options.max}) + '°' + 
+                        this.floating({min: 0, max: 59.9999, fixed: options.fixed})
+            }
+            case DMS: {
+                return 'W ' +
+                        this.integer({min: options.min, max: options.max}) + '°' +
+                        this.integer({min: 0, max: 59}) + '’' +
+                        this.floating({min: 0, max: 59.9999, fixed: options.fixed}) + '”';
+            }
+            case DD:
+            default: {    
+                return this.floating({min: options.min, max: options.max, fixed: options.fixed});
+            }
+        }
     };
 
     Chance.prototype.phone = function (options) {

--- a/docs/location/coordinates.md
+++ b/docs/location/coordinates.md
@@ -4,6 +4,7 @@
 // usage
 chance.coordinates()
 chance.coordinates({fixed: 2})
+chance.coordinates({format: 'dms'})
 ```
 
 Generate random coordinates, which are latitude and longitude, comma separated.
@@ -20,3 +21,14 @@ chance.coordinates({fixed: 2});
 => "-49.16, 68.81"
 ```
 
+By default cooridnates' format is dd, can specify otherwise.
+
+```js
+chance.coordinates({format: 'ddm'});
+=> "N 41°44.9592, W 25°56.2622"
+```
+
+```js
+chance.coordinates({format: 'dms'});
+=> "N 56°2’9.8187”, W 79°55’40.6812”"
+```

--- a/docs/location/coordinates.md
+++ b/docs/location/coordinates.md
@@ -25,10 +25,10 @@ By default cooridnates' format is dd, can specify otherwise.
 
 ```js
 chance.coordinates({format: 'ddm'});
-=> "N 41°44.9592, W 25°56.2622"
+=> "41°44.9592, 25°56.2622"
 ```
 
 ```js
 chance.coordinates({format: 'dms'});
-=> "N 56°2’9.8187”, W 79°55’40.6812”"
+=> "56°2’9.8187”, 79°55’40.6812”"
 ```

--- a/docs/location/latitude.md
+++ b/docs/location/latitude.md
@@ -4,6 +4,7 @@
 // usage
 chance.latitude()
 chance.latitude({fixed: 7})
+chance.latitude({format: 'dms'})
 ```
 
 Generate a random latitude.
@@ -27,4 +28,16 @@ By default includes entire range of allowed latitudes, can specify a min and/or 
 ```js
 chance.latitude({min: 38.7, max: 38.9});
 => 38.82358
+```
+
+By default latitudes' format is dd, can specify otherwise.
+
+```js
+chance.latitude({format: 'ddm'});
+=> "N 41°44.9592"
+```
+
+```js
+chance.latitude({format: 'dms'});
+=> "N 56°2’9.8187”"
 ```

--- a/docs/location/latitude.md
+++ b/docs/location/latitude.md
@@ -34,10 +34,10 @@ By default latitudes' format is dd, can specify otherwise.
 
 ```js
 chance.latitude({format: 'ddm'});
-=> "N 41°44.9592"
+=> "41°44.9592"
 ```
 
 ```js
 chance.latitude({format: 'dms'});
-=> "N 56°2’9.8187”"
+=> "56°2’9.8187”"
 ```

--- a/docs/location/longitude.md
+++ b/docs/location/longitude.md
@@ -4,6 +4,7 @@
 // usage
 chance.longitude()
 chance.longitude({fixed: 7})
+chance.longitude({format: 'dms'})
 ```
 
 Generate a random longitude.
@@ -27,4 +28,16 @@ By default includes entire range of allowed longitudes, can specify a min and/or
 ```js
 chance.longitude({min: -78, max: -77});
 => -77.22644
+```
+
+By default longitude' format is dd, can specify otherwise.
+
+```js
+chance.longitude({format: 'ddm'});
+=> "N 41°44.9592"
+```
+
+```js
+chance.longitude({format: 'dms'});
+=> "N 56°2’9.8187”"
 ```

--- a/docs/location/longitude.md
+++ b/docs/location/longitude.md
@@ -34,10 +34,10 @@ By default longitude' format is dd, can specify otherwise.
 
 ```js
 chance.longitude({format: 'ddm'});
-=> "N 41°44.9592"
+=> "41°44.9592"
 ```
 
 ```js
 chance.longitude({format: 'dms'});
-=> "N 56°2’9.8187”"
+=> "56°2’9.8187”"
 ```

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -87,6 +87,65 @@ test('coordinates() looks right', t => {
     })
 })
 
+test('coordinates() returns coordinates in DD format as default', t => {
+    _.times(1000, () => {
+        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        
+        let coordinates = chance.coordinates()
+        let [ latitude, longitude ] = coordinates.split(',')
+
+        t.true(_.isString(coordinates))
+        t.is(coordinates.split(',').length, 2)
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !latitude.includes(char)))
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !longitude.includes(char)))
+    })
+})
+
+test('coordinates() will obey DD format', t => {
+    _.times(1000, () => {
+        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        
+        let coordinates = chance.coordinates({format: 'dd'})
+        let [ latitude, longitude ] = coordinates.split(',')
+
+        t.true(_.isString(coordinates))
+        t.is(coordinates.split(',').length, 2)
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !latitude.includes(char)))
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !longitude.includes(char)))
+    })
+})
+
+test('coordinates() will obey DDM format', t => {
+    _.times(1000, () => {
+        const CHARS_TO_CONTAIN = ['°']
+        const CHARS_NOT_TO_CONTAIN = ['’', '”']
+        
+        let coordinates = chance.coordinates({format: 'ddm'})
+        let [ latitude, longitude ] = coordinates.split(',')
+
+        t.true(_.isString(coordinates))
+        t.is(coordinates.split(',').length, 2)
+        t.true(['N', ...CHARS_TO_CONTAIN].every(char => latitude.includes(char)))
+        t.true(['W', ...CHARS_TO_CONTAIN].every(char => longitude.includes(char)))
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !latitude.includes(char)))
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !longitude.includes(char)))
+    })
+})
+
+test('coordinates() will obey DMS format', t => {
+    _.times(1000, () => {
+        const CHARS_TO_CONTAIN = ['°', '’', '”']
+        
+        let coordinates = chance.coordinates({format: 'dms'})
+        let [ latitude, longitude ] = coordinates.split(',')
+
+        t.true(_.isString(coordinates))
+        t.is(coordinates.split(',').length, 2)
+        t.true(['N', ...CHARS_TO_CONTAIN].every(char => latitude.includes(char)))
+        t.true(['W', ...CHARS_TO_CONTAIN].every(char => longitude.includes(char)))
+    })
+})
+
 // chance.counties()
 test('counties() returns an array of counties', t => {
     t.true(_.isArray(chance.counties()))
@@ -210,6 +269,52 @@ test('latitude() will accept a max and obey it', t => {
     })
 })
 
+test('latitude() returns latitude in DD format as default', t => {
+    _.times(1000, () => {
+        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        
+        let latitude = chance.latitude()
+
+        t.is(typeof latitude, 'number')
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !latitude.toString().includes(char)))
+    })
+})
+
+test('latitude() will obey DD format', t => {
+    _.times(1000, () => {
+        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        
+        let latitude = chance.latitude({format: 'dd'})
+
+        t.is(typeof latitude, 'number')
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !latitude.toString().includes(char)))
+    })
+})
+
+test('latitude() will obey DDM format', t => {
+    _.times(1000, () => {
+        const CHARS_TO_CONTAIN = ['N', '°']
+        const CHARS_NOT_TO_CONTAIN = ['’', '”']
+        
+        let latitude = chance.latitude({format: 'ddm'})
+
+        t.true(_.isString(latitude))
+        t.true(CHARS_TO_CONTAIN.every(char => latitude.includes(char)))
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !latitude.includes(char)))
+    })
+})
+
+test('latitude() will obey DMS format', t => {
+    _.times(1000, () => {
+        const CHARS_TO_CONTAIN = ['N', '°', '’', '”']
+        
+        let latitude = chance.latitude({format: 'dms'})
+
+        t.true(_.isString(latitude))
+        t.true(CHARS_TO_CONTAIN.every(char => latitude.includes(char)))
+    })
+})
+
 // chance.longitude()
 test('longitude() looks right', t => {
     t.is(typeof chance.longitude(), 'number')
@@ -238,6 +343,52 @@ test('longitude() will accept a max and obey it', t => {
         let longitude = chance.longitude({ max: max })
         t.true(longitude >= -180)
         t.true(longitude <= max)
+    })
+})
+
+test('longitude() returns longitude in DD format as default', t => {
+    _.times(1000, () => {
+        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        
+        let longitude = chance.longitude()
+
+        t.is(typeof longitude, 'number')
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !longitude.toString().includes(char)))
+    })
+})
+
+test('longitude() will obey DD format', t => {
+    _.times(1000, () => {
+        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        
+        let longitude = chance.longitude({format: 'dd'})
+
+        t.is(typeof longitude, 'number')
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !longitude.toString().includes(char)))
+    })
+})
+
+test('longitude() will obey DDM format', t => {
+    _.times(1000, () => {
+        const CHARS_TO_CONTAIN = ['W', '°']
+        const CHARS_NOT_TO_CONTAIN = ['’', '”']
+        
+        let longitude = chance.longitude({format: 'ddm'})
+
+        t.true(_.isString(longitude))
+        t.true(CHARS_TO_CONTAIN.every(char => longitude.includes(char)))
+        t.true(CHARS_NOT_TO_CONTAIN.every(char => !longitude.includes(char)))
+    })
+})
+
+test('longitude() will obey DMS format', t => {
+    _.times(1000, () => {
+        const CHARS_TO_CONTAIN = ['W', '°', '’', '”']
+        
+        let longitude = chance.longitude({format: 'dms'})
+
+        t.true(_.isString(longitude))
+        t.true(CHARS_TO_CONTAIN.every(char => longitude.includes(char)))
     })
 })
 

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -89,7 +89,7 @@ test('coordinates() looks right', t => {
 
 test('coordinates() returns coordinates in DD format as default', t => {
     _.times(1000, () => {
-        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
         
         let coordinates = chance.coordinates()
         let [ latitude, longitude ] = coordinates.split(',')
@@ -103,7 +103,7 @@ test('coordinates() returns coordinates in DD format as default', t => {
 
 test('coordinates() will obey DD format', t => {
     _.times(1000, () => {
-        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
         
         let coordinates = chance.coordinates({format: 'dd'})
         let [ latitude, longitude ] = coordinates.split(',')
@@ -125,8 +125,8 @@ test('coordinates() will obey DDM format', t => {
 
         t.true(_.isString(coordinates))
         t.is(coordinates.split(',').length, 2)
-        t.true(['N', ...CHARS_TO_CONTAIN].every(char => latitude.includes(char)))
-        t.true(['W', ...CHARS_TO_CONTAIN].every(char => longitude.includes(char)))
+        t.true(CHARS_TO_CONTAIN.every(char => latitude.includes(char)))
+        t.true(CHARS_TO_CONTAIN.every(char => longitude.includes(char)))
         t.true(CHARS_NOT_TO_CONTAIN.every(char => !latitude.includes(char)))
         t.true(CHARS_NOT_TO_CONTAIN.every(char => !longitude.includes(char)))
     })
@@ -141,8 +141,8 @@ test('coordinates() will obey DMS format', t => {
 
         t.true(_.isString(coordinates))
         t.is(coordinates.split(',').length, 2)
-        t.true(['N', ...CHARS_TO_CONTAIN].every(char => latitude.includes(char)))
-        t.true(['W', ...CHARS_TO_CONTAIN].every(char => longitude.includes(char)))
+        t.true(CHARS_TO_CONTAIN.every(char => latitude.includes(char)))
+        t.true(CHARS_TO_CONTAIN.every(char => longitude.includes(char)))
     })
 })
 
@@ -271,7 +271,7 @@ test('latitude() will accept a max and obey it', t => {
 
 test('latitude() returns latitude in DD format as default', t => {
     _.times(1000, () => {
-        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
         
         let latitude = chance.latitude()
 
@@ -282,7 +282,7 @@ test('latitude() returns latitude in DD format as default', t => {
 
 test('latitude() will obey DD format', t => {
     _.times(1000, () => {
-        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
         
         let latitude = chance.latitude({format: 'dd'})
 
@@ -293,7 +293,7 @@ test('latitude() will obey DD format', t => {
 
 test('latitude() will obey DDM format', t => {
     _.times(1000, () => {
-        const CHARS_TO_CONTAIN = ['N', '°']
+        const CHARS_TO_CONTAIN = ['°']
         const CHARS_NOT_TO_CONTAIN = ['’', '”']
         
         let latitude = chance.latitude({format: 'ddm'})
@@ -306,7 +306,7 @@ test('latitude() will obey DDM format', t => {
 
 test('latitude() will obey DMS format', t => {
     _.times(1000, () => {
-        const CHARS_TO_CONTAIN = ['N', '°', '’', '”']
+        const CHARS_TO_CONTAIN = ['°', '’', '”']
         
         let latitude = chance.latitude({format: 'dms'})
 
@@ -348,7 +348,7 @@ test('longitude() will accept a max and obey it', t => {
 
 test('longitude() returns longitude in DD format as default', t => {
     _.times(1000, () => {
-        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
         
         let longitude = chance.longitude()
 
@@ -359,7 +359,7 @@ test('longitude() returns longitude in DD format as default', t => {
 
 test('longitude() will obey DD format', t => {
     _.times(1000, () => {
-        const CHARS_NOT_TO_CONTAIN = ['N', 'W', '°', '’', '”']
+        const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
         
         let longitude = chance.longitude({format: 'dd'})
 
@@ -370,7 +370,7 @@ test('longitude() will obey DD format', t => {
 
 test('longitude() will obey DDM format', t => {
     _.times(1000, () => {
-        const CHARS_TO_CONTAIN = ['W', '°']
+        const CHARS_TO_CONTAIN = ['°']
         const CHARS_NOT_TO_CONTAIN = ['’', '”']
         
         let longitude = chance.longitude({format: 'ddm'})
@@ -383,7 +383,7 @@ test('longitude() will obey DDM format', t => {
 
 test('longitude() will obey DMS format', t => {
     _.times(1000, () => {
-        const CHARS_TO_CONTAIN = ['W', '°', '’', '”']
+        const CHARS_TO_CONTAIN = ['°', '’', '”']
         
         let longitude = chance.longitude({format: 'dms'})
 


### PR DESCRIPTION
Up to now chancejs supports only one type of coordinates format, which is **Decimal Degrees (DD)**.
In reality there are more popular types of formats:
> **Degrees, Decimal Minutes (DDM)**:
> 47°38.938
> 122°20.887

> **Degrees, Minutes, Decimal Seconds (DMS)**:
> 47°38’56.26”
> 122°20’53.20”

> **Decimal Degrees (DD)**:
> 47.64896
> -122.34811

This PR adds the support of those two additional formats.
So we can write:
`chance.latitude({format: 'ddm'}) / chance.latitude({format: 'ddm'})`
`chance.latitude({format: 'dms'}) / chance.longitude({format: 'dms'})`
`chance.latitude({format: 'dd'}) / chance.longitude({format: 'dd'})`

When **format** is not specified, it will be default to **DD format**, so it won't cause any retroactive damage.

Examples:
`chance.latitude({format: 'ddm'})
--> 76°30.6021
`
`chance.longitude({format: 'dms'})
--> 42°16’7.9445”
`
`chance.latitude({format: 'dd'})
--> 37.53812
`
`chance.longitude() // defaults to dd
--> -100.493
`
`chance.coordinates({format: 'ddm'})
--> 66°13.8172, 66°25.914
`

_**IMPORTANT!**_
After a deep research, direction symbols 'N' / 'S' / 'W' / 'E' are not a part of the coordinate itself.
It doesn't changes the coordinate's value, so I removed it from the PR.

Thanks :)
@victorquinn 

[Coordinate Formats](http://www.avenza.com/help/geographic-imager/5.0/coordinate_formats.htm)
[Coordinate formats](https://www.geocaching.com/help/index.php?pg=kb.chapter&id=128&pgid=811)
[Coordinate Converter](https://www.pgc.umn.edu/apps/convert/)