### PR TITLE
♻️ refactored integer generator to accept object as param

### DIFF
--- a/packages/bool/src/main.ts
+++ b/packages/bool/src/main.ts
@@ -23,7 +23,7 @@ export function bool(options?: IBoolOptions): boolean {
     }
 
     if (likelihood < 0 || likelihood > 100) {
-	throw new RangeError('Chance: Likelihood accepts values from 0 to 100.')
+        throw new RangeError('Chance: Likelihood accepts values from 0 to 100.')
     }
 
     return chance.random() * 100 < likelihood

--- a/packages/falsy/src/main.test.ts
+++ b/packages/falsy/src/main.test.ts
@@ -2,14 +2,14 @@ import { falsy } from './main'
 import test from 'ava'
 
 test('falsy() should return a falsy value', (t) => {
-    for (let i=0; i < 1000; i++) {
+    for (let i = 0; i < 1000; i++) {
         t.falsy(falsy())
     }
 })
 
 test('falsy() should return a falsy value using a pool data', (t) => {
     const pool = [null, undefined];
-    for (let i=0; i < 1000; i++) {
-        t.falsy(falsy({pool}));
+    for (let i = 0; i < 1000; i++) {
+        t.falsy(falsy({ pool }));
     }
 })

--- a/packages/falsy/src/main.ts
+++ b/packages/falsy/src/main.ts
@@ -16,9 +16,10 @@ export interface IFalsyOptions {
  *      of possible values.
  *  @returns {FalsyValue} One of [false, null, undefined, 0, NaN, ''], or of the pool provided.
  */
-export function falsy(options?: IFalsyOptions): FalsyValue {
-    const {pool} = {...options, pool: [false, null, undefined, 0, NaN, ''] as const};
-    const value = pool[integer(0, pool.length - 1)];
+const defaultOptions: IFalsyOptions = { pool: [false, null, undefined, 0, NaN, ''] };
+export function falsy(options = defaultOptions): FalsyValue {
+    const { pool } = options;
+    const value = pool[integer({ min: 0, max: pool.length - 1 })];
 
     return value;
 }

--- a/packages/integer/src/main.test.ts
+++ b/packages/integer/src/main.test.ts
@@ -1,17 +1,23 @@
 import { integer } from './main'
 import test from 'ava'
 
-test('integer() returns a random boolean', (t) => {
-  t.is(typeof integer(), 'number')
+const NUM_TEST_SAMPLES = 1000;
+
+test('integer() returns a value with typeof number', (t) => {
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
+    t.is(typeof integer(), 'number')
+  }
 })
 
-test('integer() returns a random integer', (t) => {
-  t.is(typeof integer(), 'number')
+test('integer() returns a whole number', (t) => {
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
+    t.true(Number.isInteger(integer()))
+  }
 })
 
 test('integer() is sometimes negative, sometimes positive', (t) => {
   let positiveCount = 0
-  for (let i = 0; i < 1000; i++) {
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
     if (integer() > 0) {
       positiveCount++
     }
@@ -24,30 +30,48 @@ test('integer() is sometimes negative, sometimes positive', (t) => {
 })
 
 test('integer() can take a zero min and obey it', (t) => {
-  for (let i = 0; i < 1000; i++) {
-    t.true(integer(0) > 0)
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
+    t.true(integer({ min: 0 }) >= 0)
   }
 })
 
 test('integer() can take a negative min and obey it', (t) => {
-  for (let i = 0; i < 1000; i++) {
-    t.true(integer(-25) > -26)
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
+    t.true(integer({ min: -25 }) >= -25)
+  }
+})
+
+test('integer() can take a zero max and obey it', (t) => {
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
+    t.true(integer({ max: 0 }) <= 0)
+  }
+})
+
+test('integer() can take a positive max and obey it', (t) => {
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
+    t.true(integer({ max: 10 }) <= 10)
+  }
+})
+
+test('integer() can take a negative max and obey it', (t) => {
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
+    t.true(integer({ max: -9999 }) <= -9999)
   }
 })
 
 test('integer() can take a negative min and max and obey both', (t) => {
-  for (let i = 0; i < 1000; i++) {
-    const int = integer(-25, -1)
-    t.true((int > -26) && int < 0)
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
+    const int = integer({ min: -25, max: -1 })
+    t.true((int >= -25) && int <= -1)
   }
 })
 
 test('integer() can take a min with absolute value less than max and return in range above', (t) => {
   let count = 0
-  for (let i = 0; i < 1000; i++) {
+  for (let i = 0; i < NUM_TEST_SAMPLES; i++) {
     // With a range this large we'd expect most values to be
     // greater than 1 if this works correctly.
-    if (Math.abs(integer(-1, 1000000)) < 2) {
+    if (Math.abs(integer({ min: -1, max: 1000000 })) < 2) {
       count++
     }
   }
@@ -55,6 +79,6 @@ test('integer() can take a min with absolute value less than max and return in r
 })
 
 test('integer() throws an error when min > max', (t) => {
-  const fn = () => integer(1000, 500)
+  const fn = () => integer({ min: 1000, max: 500 })
   t.throws(fn, 'Chance: Min cannot be greater than Max.')
 })

--- a/packages/integer/src/main.ts
+++ b/packages/integer/src/main.ts
@@ -4,8 +4,13 @@ const core = new Core()
 
 // 9007199254740992 (2^53) is the max integer number in JavaScript
 // See: http://vq.io/132sa2j
-const MAX_INT = 9007199254740992
-const MIN_INT = -MAX_INT
+export const MAX_INT = 9007199254740992
+export const MIN_INT = -MAX_INT
+
+export interface IIntegerOptions {
+  min?: number
+  max?: number
+}
 
 /**
  *  Return a random integer
@@ -18,7 +23,8 @@ const MIN_INT = -MAX_INT
  *  @returns {Number} a single random integer number
  *  @throws {RangeError} min cannot be greater than max
  */
-export function integer(min = MIN_INT, max = MAX_INT): number {
+const defaultOptions: IIntegerOptions = { min: MIN_INT, max: MAX_INT }
+export function integer({ min = MIN_INT, max = MAX_INT } = defaultOptions): number {
   if (min > max) {
     throw new RangeError('Chance: Min cannot be greater than Max.')
   }


### PR DESCRIPTION
Looking at the 1.0 version of the `integer` generator, and the documentation comment for the generator, it should accept an options object as parameters, rather than 2 numbers as currently implemented in v2. i.e. it currently uses `integer(25, 100)`, but is documented to use `integer({ min: 25, max: 100 })`
This PR corrects the input shape to be an object.

```js
/**
 *  Return a random integer
 *
 *  NOTE the max and min are INCLUDED in the range. So:
 *  chance.integer({min: 1, max: 3});
 *  would return either 1, 2, or 3.
 *
 *  @param {Object} [options={}] can specify a min and/or max
 *  @returns {Number} a single random integer number
 *  @throws {RangeError} min cannot be greater than max
 *
```