### PR TITLE
Added falsy generator

### DIFF
--- a/packages/chance/package.json
+++ b/packages/chance/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@chancejs/bool": "^2.2.5",
     "@chancejs/integer": "^2.2.5",
+    "@chancejs/falsy": "^2.2.5",
     "@types/node": "^12.0.3"
   }
 }

--- a/packages/chance/src/main.test.ts
+++ b/packages/chance/src/main.test.ts
@@ -1,4 +1,4 @@
-import { bool, integer } from './main'
+import { bool, integer, falsy } from './main'
 import test from 'ava'
 
 test('bool() returns a random boolean', (t) => {
@@ -7,4 +7,8 @@ test('bool() returns a random boolean', (t) => {
 
 test('integer() exists and returns a number', (t) => {
   t.is(typeof integer(), 'number')
+})
+
+test('falsy() exists and returns a falsy value', (t) => {
+  t.falsy(falsy())
 })

--- a/packages/chance/src/main.ts
+++ b/packages/chance/src/main.ts
@@ -1,7 +1,9 @@
 import { bool } from '@chancejs/bool'
 import { integer } from '@chancejs/integer'
+import { falsy } from '@chancejs/falsy'
 
 export {
   bool,
   integer,
+  falsy,
 }

--- a/packages/falsy/README.md
+++ b/packages/falsy/README.md
@@ -1,0 +1,5 @@
+# Falsy
+
+This is the `falsy` generator, to select from a set of falsy values (`[false, null, undefined, 0, NaN, '']`)
+
+Note: This is a WIP proof of concept. DO NOT USE YET. I will remove this once it's ready for prime time :)

--- a/packages/falsy/package.json
+++ b/packages/falsy/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@chancejs/falsy",
+  "version": "2.2.5",
+  "description": "ChanceJS random falsy generator",
+  "main": "lib/main.js",
+  "typings": "lib/main.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "coverage": "nyc npm test && nyc report --reporter=text-lcov --report-dir=./coverage > ./coverage/lcov.info",
+    "test": "ava"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github.com/chancejs/chancejs"
+  },
+  "keywords": [
+    "chance",
+    "chancejs",
+    "random",
+    "falsy"
+  ],
+  "author": "Victor Quinn <mail@victorquinn.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "ava": "^1.4.1",
+    "onchange": "^6.0.0",
+    "nyc": "^10.3.2",
+    "typescript": "^3.5.3"
+  },
+  "ava": {
+    "files": [
+      "lib/**/*.test.js"
+    ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@chancejs/core": "^2.2.5",
+    "@chancejs/integer": "^2.2.5",
+    "@types/node": "^12.0.3"
+  }
+}

--- a/packages/falsy/src/main.test.ts
+++ b/packages/falsy/src/main.test.ts
@@ -1,0 +1,15 @@
+import { falsy } from './main'
+import test from 'ava'
+
+test('falsy() should return a falsy value', (t) => {
+    for (let i=0; i < 1000; i++) {
+        t.falsy(falsy())
+    }
+})
+
+test('falsy() should return a falsy value using a pool data', (t) => {
+    const pool = [null, undefined];
+    for (let i=0; i < 1000; i++) {
+        t.falsy(falsy({pool}));
+    }
+})

--- a/packages/falsy/src/main.ts
+++ b/packages/falsy/src/main.ts
@@ -1,0 +1,27 @@
+import { Core } from '@chancejs/core'
+import { integer } from '@chancejs/integer';
+
+/**
+ * Type of default pool. `0 | NaN` collapses to just `number`, but other literals persist.
+ */
+type FalsyValue = false | null | undefined | number | '';
+
+export interface IFalsyOptions {
+    pool: FalsyValue[];
+}
+
+const chance = new Core()
+
+/**
+ *  Return a random falsy value (false, null, undefined, 0, NaN, '').
+ *
+ *  @param {Object} [options={ pool: (false | null | undefined | number | '')[] }] alter the pool
+ *      of possible values.
+ *  @returns {FalsyValue} One of [false, null, undefined, 0, NaN, ''], or of the pool provided.
+ */
+export function falsy(options?: IFalsyOptions): FalsyValue {
+    const {pool} = {...options, pool: [false, null, undefined, 0, NaN, ''] as const};
+    const value = pool[integer(0, pool.length - 1)];
+
+    return value;
+}

--- a/packages/falsy/src/main.ts
+++ b/packages/falsy/src/main.ts
@@ -1,4 +1,3 @@
-import { Core } from '@chancejs/core'
 import { integer } from '@chancejs/integer';
 
 /**
@@ -9,8 +8,6 @@ type FalsyValue = false | null | undefined | number | '';
 export interface IFalsyOptions {
     pool: FalsyValue[];
 }
-
-const chance = new Core()
 
 /**
  *  Return a random falsy value (false, null, undefined, 0, NaN, '').

--- a/packages/falsy/tsconfig.json
+++ b/packages/falsy/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.settings.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "references": [
+    { "path": "../mersenne-twister" }
+  ]
+}

--- a/packages/falsy/tslint.yaml
+++ b/packages/falsy/tslint.yaml
@@ -1,0 +1,21 @@
+---
+extends:
+  - tslint:recommended
+  - tslint-config-prettier
+  - tslint-immutable
+linterOptions:
+  exclude:
+    - node_modules/**/*.ts
+    - packages/**/node_modules/**/*
+    - packages/**/lib/**
+rules:
+  trailing-comma: true
+  semicolon:
+    - true
+    - never
+  no-console: true
+  variable-name:
+    - true
+    - check-format
+    - allow-snake-case
+


### PR DESCRIPTION
I figured this would be a good small start to test the waters. I essentially copied your bool package and modified it to be equivalent to your falsy code from your 1.X `chance.js` file. I left your package.json w/ author and license and all in place, only modifying tags and dependencies. Comments were sourced from your docs and I filled in the blanks where needed. **There is one breaking change**: Your default pool in 1.X didn't actually include `undefined`. I added it to match the docs. Anything missing? Is there anywhere you wanted contributors to sign off?