### PR TITLE
Add unformatted CPF example to docs

### DIFF
--- a/docs/person/cpf.md
+++ b/docs/person/cpf.md
@@ -11,3 +11,10 @@ Generate a random Brazilian tax id.
 chance.cpf();
 => '607.116.899-62'
 ```
+
+Optionally omit punctuation:
+
+```js
+chance.cpf({ formatted: false });
+=> '18641718397'
+```


### PR DESCRIPTION
The `formatted` option exists in the implementation but is currently not mentioned anywhere in the docs.