### PR TITLE
🚨 fix import sort errors

### DIFF
--- a/packages/chance/src/main.test.ts
+++ b/packages/chance/src/main.test.ts
@@ -1,4 +1,4 @@
-import { bool, integer, falsy } from './main'
+import { bool, falsy, integer } from './main'
 import test from 'ava'
 
 test('bool() returns a random boolean', (t) => {

--- a/packages/chance/src/main.ts
+++ b/packages/chance/src/main.ts
@@ -1,6 +1,6 @@
 import { bool } from '@chancejs/bool'
-import { integer } from '@chancejs/integer'
 import { falsy } from '@chancejs/falsy'
+import { integer } from '@chancejs/integer'
 
 export {
   bool,


### PR DESCRIPTION
I went and checked out the `2.0` branch, but when running `yarn test` I ran into some import sort errors which prevented the rest of the build from completing. This PR fixes those errors so that the build step can complete properly.

@victorquinn would you consider adding some pre-commit hook to run `yarn test`? [Husky](https://github.com/typicode/husky/tree/master) is pretty easy add add in.

<img width="916" alt="image" src="https://user-images.githubusercontent.com/52963980/95455966-57690700-09ba-11eb-9b30-be412b2a13a8.png">
