### PR TITLE
 Make generated seed available to user if hasn't provided

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -74,6 +74,11 @@
 
     Chance.prototype.VERSION = "1.1.7";
 
+    function generateSeed() {
+        // kept random number same size as time used previously to ensure no unexpected results downstream
+        return Math.floor(Math.random() * Math.pow(10, 13));
+    }
+
     // Random helper functions
     function initOptions(options, defaults) {
         options = options || {};
@@ -7497,8 +7502,7 @@ options,
      */
     var MersenneTwister = function (seed) {
         if (seed === undefined) {
-            // kept random number same size as time used previously to ensure no unexpected results downstream
-            seed = Math.floor(Math.random()*Math.pow(10,13));
+            seed = generateSeed();
         }
         /* Period parameters */
         this.N = 624;

--- a/chance.js
+++ b/chance.js
@@ -28,8 +28,12 @@
     // Constructor
     function Chance (seed) {
         if (!(this instanceof Chance)) {
-            if (!seed) { seed = null; } // handle other non-truthy seeds, as described in issue #322
-            return seed === null ? new Chance() : new Chance(seed);
+            return new Chance(seed);
+        }
+
+        if (!seed) { // handle other non-truthy seeds, as described in issue #322
+            seed = generateSeed();
+            return new Chance(seed)
         }
 
         // if user has provided a function, use that as the generator

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -86,6 +86,11 @@ test('Chance() does not return repeatable results if no seed provided', async t 
     })
 })
 
+test('Chance() return generated seed if no seed provided', async t => {
+    let chance = new Chance()
+    t.not(chance.seed, undefined)
+})
+
 test('Chance() returns repeatable results if seed provided on the Chance object', t => {
     let seed = new Date().getTime()
     let chance1 = new Chance(seed)


### PR DESCRIPTION
This is useful in such case, for example:
I can print chance seed if some test failed and easily rerun tests with that seed