### PR TITLE
issue#385: generate date not in MM/DD/YYYY format

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -2091,12 +2091,28 @@ options,
             date = new Date(options.year, options.month, options.day, options.hour, options.minute, options.second, options.millisecond);
         }
 
+        var newDay = '';
+        if (date.getDate() > 9) {
+            newDay = date.getDate();
+        }
+        else {
+            newDay = '0' + date.getDate();
+        }
+
+        var newMonth = '';
+        if (date.getMonth() > 8) {
+            newMonth = (date.getMonth() + 1);
+        }
+        else {
+            newMonth = '0' + (date.getDate() + 1);
+        }
+
         if (options.american) {
             // Adding 1 to the month is necessary because Date() 0-indexes
             // months but not day for some odd reason.
-            date_string = (date.getMonth() + 1) + '/' + date.getDate() + '/' + date.getFullYear();
+            date_string = newMonth + '/' + newDay + '/' + date.getFullYear();
         } else {
-            date_string = date.getDate() + '/' + (date.getMonth() + 1) + '/' + date.getFullYear();
+            date_string = newDay + '/' + newMonth + '/' + date.getFullYear();
         }
 
         return options.string ? date_string : date;

--- a/test/test.time.js
+++ b/test/test.time.js
@@ -198,7 +198,7 @@ test('month() will return a raw month', t => {
 
 test('month() returns a month, can specify min and max', t => {
     _.times(1000, () => {
-        let month = chance.month({raw: true, min: 5, max: 10})
+        let month = chance.month({ raw: true, min: 5, max: 10 })
         t.false(_.isString(month))
         t.true(month.numeric >= 5)
         t.true(month.numeric <= 10)
@@ -207,7 +207,7 @@ test('month() returns a month, can specify min and max', t => {
 
 test('month() returns a month, can specify just min', t => {
     _.times(1000, () => {
-        let month = chance.month({raw: true, min: 5})
+        let month = chance.month({ raw: true, min: 5 })
         t.false(_.isString(month))
         t.true(month.numeric >= 5)
         t.true(month.numeric <= 12)
@@ -216,7 +216,7 @@ test('month() returns a month, can specify just min', t => {
 
 test('month() returns a month, can specify just max', t => {
     _.times(1000, () => {
-        let month = chance.month({raw: true, max: 7})
+        let month = chance.month({ raw: true, max: 7 })
         t.false(_.isString(month))
         t.true(month.numeric >= 1)
         t.true(month.numeric <= 7)


### PR DESCRIPTION
In date, numbers less than 10 would be shown like '09', '08', etc.