### PR TITLE
Add MAC address function

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -312,8 +312,8 @@
 
             let random = options.min + this.natural({max: options.max - options.min - options.exclude.length})
             var sortedExclusions = options.exclude.sort();
-            for (var exclusionIndex in sortedExclusions) {
-                if (random < sortedExclusions[exclusionIndex]) {
+            for (var sortedExclusionIndex in sortedExclusions) {
+                if (random < sortedExclusions[sortedExclusionIndex]) {
                     break
                 }
                 random++
@@ -1720,13 +1720,15 @@
         // Constants - Formats
         const [DDM, DMS, DD] = ['ddm', 'dms', 'dd'];
 
-        options = initOptions(options, 
+        options = initOptions(
+options,
             options && options.format && [DDM, DMS].includes(options.format.toLowerCase()) ?
             {min: 0, max: 89, fixed: 4} :
-            {fixed: 5, min: -90, max: 90, format: DD});
+            {fixed: 5, min: -90, max: 90, format: DD}
+);
 
         const format = options.format.toLowerCase();
-        
+
         if (format === DDM || format === DMS) {
             testRange(options.min < 0 || options.min > 89, "Chance: Min specified is out of range. Should be between 0 - 89");
             testRange(options.max < 0 || options.max > 89, "Chance: Max specified is out of range. Should be between 0 - 89");
@@ -1735,16 +1737,16 @@
 
         switch (format) {
             case DDM: {
-                return  this.integer({min: options.min, max: options.max}) + '°' + 
+                return  this.integer({min: options.min, max: options.max}) + '°' +
                         this.floating({min: 0, max: 59, fixed: options.fixed});
             }
             case DMS: {
-                return  this.integer({min: options.min, max: options.max}) + '°' + 
-                        this.integer({min: 0, max: 59}) + '’' + 
+                return  this.integer({min: options.min, max: options.max}) + '°' +
+                        this.integer({min: 0, max: 59}) + '’' +
                         this.floating({min: 0, max: 59, fixed: options.fixed}) + '”';
             }
             case DD:
-            default: {    
+            default: {
                 return this.floating({min: options.min, max: options.max, fixed: options.fixed});
             }
         }
@@ -1754,10 +1756,12 @@
         // Constants - Formats
         const [DDM, DMS, DD] = ['ddm', 'dms', 'dd'];
 
-        options = initOptions(options, 
+        options = initOptions(
+options,
             options && options.format && [DDM, DMS].includes(options.format.toLowerCase()) ?
             {min: 0, max: 179, fixed: 4} :
-            {fixed: 5, min: -180, max: 180, format: DD});
+            {fixed: 5, min: -180, max: 180, format: DD}
+);
 
         const format = options.format.toLowerCase();
 
@@ -1769,7 +1773,7 @@
 
         switch (format) {
             case DDM: {
-                return  this.integer({min: options.min, max: options.max}) + '°' + 
+                return  this.integer({min: options.min, max: options.max}) + '°' +
                         this.floating({min: 0, max: 59.9999, fixed: options.fixed})
             }
             case DMS: {
@@ -1778,7 +1782,7 @@
                         this.floating({min: 0, max: 59.9999, fixed: options.fixed}) + '”';
             }
             case DD:
-            default: {    
+            default: {
                 return this.floating({min: options.min, max: options.max, fixed: options.fixed});
             }
         }

--- a/chance.js
+++ b/chance.js
@@ -1571,6 +1571,20 @@
         return this.natural({min: 1, max: 99});
     };
 
+    Chance.prototype.mac = function (options) {
+        // Todo: This could also be extended to EUI-64 based MACs
+        // (https://www.iana.org/assignments/ethernet-numbers/ethernet-numbers.xhtml#ethernet-numbers-4)
+        // Todo: This can return some reserved MACs (similar to IP function)
+        // this should probably be updated to account for that rare as it may be
+        options = initOptions(options, { delimiter: ':' });
+        return this.pad(this.natural({max: 255}).toString(16),2) + options.delimiter +
+               this.pad(this.natural({max: 255}).toString(16),2) + options.delimiter +
+               this.pad(this.natural({max: 255}).toString(16),2) + options.delimiter +
+               this.pad(this.natural({max: 255}).toString(16),2) + options.delimiter +
+               this.pad(this.natural({max: 255}).toString(16),2) + options.delimiter +
+               this.pad(this.natural({max: 255}).toString(16),2);
+    };
+
     Chance.prototype.semver = function (options) {
         options = initOptions(options, { include_prerelease: true });
 

--- a/docs/web/mac.md
+++ b/docs/web/mac.md
@@ -1,0 +1,22 @@
+# ip
+
+```js
+// usage
+chance.mac()
+chance.mac({delimiter: '-'})
+```
+
+Return a random MAC Address (EUI-48).
+
+```js
+chance.mac()
+=> '08:c2:88:ad:49:23'
+```
+
+Optionally specify a specific delimiter between octets.
+
+```js
+chance.domain({delimiter: '-'})
+=> '00-0d-b9-52-f2-f0'
+```
+

--- a/test/test.web.js
+++ b/test/test.web.js
@@ -397,6 +397,27 @@ test('locales() should return a list of locales', t => {
     t.true(locales.length > 100)
 })
 
+// chance.mac()
+test('mac() returns what looks like an MAC address (EUI-48)', t => {
+    _.times(1000, () => {
+        let mac = chance.mac()
+        t.true(_.isString(mac))
+        t.is(mac.split(':').length, 6)
+        t.true(/^[0-9a-f]{2}\:[0-9a-f]{2}\:[0-9a-f]{2}\:[0-9a-f]{2}\:[0-9a-f]{2}\:[0-9a-f]{2}$/.test(mac))
+    })
+})
+test('mac() uses delimiter option for MAC address', t => {
+_.times(1000, () => {
+        const delimiter = ([':','-','.'])[Math.floor(Math.random() * 3)]
+        let mac = chance.mac({ delimiter })
+        t.true(_.isString(mac))
+        t.is(mac.split(delimiter).length, 6)
+        t.true((
+            new RegExp(`^${Array(6).fill('[0-9a-f]{2}').join(`\\${delimiter}`)}$`)
+        ).test(mac))
+    })
+})
+
 // chance.md5()
 test('md5() should create a hex-encoded MD5 hash of a random ASCII value when passed nothing', t => {
     t.is(chance.md5().length, '2063c1608d6e0baf80249c42e2be5804'.length)


### PR DESCRIPTION
Adds the ability to randomly generated Network MAC addresses (6 octets) with the ability to specify the MAC address delimiter.

If there is enough demand we could also add the ability to specify an OUI or generate an EUI-64 address (8 octet based MAC for non-network devices).