### PR TITLE
Fixed error in docs for chance.first()

### DIFF
--- a/docs/person/first.md
+++ b/docs/person/first.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.first()
-chance.first({ nationality: 'us' })
+chance.first({ nationality: 'en' })
 ```
 
 Generate a random first name
@@ -27,5 +27,5 @@ Chance.first({ nationality: "it" });
 => 'Alberto'
 ```
 
-Note, currently support for nationality is limited to: `'us', 'it'`.
+Note, currently support for nationality is limited to: `'en', 'it', 'nl', 'fr'`.
 


### PR DESCRIPTION
The docs state that 'us' and 'it' are the only values that can be assigned to the nationality parameter for chance.first().

1) 'us' is NOT accepted and results in an error. 'en' works fine instead.
2) 'nl' and 'fr' have been added in the meantime.
Code reference: https://github.com/chancejs/chancejs/blob/b3658c9c2161fc8c500ceadd87741a53e4a235d6/chance.js#L2797

I ran into the issue that 'us' threw an error in my code, hence I tracked the issue back to the docs and fixed it.
There are some other pull requests adding new nationalities to chance.first() which have not been considered yet in this change.