### PR TITLE
Added international code option for phone()

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1806,13 +1806,16 @@ options,
             country: 'us',
             mobile: false,
             exampleNumber: false,
+            intlCode: false,
         });
         if (!options.formatted) {
             options.parens = false;
         }
         var phone;
+        var intlCode;
         switch (options.country) {
             case 'fr':
+                intlCode = '+33';
                 if (!options.mobile) {
                     numPick = this.pick([
                         // Valid zone and département codes.
@@ -1830,6 +1833,7 @@ options,
                 }
                 break;
             case 'uk':
+                intlCode = '+44';
                 if (!options.mobile) {
                     numPick = this.pick([
                         //valid area codes of major cities/counties followed by random numbers in required format.
@@ -1858,6 +1862,7 @@ options,
                 }
                 break;
             case 'za':
+                intlCode = '+27';
                 if (!options.mobile) {
                     numPick = this.pick([
                        '01' + this.pick(['0', '1', '2', '3', '4', '5', '6', '7', '8']) + self.string({ pool: '0123456789', length: 7}),
@@ -1880,6 +1885,7 @@ options,
                 }
                 break;
             case 'us':
+                intlCode = '+1';
                 var areacode = this.areacode(options).toString();
                 var exchange = this.natural({ min: 2, max: 9 }).toString() +
                     this.natural({ min: 0, max: 9 }).toString() +
@@ -1888,6 +1894,7 @@ options,
                 phone = options.formatted ? areacode + ' ' + exchange + '-' + subscriber : areacode + exchange + subscriber;
                 break;
             case 'br':
+                intlCode = '+55';
                 var areaCode = this.pick(["11", "12", "13", "14", "15", "16", "17", "18", "19", "21", "22", "24", "27", "28", "31", "32", "33", "34", "35", "37", "38", "41", "42", "43", "44", "45", "46", "47", "48", "49", "51", "53", "54", "55", "61", "62", "63", "64", "65", "66", "67", "68", "69", "71", "73", "74", "75", "77", "79", "81", "82", "83", "84", "85", "86", "87", "88", "89", "91", "92", "93", "94", "95", "96", "97", "98", "99"]);
                 var prefix;
                 if (options.mobile) {
@@ -1901,6 +1908,12 @@ options,
                 phone = options.formatted ? '(' + areaCode + ') ' + prefix + '-' + mcdu : areaCode + prefix + mcdu;
                 break;
         }
+
+        // Prepend the phone number with the international code, if required
+        if (options.intlCode) {
+            phone = [intlCode, phone].join(options.formatted ? ' ' : '');
+        }
+        
         return phone;
     };
 

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -553,6 +553,24 @@ test('phone() with br country, formatted and mobile option apply the correct mas
     })))
 })
 
+test('phone() returns a random phone with unformatted international code', t => {
+    const regex = new RegExp(/^\+44\d/);
+    _.times(1000, () => {
+        const phone = chance.phone({ country: 'uk', intlCode: true, formatted: false })
+        t.true(_.isString(phone))
+        t.true(regex.test(phone));
+    })
+})
+
+test('phone() returns a random phone with formatted international code', t => {
+    const regex = new RegExp(/^\+33 /);
+    _.times(1000, () => {
+        const phone = chance.phone({ country: 'fr', intlCode: true })
+        t.true(_.isString(phone))
+        t.true(regex.test(phone));
+    })
+})
+
 // chance.postal()
 test('postal() returns a valid basic postal code', t => {
     _.times(1000, () => {


### PR DESCRIPTION
* Added `intlCode` (`boolean`) option to `phone()` function, so that phone numbers can be prepended with `+44`, etc.
If `formatted = true`, then a space is added after the international code.
* Added the relevant international codes to the existing `country` options.
* Added relevant tests.