### PR TITLE
Add "555" area code option

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1659,7 +1659,9 @@
     Chance.prototype.areacode = function (options) {
         options = initOptions(options, {parens : true});
         // Don't want area codes to start with 1, or have a 9 as the second digit
-        var areacode = this.natural({min: 2, max: 9}).toString() +
+        var areacode = options.exampleNumber ?
+        "555" :
+        this.natural({min: 2, max: 9}).toString() +
                 this.natural({min: 0, max: 8}).toString() +
                 this.natural({min: 0, max: 9}).toString();
 
@@ -1784,7 +1786,8 @@
         options = initOptions(options, {
             formatted: true,
             country: 'us',
-            mobile: false
+            mobile: false,
+            exampleNumber: false,
         });
         if (!options.formatted) {
             options.parens = false;

--- a/docs/location/phone.md
+++ b/docs/location/phone.md
@@ -39,3 +39,10 @@ For `uk` and `fr`, optionally specify a mobile phone.
 chance.phone({ country: 'uk', mobile: true });
 => '07624 321221'
 ```
+
+For `us`, optionally specify an exampleNumber for a '555' area code.
+
+```js
+chance.phone({ country: 'us', exampleNumber: true });
+=> '(555) 927-2152'
+```

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -417,6 +417,22 @@ test('phone() obeys formatted option and parens option', t => {
     })
 })
 
+test("phone() obeys exampleNumber option", (t) => {
+  _.times(1000, () => {
+    let phone = chance.phone({ exampleNumber: true });
+    t.true(_.isString(phone));
+    t.true(/^\(555\)?[\-. ]?([2-9][0-9]{2,2})[\-. ]?([0-9]{4,4})$/.test(phone));
+  });
+});
+
+test("phone() obeys formatted option and exampleNumber option", (t) => {
+  _.times(1000, () => {
+    let phone = chance.phone({ exampleNumber: true, formatted: false });
+    t.true(_.isString(phone));
+    t.true(/^555[2-9]\d{6,6}$/.test(phone));
+  });
+});
+
 test('phone() with uk option works', t => {
     t.true(_.isString(chance.phone({ country: 'uk' })))
 })


### PR DESCRIPTION
Option to specify an example number with an area code of '555' specifically for US.


chance.phone({ country: 'us', exampleNumber: true });
=> '(555) 927-2152'