### PR TITLE
Improve consistency of formatting

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -11,7 +11,7 @@
     var NUMBERS = '0123456789';
     var CHARS_LOWER = 'abcdefghijklmnopqrstuvwxyz';
     var CHARS_UPPER = CHARS_LOWER.toUpperCase();
-    var HEX_POOL  = NUMBERS + "abcdef";
+    var HEX_POOL = NUMBERS + "abcdef";
 
     // Errors
     function UnsupportedError(message) {
@@ -26,7 +26,7 @@
     var slice = Array.prototype.slice;
 
     // Constructor
-    function Chance (seed) {
+    function Chance(seed) {
         if (!(this instanceof Chance)) {
             if (!seed) { seed = null; } // handle other non-truthy seeds, as described in issue #322
             return seed === null ? new Chance() : new Chance(seed);
@@ -102,7 +102,7 @@
     /**
      * Encode the input string with Base64.
      */
-    var base64 = function() {
+    var base64 = function () {
         throw new Error('No Base64 encoder available.');
     };
 
@@ -111,7 +111,7 @@
         if (typeof btoa === 'function') {
             base64 = btoa;
         } else if (typeof Buffer === 'function') {
-            base64 = function(input) {
+            base64 = function (input) {
                 return new Buffer(input).toString('base64');
             };
         }
@@ -155,24 +155,6 @@
 
         return value;
     }
-
-    Chance.prototype.animal = function (options){
-      //returns a random animal
-      options = initOptions(options);
-
-      if(typeof options.type !== 'undefined'){
-        //if user does not put in a valid animal type, user will get an error
-        testRange(
-           !this.get("animals")[options.type.toLowerCase()],
-           "Please pick from desert, ocean, grassland, forest, zoo, pets, farm."
-         );
-         //if user does put in valid animal type, will return a random animal of that type
-          return this.pick(this.get("animals")[options.type.toLowerCase()]);
-      }
-       //if user does not put in any animal type, will return a random animal regardless
-      var animalTypeArray = ["desert","forest","ocean","zoo","farm","pet","grassland"];
-      return this.pick(this.get("animals")[this.pick(animalTypeArray)]);
-    };
 
     /**
      *  Return a random character.
@@ -219,7 +201,7 @@
     // Note, wanted to use "float" or "double" but those are both JS reserved words.
 
     // Note, fixed means N OR LESS digits after the decimal. This because
-    // It could be 14.9000 but in JavaScript, when this is cast as a number,
+    // it could be 14.9000 but in JavaScript, when this is cast as a number,
     // the trailing zeroes are dropped. Left to the consumer if trailing zeroes are
     // needed
     /**
@@ -245,11 +227,11 @@
 
         testRange(
             options.min && options.fixed && options.min < min,
-            "Chance: Min specified is out of range with fixed. Min should be, at least, " + min
+            "Chance: Min is out of range with fixed. Min should be, at least, " + min
         );
         testRange(
             options.max && options.fixed && options.max > max,
-            "Chance: Max specified is out of range with fixed. Max should be, at most, " + max
+            "Chance: Max is out of range with fixed. Max should be, at most, " + max
         );
 
         options = initOptions(options, { min : min, max : max });
@@ -296,10 +278,10 @@
      */
     Chance.prototype.natural = function (options) {
         options = initOptions(options, {min: 0, max: MAX_INT});
-        if (typeof options.numerals === 'number'){
-          testRange(options.numerals < 1, "Chance: Numerals cannot be less than one.");
-          options.min = Math.pow(10, options.numerals - 1);
-          options.max = Math.pow(10, options.numerals) - 1;
+        if (typeof options.numerals === 'number') {
+            testRange(options.numerals < 1, "Chance: Numerals cannot be less than one.");
+            options.min = Math.pow(10, options.numerals - 1);
+            options.max = Math.pow(10, options.numerals) - 1;
         }
         testRange(options.min < 0, "Chance: Min cannot be less than zero.");
 
@@ -387,14 +369,14 @@
     Chance.prototype.hex = function (options) {
         options = initOptions(options, {min: 0, max: MAX_INT, casing: 'lower'});
         testRange(options.min < 0, "Chance: Min cannot be less than zero.");
-		var integer = this.natural({min: options.min, max: options.max});
-		if (options.casing === 'upper') {
-			return integer.toString(16).toUpperCase();
-		}
-		return integer.toString(16);
+        var integer = this.natural({min: options.min, max: options.max});
+        if (options.casing === 'upper') {
+            return integer.toString(16).toUpperCase();
+        }
+        return integer.toString(16);
     };
 
-    Chance.prototype.letter = function(options) {
+    Chance.prototype.letter = function (options) {
         options = initOptions(options, {casing: 'lower'});
         var pool = "abcdefghijklmnopqrstuvwxyz";
         var letter = this.character({pool: pool});
@@ -412,10 +394,10 @@
      *  @throws {RangeError} length cannot be less than zero
      */
     Chance.prototype.string = function (options) {
-        options = initOptions(options, { min: 5, max: 20 });
+        options = initOptions(options, {min: 5, max: 20});
 
         if (!options.length) {
-            options.length = this.natural({ min: options.min, max: options.max })
+            options.length = this.natural({min: options.min, max: options.max})
         }
 
         testRange(options.length < 0, "Chance: Length cannot be less than zero.");
@@ -471,7 +453,7 @@
     function parseTemplate(template) {
         var tokens = []
         var mode = 'identity'
-        for (var i = 0; i<template.length; i++) {
+        for (var i = 0; i < template.length; i++) {
             var c = template[i]
             switch (mode) {
                 case 'escape':
@@ -543,7 +525,7 @@
         if (typeof Buffer === 'undefined') {
             throw new UnsupportedError('Sorry, the buffer() function is not supported on your platform');
         }
-        options = initOptions(options, { length: this.natural({min: 5, max: 20}) });
+        options = initOptions(options, {length: this.natural({min: 5, max: 20})});
         testRange(options.length < 0, "Chance: Length cannot be less than zero.");
         var length = options.length;
         var content = this.n(this.character, length, options);
@@ -577,13 +559,13 @@
      *
      *  There can be more parameters after these. All additional parameters are provided to the given function
      */
-    Chance.prototype.unique = function(fn, num, options) {
+    Chance.prototype.unique = function (fn, num, options) {
         testRange(
             typeof fn !== "function",
             "Chance: The first argument must be a function."
         );
 
-        var comparator = function(arr, val) { return arr.indexOf(val) !== -1; };
+        var comparator = function (arr, val) { return arr.indexOf(val) !== -1; };
 
         if (options) {
             comparator = options.comparator || comparator;
@@ -616,7 +598,7 @@
      *
      *  There can be more parameters after these. All additional parameters are provided to the given function
      */
-    Chance.prototype.n = function(fn, n) {
+    Chance.prototype.n = function (fn, n) {
         testRange(
             typeof fn !== "function",
             "Chance: The first argument must be a function."
@@ -759,7 +741,7 @@
             }
 
             // handle any possible rounding error comparison to ensure something is picked
-            if (weightIndex === (weights.length - 1)) {
+            if (weightIndex === weights.length - 1) {
                 chosenIdx = lastGoodIdx;
             }
         }
@@ -941,19 +923,19 @@
             formatted: true
         });
 
-        var n = this.n(this.natural, 9, { max: 9 });
+        var n = this.n(this.natural, 9, {max: 9});
         var d1 = n[8]*2+n[7]*3+n[6]*4+n[5]*5+n[4]*6+n[3]*7+n[2]*8+n[1]*9+n[0]*10;
         d1 = 11 - (d1 % 11);
-        if (d1>=10) {
+        if (d1 >= 10) {
             d1 = 0;
         }
         var d2 = d1*2+n[8]*3+n[7]*4+n[6]*5+n[5]*6+n[4]*7+n[3]*8+n[2]*9+n[1]*10+n[0]*11;
         d2 = 11 - (d2 % 11);
-        if (d2>=10) {
+        if (d2 >= 10) {
             d2 = 0;
         }
         var cpf = ''+n[0]+n[1]+n[2]+'.'+n[3]+n[4]+n[5]+'.'+n[6]+n[7]+n[8]+'-'+d1+d2;
-        return options.formatted ? cpf : cpf.replace(/\D/g,'');
+        return options.formatted ? cpf : cpf.replace(/\D/g, '');
     };
 
     // CNPJ: ID to identify companies in Brazil
@@ -965,16 +947,16 @@
         var n = this.n(this.natural, 12, { max: 12 });
         var d1 = n[11]*2+n[10]*3+n[9]*4+n[8]*5+n[7]*6+n[6]*7+n[5]*8+n[4]*9+n[3]*2+n[2]*3+n[1]*4+n[0]*5;
         d1 = 11 - (d1 % 11);
-        if (d1<2) {
+        if (d1 < 2) {
             d1 = 0;
         }
         var d2 = d1*2+n[11]*3+n[10]*4+n[9]*5+n[8]*6+n[7]*7+n[6]*8+n[5]*9+n[4]*2+n[3]*3+n[2]*4+n[1]*5+n[0]*6;
         d2 = 11 - (d2 % 11);
-        if (d2<2) {
+        if (d2 < 2) {
             d2 = 0;
         }
         var cnpj = ''+n[0]+n[1]+'.'+n[2]+n[3]+n[4]+'.'+n[5]+n[6]+n[7]+'/'+n[8]+n[9]+n[10]+n[11]+'-'+d1+d2;
-        return options.formatted ? cnpj : cnpj.replace(/\D/g,'');
+        return options.formatted ? cnpj : cnpj.replace(/\D/g, '');
     };
 
     Chance.prototype.first = function (options) {
@@ -984,9 +966,9 @@
 
     Chance.prototype.profession = function (options) {
         options = initOptions(options);
-        if(options.rank){
+        if (options.rank){
             return this.pick(['Apprentice ', 'Junior ', 'Senior ', 'Lead ']) + this.pick(this.get("profession"));
-        } else{
+        } else {
             return this.pick(this.get("profession"));
         }
     };
@@ -1001,48 +983,46 @@
     };
 
     Chance.prototype.last = function (options) {
-      options = initOptions(options, {nationality: '*'});
-      if (options.nationality === "*") {
-        var allLastNames = []
-        var lastNames = this.get("lastNames")
-        Object.keys(lastNames).forEach(function(key){
-          allLastNames = allLastNames.concat(lastNames[key])
-        })
-        return this.pick(allLastNames)
-      }
-      else {
-        return this.pick(this.get("lastNames")[options.nationality.toLowerCase()]);
-      }
-
+        options = initOptions(options, {nationality: '*'});
+        if (options.nationality === "*") {
+            var allLastNames = []
+            var lastNames = this.get("lastNames")
+            Object.keys(lastNames).forEach(function (key){
+                allLastNames = allLastNames.concat(lastNames[key])
+            })
+            return this.pick(allLastNames)
+        } else {
+            return this.pick(this.get("lastNames")[options.nationality.toLowerCase()]);
+        }
     };
 
-    Chance.prototype.israelId=function(){
-        var x=this.string({pool: '0123456789',length:8});
-        var y=0;
-        for (var i=0;i<x.length;i++){
-            var thisDigit=  x[i] *  (i/2===parseInt(i/2) ? 1 : 2);
-            thisDigit=this.pad(thisDigit,2).toString();
-            thisDigit=parseInt(thisDigit[0]) + parseInt(thisDigit[1]);
-            y=y+thisDigit;
+    Chance.prototype.israelId = function () {
+        var x = this.string({pool: '0123456789', length: 8});
+        var y = 0;
+        for (var i = 0; i < x.length; i++) {
+            var thisDigit = x[i] * (i / 2 === parseInt(i / 2) ? 1 : 2);
+            thisDigit = this.pad(thisDigit, 2).toString();
+            thisDigit = parseInt(thisDigit[0]) + parseInt(thisDigit[1]);
+            y += thisDigit;
         }
-        x=x+(10-parseInt(y.toString().slice(-1))).toString().slice(-1);
+        x += (10 - parseInt(y.toString().slice(-1))).toString().slice(-1);
         return x;
     };
 
     Chance.prototype.mrz = function (options) {
         var checkDigit = function (input) {
             var alpha = "<ABCDEFGHIJKLMNOPQRSTUVWXYXZ".split(''),
-                multipliers = [ 7, 3, 1 ],
+                multipliers = [7, 3, 1],
                 runningTotal = 0;
 
             if (typeof input !== 'string') {
                 input = input.toString();
             }
 
-            input.split('').forEach(function(character, idx) {
+            input.split('').forEach(function (character, idx) {
                 var pos = alpha.indexOf(character);
 
-                if(pos !== -1) {
+                if (pos !== -1) {
                     character = pos === 0 ? 0 : pos + 9;
                 } else {
                     character = parseInt(character, 10);
@@ -1056,22 +1036,24 @@
             var pad = function (length) {
                 return new Array(length + 1).join('<');
             };
-            var number = [ 'P<',
-                           opts.issuer,
-                           opts.last.toUpperCase(),
-                           '<<',
-                           opts.first.toUpperCase(),
-                           pad(39 - (opts.last.length + opts.first.length + 2)),
-                           opts.passportNumber,
-                           checkDigit(opts.passportNumber),
-                           opts.nationality,
-                           opts.dob,
-                           checkDigit(opts.dob),
-                           opts.gender,
-                           opts.expiry,
-                           checkDigit(opts.expiry),
-                           pad(14),
-                           checkDigit(pad(14)) ].join('');
+            var number = [
+                'P<',
+                opts.issuer,
+                opts.last.toUpperCase(),
+                '<<',
+                opts.first.toUpperCase(),
+                pad(39 - (opts.last.length + opts.first.length + 2)),
+                opts.passportNumber,
+                checkDigit(opts.passportNumber),
+                opts.nationality,
+                opts.dob,
+                checkDigit(opts.dob),
+                opts.gender,
+                opts.expiry,
+                checkDigit(opts.expiry),
+                pad(14),
+                checkDigit(pad(14))
+            ].join('');
 
             return number +
                 (checkDigit(number.substr(44, 10) +
@@ -1163,14 +1145,15 @@
             this.pick(this.name_prefixes(options.gender)).name :
             this.pick(this.name_prefixes(options.gender)).abbreviation;
     };
-    //Hungarian ID number
-    Chance.prototype.HIDN= function(){
-     //Hungarian ID nuber structure: XXXXXXYY (X=number,Y=Capital Latin letter)
-      var idn_pool="0123456789";
-      var idn_chrs="ABCDEFGHIJKLMNOPQRSTUVWXYXZ";
-      var idn="";
-        idn+=this.string({pool:idn_pool,length:6});
-        idn+=this.string({pool:idn_chrs,length:2});
+
+    // Hungarian ID number
+    Chance.prototype.HIDN = function () {
+        // Hungarian ID nuber structure: XXXXXXYY (X=number,Y=Capital Latin letter)
+        var idn_pool = "0123456789";
+        var idn_chrs = "ABCDEFGHIJKLMNOPQRSTUVWXYXZ";
+        var idn = "";
+        idn += this.string({pool: idn_pool, length: 6});
+        idn += this.string({pool: idn_chrs, length: 2});
         return idn;
     };
 
@@ -1181,7 +1164,7 @@
             ssn,
             dash = options.dashes ? '-' : '';
 
-        if(!options.ssnFour) {
+        if (!options.ssnFour) {
             ssn = this.string({pool: ssn_pool, length: 3}) + dash +
             this.string({pool: ssn_pool, length: 2}) + dash +
             this.string({pool: ssn_pool, length: 4});
@@ -1198,7 +1181,7 @@
             aadhar,
             whiteSpace = options.separatedByWhiteSpace ? ' ' : '';
 
-        if(!options.onlyLastFour) {
+        if (!options.onlyLastFour) {
             aadhar = this.string({pool: aadhar_pool, length: 4}) + whiteSpace +
             this.string({pool: aadhar_pool, length: 4}) + whiteSpace +
             this.string({pool: aadhar_pool, length: 4});
@@ -1255,34 +1238,36 @@
     // -- End Person --
 
     // -- Mobile --
+
     // Android GCM Registration ID
     Chance.prototype.android_id = function () {
-        return "APA91" + this.string({ pool: "0123456789abcefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_", length: 178 });
+        return "APA91" + this.string({pool: "0123456789abcefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_", length: 178});
     };
 
     // Apple Push Token
     Chance.prototype.apple_token = function () {
-        return this.string({ pool: "abcdef1234567890", length: 64 });
+        return this.string({pool: "abcdef1234567890", length: 64});
     };
 
     // Windows Phone 8 ANID2
     Chance.prototype.wp8_anid2 = function () {
-        return base64( this.hash( { length : 32 } ) );
+        return base64(this.hash({length: 32}));
     };
 
     // Windows Phone 7 ANID
     Chance.prototype.wp7_anid = function () {
-        return 'A=' + this.guid().replace(/-/g, '').toUpperCase() + '&E=' + this.hash({ length:3 }) + '&W=' + this.integer({ min:0, max:9 });
+        return 'A=' + this.guid().replace(/-/g, '').toUpperCase() + '&E=' + this.hash({length: 3}) + '&W=' + this.integer({min: 0, max: 9});
     };
 
     // BlackBerry Device PIN
     Chance.prototype.bb_pin = function () {
-        return this.hash({ length: 8 });
+        return this.hash({length: 8});
     };
 
     // -- End Mobile --
 
     // -- Web --
+
     Chance.prototype.avatar = function (options) {
         var url = null;
         var URL_BASE = '//www.gravatar.com/avatar/';
@@ -1324,15 +1309,12 @@
             // Set to a random email
             opts.email = this.email();
             options = {};
-        }
-        else if (typeof options === 'string') {
+        } else if (typeof options === 'string') {
             opts.email = options;
             options = {};
-        }
-        else if (typeof options !== 'object') {
+        } else if (typeof options !== 'object') {
             return null;
-        }
-        else if (options.constructor === 'Array') {
+        } else if (options.constructor === 'Array') {
             return null;
         }
 
@@ -1410,7 +1392,7 @@
 
         function rgb(hasAlpha) {
             var rgbValue     = (hasAlpha)    ? 'rgba' : 'rgb';
-            var alphaChannel = (hasAlpha)    ? (',' + this.floating({min:min_alpha, max:max_alpha})) : "";
+            var alphaChannel = (hasAlpha)    ? (',' + this.floating({min: min_alpha, max: max_alpha})) : "";
             var colorValue   = (isGrayscale) ? (gray(this.natural({min: min_rgb, max: max_rgb}), ',')) : (this.natural({min: min_green, max: max_green}) + ',' + this.natural({min: min_blue, max: max_blue}) + ',' + this.natural({max: 255}));
             return rgbValue + '(' + colorValue + alphaChannel + ')';
         }
@@ -1424,15 +1406,12 @@
                 if (options.format === "shorthex") {
                     hexstring = gray(this.hex({min: 0, max: 15}));
                 }
-            }
-            else {
+            } else {
                 if (options.format === "shorthex") {
                     hexstring = this.pad(this.hex({min: Math.floor(min_red / 16), max: Math.floor(max_red / 16)}), 1) + this.pad(this.hex({min: Math.floor(min_green / 16), max: Math.floor(max_green / 16)}), 1) + this.pad(this.hex({min: Math.floor(min_blue / 16), max: Math.floor(max_blue / 16)}), 1);
-                }
-                else if (min_red !== undefined || max_red !== undefined || min_green !== undefined || max_green !== undefined || min_blue !== undefined || max_blue !== undefined) {
+                } else if (min_red !== undefined || max_red !== undefined || min_green !== undefined || max_green !== undefined || min_blue !== undefined || max_blue !== undefined) {
                     hexstring = this.pad(this.hex({min: min_red, max: max_red}), 2) + this.pad(this.hex({min: min_green, max: max_green}), 2) + this.pad(this.hex({min: min_blue, max: max_blue}), 2);
-                }
-                else {
+                } else {
                     hexstring = this.pad(this.hex({min: min_rgb, max: max_rgb}), 2) + this.pad(this.hex({min: min_rgb, max: max_rgb}), 2) + this.pad(this.hex({min: min_rgb, max: max_rgb}), 2);
                 }
             }
@@ -1483,23 +1462,17 @@
 
         if (options.format === 'hex') {
             colorValue = hex.call(this, 2, 6, true);
-        }
-        else if (options.format === 'shorthex') {
+        } else if (options.format === 'shorthex') {
             colorValue = hex.call(this, 1, 3, true);
-        }
-        else if (options.format === 'rgb') {
+        } else if (options.format === 'rgb') {
             colorValue = rgb.call(this, false);
-        }
-        else if (options.format === 'rgba') {
+        } else if (options.format === 'rgba') {
             colorValue = rgb.call(this, true);
-        }
-        else if (options.format === '0x') {
+        } else if (options.format === '0x') {
             colorValue = '0x' + hex.call(this, 2, 6);
-        }
-        else if(options.format === 'name') {
+        } else if (options.format === 'name') {
             return this.pick(this.get("colorNames"));
-        }
-        else {
+        } else {
             throw new RangeError('Invalid format provided. Please provide one of "hex", "shorthex", "rgb", "rgba", "0x" or "name".');
         }
 
@@ -1601,7 +1574,22 @@
     };
 
     Chance.prototype.tlds = function () {
-        return ['com', 'org', 'edu', 'gov', 'co.uk', 'net', 'io', 'ac', 'ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'ax', 'az', 'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bm', 'bn', 'bo', 'br', 'bs', 'bt', 'bv', 'bw', 'by', 'bz', 'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn', 'co', 'cr', 'cu', 'cv', 'cw', 'cx', 'cy', 'cz', 'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg', 'eh', 'er', 'es', 'et', 'eu', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr', 'ga', 'gb', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm', 'hn', 'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm', 'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly', 'ma', 'mc', 'md', 'me', 'mg', 'mh', 'mk', 'ml', 'mm', 'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz', 'na', 'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om', 'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'rs', 'ru', 'rw', 'sa', 'sb', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'ss', 'st', 'su', 'sv', 'sx', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk', 'tl', 'tm', 'tn', 'to', 'tp', 'tr', 'tt', 'tv', 'tw', 'tz', 'ua', 'ug', 'uk', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn', 'vu', 'wf', 'ws', 'ye', 'yt', 'za', 'zm', 'zw'];
+        return [
+            'com', 'org', 'edu', 'gov', 'co.uk', 'net', 'io',
+            'ac', 'ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'ax', 'az',
+            'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bm', 'bn', 'bo', 'br', 'bs', 'bt', 'bv', 'bw', 'by', 'bz',
+            'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn', 'co', 'cr', 'cu', 'cv', 'cw', 'cx', 'cy', 'cz',
+            'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg', 'eh', 'er', 'es', 'et', 'eu', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr',
+            'ga', 'gb', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy',
+            'hk', 'hm', 'hn', 'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm', 'jo', 'jp',
+            'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly',
+            'ma', 'mc', 'md', 'me', 'mg', 'mh', 'mk', 'ml', 'mm', 'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz',
+            'na', 'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om',
+            'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'rs', 'ru', 'rw',
+            'sa', 'sb', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'ss', 'st', 'su', 'sv', 'sx', 'sy', 'sz',
+            'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk', 'tl', 'tm', 'tn', 'to', 'tp', 'tr', 'tt', 'tv', 'tw', 'tz',
+            'ua', 'ug', 'uk', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn', 'vu', 'wf', 'ws', 'ye', 'yt', 'za', 'zm', 'zw'
+        ];
     };
 
     Chance.prototype.tld = function () {
@@ -1613,7 +1601,7 @@
     };
 
     Chance.prototype.url = function (options) {
-        options = initOptions(options, { protocol: "http", domain: this.domain(options), domain_prefix: "", path: this.word(), extensions: []});
+        options = initOptions(options, {protocol: "http", domain: this.domain(options), domain_prefix: "", path: this.word(), extensions: []});
 
         var extension = options.extensions.length > 0 ? "." + this.pick(options.extensions) : "";
         var domain = options.domain_prefix ? options.domain_prefix + "." + options.domain : options.domain;
@@ -1621,30 +1609,30 @@
         return options.protocol + "://" + domain + "/" + options.path + extension;
     };
 
-    Chance.prototype.port = function() {
+    Chance.prototype.port = function () {
         return this.integer({min: 0, max: 65535});
     };
 
     Chance.prototype.locale = function (options) {
         options = initOptions(options);
         if (options.region){
-          return this.pick(this.get("locale_regions"));
+            return this.pick(this.get("locale_regions"));
         } else {
-          return this.pick(this.get("locale_languages"));
+            return this.pick(this.get("locale_languages"));
         }
     };
 
     Chance.prototype.locales = function (options) {
-      options = initOptions(options);
-      if (options.region){
-        return this.get("locale_regions");
-      } else {
-        return this.get("locale_languages");
-      }
+        options = initOptions(options);
+        if (options.region){
+            return this.get("locale_regions");
+        } else {
+            return this.get("locale_languages");
+        }
     };
 
     Chance.prototype.loremPicsum = function (options) {
-        options = initOptions(options, { width: 500, height: 500, greyscale: false, blurred: false });
+        options = initOptions(options, {width: 500, height: 500, greyscale: false, blurred: false});
 
         var greyscale = options.greyscale ? 'g/' : '';
         var query = options.blurred ? '/?blur' : '/?random';
@@ -1674,8 +1662,8 @@
         options = initOptions(options, {parens : true});
         // Don't want area codes to start with 1, or have a 9 as the second digit
         var areacode = options.exampleNumber ?
-        "555" :
-        this.natural({min: 2, max: 9}).toString() +
+            "555" :
+            this.natural({min: 2, max: 9}).toString() +
                 this.natural({min: 0, max: 8}).toString() +
                 this.natural({min: 0, max: 9}).toString();
 
@@ -1710,8 +1698,8 @@
     };
 
     Chance.prototype.geohash = function (options) {
-        options = initOptions(options, { length: 7 });
-        return this.string({ length: options.length, pool: '0123456789bcdefghjkmnpqrstuvwxyz' });
+        options = initOptions(options, {length: 7});
+        return this.string({length: options.length, pool: '0123456789bcdefghjkmnpqrstuvwxyz'});
     };
 
     Chance.prototype.geojson = function (options) {
@@ -1723,18 +1711,18 @@
         var [DDM, DMS, DD] = ['ddm', 'dms', 'dd'];
 
         options = initOptions(
-options,
+            options,
             options && options.format && [DDM, DMS].includes(options.format.toLowerCase()) ?
             {min: 0, max: 89, fixed: 4} :
             {fixed: 5, min: -90, max: 90, format: DD}
-);
+        );
 
         var format = options.format.toLowerCase();
 
         if (format === DDM || format === DMS) {
-            testRange(options.min < 0 || options.min > 89, "Chance: Min specified is out of range. Should be between 0 - 89");
-            testRange(options.max < 0 || options.max > 89, "Chance: Max specified is out of range. Should be between 0 - 89");
-            testRange(options.fixed > 4, 'Chance: Fixed specified should be below or equal to 4');
+            testRange(options.min < 0 || options.min > 89, "Chance: Min is out of range. Should be between 0 - 89");
+            testRange(options.max < 0 || options.max > 89, "Chance: Max is out of range. Should be between 0 - 89");
+            testRange(options.fixed > 4, "Chance: Fixed should be below or equal to 4");
         }
 
         switch (format) {
@@ -1759,18 +1747,18 @@ options,
         var [DDM, DMS, DD] = ['ddm', 'dms', 'dd'];
 
         options = initOptions(
-options,
+            options,
             options && options.format && [DDM, DMS].includes(options.format.toLowerCase()) ?
             {min: 0, max: 179, fixed: 4} :
             {fixed: 5, min: -180, max: 180, format: DD}
-);
+        );
 
         var format = options.format.toLowerCase();
 
         if (format === DDM || format === DMS) {
-            testRange(options.min < 0 || options.min > 179, "Chance: Min specified is out of range. Should be between 0 - 179");
-            testRange(options.max < 0 || options.max > 179, "Chance: Max specified is out of range. Should be between 0 - 179");
-            testRange(options.fixed > 4, 'Chance: Fixed specified should be below or equal to 4');
+            testRange(options.min < 0 || options.min > 179, "Chance: Min is out of range. Should be between 0 - 179");
+            testRange(options.max < 0 || options.max > 179, "Chance: Max is out of range. Should be between 0 - 179");
+            testRange(options.fixed > 4, "Chance: Fixed should be below or equal to 4");
         }
 
         switch (format) {
@@ -1795,8 +1783,8 @@ options,
             numPick,
             ukNum = function (parts) {
                 var section = [];
-                //fills the section part of the phone number with random numbers.
-                parts.sections.forEach(function(n) {
+                // fills the section part of the phone number with random numbers.
+                parts.sections.forEach(function (n) {
                     section.push(self.string({ pool: '0123456789', length: n}));
                 });
                 return parts.area + section.join(' ');
@@ -1816,12 +1804,27 @@ options,
                 if (!options.mobile) {
                     numPick = this.pick([
                         // Valid zone and département codes.
-                        '01' + this.pick(['30', '34', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '53', '55', '56', '58', '60', '64', '69', '70', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83']) + self.string({ pool: '0123456789', length: 6}),
-                        '02' + this.pick(['14', '18', '22', '23', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '40', '41', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '56', '57', '61', '62', '69', '72', '76', '77', '78', '85', '90', '96', '97', '98', '99']) + self.string({ pool: '0123456789', length: 6}),
-                        '03' + this.pick(['10', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '39', '44', '45', '51', '52', '54', '55', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90']) + self.string({ pool: '0123456789', length: 6}),
-                        '04' + this.pick(['11', '13', '15', '20', '22', '26', '27', '30', '32', '34', '37', '42', '43', '44', '50', '56', '57', '63', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '88', '89', '90', '91', '92', '93', '94', '95', '97', '98']) + self.string({ pool: '0123456789', length: 6}),
-                        '05' + this.pick(['08', '16', '17', '19', '24', '31', '32', '33', '34', '35', '40', '45', '46', '47', '49', '53', '55', '56', '57', '58', '59', '61', '62', '63', '64', '65', '67', '79', '81', '82', '86', '87', '90', '94']) + self.string({ pool: '0123456789', length: 6}),
-                        '09' + self.string({ pool: '0123456789', length: 8}),
+                        '01' + this.pick([
+                            '30', '34', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '53', '55', '56', '58', '60', '64', '69',
+                            '70', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83'
+                        ]) + self.string({pool: '0123456789', length: 6}),
+                        '02' + this.pick([
+                            '14', '18', '22', '23', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '40', '41', '43', '44', '45', '46', '47', '48', '49',
+                            '50', '51', '52', '53', '54', '56', '57', '61', '62', '69', '72', '76', '77', '78', '85', '90', '96', '97', '98', '99'
+                        ]) + self.string({pool: '0123456789', length: 6}),
+                            '03' + this.pick(['10', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '39', '44', '45', '51', '52', '54', '55', '57', '58', '59',
+                            '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90'
+                        ]) + self.string({pool: '0123456789', length: 6}),
+                        '04' + this.pick([
+                            '11', '13', '15', '20', '22', '26', '27', '30', '32', '34', '37', '42', '43', '44', '50', '56', '57',
+                            '63', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79',
+                            '80', '81', '82', '83', '84', '85', '86', '88', '89', '90', '91', '92', '93', '94', '95', '97', '98'
+                        ]) + self.string({pool: '0123456789', length: 6}),
+                        '05' + this.pick([
+                            '08', '16', '17', '19', '24', '31', '32', '33', '34', '35', '40', '45', '46', '47', '49', '53', '55', '56', '57', '58', '59',
+                            '61', '62', '63', '64', '65', '67', '79', '81', '82', '86', '87', '90', '94'
+                        ]) + self.string({pool: '0123456789', length: 6}),
+                        '09' + self.string({pool: '0123456789', length: 8}),
                     ]);
                     phone = options.formatted ? numPick.match(/../g).join(' ') : numPick;
                 } else {
@@ -1833,7 +1836,6 @@ options,
                 if (!options.mobile) {
                     numPick = this.pick([
                         //valid area codes of major cities/counties followed by random numbers in required format.
-
                         { area: '01' + this.character({ pool: '234569' }) + '1 ', sections: [3,4] },
                         { area: '020 ' + this.character({ pool: '378' }), sections: [3,4] },
                         { area: '023 ' + this.character({ pool: '89' }), sections: [3,4] },
@@ -1881,14 +1883,18 @@ options,
                 break;
             case 'us':
                 var areacode = this.areacode(options).toString();
-                var exchange = this.natural({ min: 2, max: 9 }).toString() +
-                    this.natural({ min: 0, max: 9 }).toString() +
-                    this.natural({ min: 0, max: 9 }).toString();
-                var subscriber = this.natural({ min: 1000, max: 9999 }).toString(); // this could be random [0-9]{4}
+                var exchange = this.natural({min: 2, max: 9}).toString() +
+                    this.natural({min: 0, max: 9}).toString() +
+                    this.natural({min: 0, max: 9}).toString();
+                var subscriber = this.natural({min: 1000, max: 9999}).toString(); // this could be random [0-9]{4}
                 phone = options.formatted ? areacode + ' ' + exchange + '-' + subscriber : areacode + exchange + subscriber;
                 break;
             case 'br':
-                var areaCode = this.pick(["11", "12", "13", "14", "15", "16", "17", "18", "19", "21", "22", "24", "27", "28", "31", "32", "33", "34", "35", "37", "38", "41", "42", "43", "44", "45", "46", "47", "48", "49", "51", "53", "54", "55", "61", "62", "63", "64", "65", "66", "67", "68", "69", "71", "73", "74", "75", "77", "79", "81", "82", "83", "84", "85", "86", "87", "88", "89", "91", "92", "93", "94", "95", "96", "97", "98", "99"]);
+                var areaCode = this.pick([
+                    '11', '12', '13', '14', '15', '16', '17', '18', '19', '21', '22', '24', '27', '28', '31', '32', '33', '34', '35', '37', '38',
+                    '41', '42', '43', '44', '45', '46', '47', '48', '49', '51', '53', '54', '55', '61', '62', '63', '64', '65', '66', '67', '68', '69',
+                    '71', '73', '74', '75', '77', '79', '81', '82', '83', '84', '85', '86', '87', '88', '89', '91', '92', '93', '94', '95', '96', '97', '98', '99'
+                ]);
                 var prefix;
                 if (options.mobile) {
                     // Brasilian official reference (mobile): http://www.anatel.gov.br/setorregulado/plano-de-numeracao-brasileiro?id=330
@@ -1909,7 +1915,7 @@ options,
         var pd = this.character({pool: "XVTSRPNKLMHJGECBA"});
         // Forward Sortation Area (FSA)
         var fsa = pd + this.natural({max: 9}) + this.character({alpha: true, casing: "upper"});
-        // Local Delivery Unut (LDU)
+        // Local Delivery Unit (LDU)
         var ldu = this.natural({max: 9}) + this.character({alpha: true, casing: "upper"}) + this.natural({max: 9});
 
         return fsa + " " + ldu;
@@ -1961,7 +1967,7 @@ options,
     };
 
     Chance.prototype.states = function (options) {
-        options = initOptions(options, { country: 'us', us_states_and_dc: true } );
+        options = initOptions(options, {country: 'us', us_states_and_dc: true} );
 
         var states;
 
@@ -1996,8 +2002,8 @@ options,
     };
 
     Chance.prototype.street = function (options) {
-        options = initOptions(options, { country: 'us', syllables: 2 });
-        var     street;
+        options = initOptions(options, {country: 'us', syllables: 2});
+        var street;
 
         switch (options.country.toLowerCase()) {
             case 'us':
@@ -2020,12 +2026,12 @@ options,
     };
 
     Chance.prototype.street_suffix = function (options) {
-        options = initOptions(options, { country: 'us' });
+        options = initOptions(options, {country: 'us'});
         return this.pick(this.street_suffixes(options));
     };
 
     Chance.prototype.street_suffixes = function (options) {
-        options = initOptions(options, { country: 'us' });
+        options = initOptions(options, {country: 'us'});
         // These are the most common suffixes.
         return this.get("street_suffixes")[options.country.toLowerCase()];
     };
@@ -2055,7 +2061,7 @@ options,
         var date_string, date;
 
         // If interval is specified we ignore preset
-        if(options && (options.min || options.max)) {
+        if (options && (options.min || options.max)) {
             options = initOptions(options, {
                 american: true,
                 string: false
@@ -2069,7 +2075,7 @@ options,
             var m = this.month({raw: true});
             var daysInMonth = m.days;
 
-            if(options && options.month) {
+            if (options && options.month) {
                 // Mod 12 to allow months outside range of 0-11 (not encouraged, but also not prevented).
                 daysInMonth = this.get('months')[((options.month % 12) + 12) % 12].days;
             }
@@ -2250,12 +2256,11 @@ options,
         return this.pick(this.timezones());
     };
 
-    //Return random correct currency exchange pair (e.g. EUR/USD) or array of currency code
+    // Return random correct currency exchange pair (e.g. EUR/USD) or array of currency codes
     Chance.prototype.currency_pair = function (returnAsString) {
         var currencies = this.unique(this.currency, 2, {
-            comparator: function(arr, val) {
-
-                return arr.reduce(function(acc, item) {
+            comparator: function (arr, val) {
+                return arr.reduce(function (acc, item) {
                     // If a match has been found, short circuit check and just return
                     return acc || (item.code === val.code);
                 }, false);
@@ -2270,8 +2275,8 @@ options,
     };
 
     Chance.prototype.dollar = function (options) {
-        // By default, a somewhat more sane max for dollar than all available numbers
-        options = initOptions(options, {max : 10000, min : 0});
+        // By default, a somewhat saner max for dollar than all available numbers
+        options = initOptions(options, {max: 10000, min: 0});
 
         var dollar = this.floating({min: options.min, max: options.max, fixed: 2}).toString(),
             cents = dollar.split('.')[1];
@@ -2351,10 +2356,10 @@ options,
         var alpha = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
         var alphanum = alpha + '0123456789';
         var iban =
-            this.string({ length: 2, pool: alpha }) +
-            this.pad(this.integer({ min: 0, max: 99 }), 2) +
-            this.string({ length: 4, pool: alphanum }) +
-            this.pad(this.natural(), this.natural({ min: 6, max: 26 }));
+            this.string({length: 2, pool: alpha}) +
+            this.pad(this.integer({min: 0, max: 99}), 2) +
+            this.string({length: 4, pool: alphanum}) +
+            this.pad(this.natural(), this.natural({min: 6, max: 26}));
         return iban;
     };
 
@@ -2391,15 +2396,14 @@ options,
             birthday = !!options.birthday ? options.birthday : this.birthday(),
             city = !!options.city ? options.city : this.pickone(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'L', 'M', 'Z']) + this.pad(this.natural({max:999}), 3),
             cf = [],
-            name_generator = function(name, isLast) {
+            name_generator = function (name, isLast) {
                 var temp,
                     return_value = [];
 
                 if (name.length < 3) {
                     return_value = name.split("").concat("XXX".split("")).splice(0,3);
-                }
-                else {
-                    temp = name.toUpperCase().split('').map(function(c){
+                } else {
+                    temp = name.toUpperCase().split('').map(function (c){
                         return ("BCDFGHJKLMNPRSTVWZ".indexOf(c) !== -1) ? c : undefined;
                     }).join('');
                     if (temp.length > 3) {
@@ -2411,7 +2415,7 @@ options,
                     }
                     if (temp.length < 3) {
                         return_value = temp;
-                        temp = name.toUpperCase().split('').map(function(c){
+                        temp = name.toUpperCase().split('').map(function (c){
                             return ("AEIOU".indexOf(c) !== -1) ? c : undefined;
                         }).join('').substr(0, 3 - return_value.length);
                     }
@@ -2420,14 +2424,14 @@ options,
 
                 return return_value;
             },
-            date_generator = function(birthday, gender, that) {
+            date_generator = function (birthday, gender, that) {
                 var lettermonths = ['A', 'B', 'C', 'D', 'E', 'H', 'L', 'M', 'P', 'R', 'S', 'T'];
 
                 return  birthday.getFullYear().toString().substr(2) +
                         lettermonths[birthday.getMonth()] +
                         that.pad(birthday.getDate() + ((gender.toLowerCase() === "female") ? 40 : 0), 2);
             },
-            checkdigit_generator = function(cf) {
+            checkdigit_generator = function (cf) {
                 var range1 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
                     range2 = "ABCDEFGHIJABCDEFGHIJKLMNOPQRSTUVWXYZ",
                     evens  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -2435,12 +2439,11 @@ options,
                     digit  = 0;
 
 
-                for(var i = 0; i < 15; i++) {
+                for (var i = 0; i < 15; i++) {
                     if (i % 2 !== 0) {
                         digit += evens.indexOf(range2[range1.indexOf(cf[i])]);
-                    }
-                    else {
-                        digit +=  odds.indexOf(range2[range1.indexOf(cf[i])]);
+                    } else {
+                        digit += odds.indexOf(range2[range1.indexOf(cf[i])]);
                     }
                 }
                 return evens[digit % 26];
@@ -2501,59 +2504,59 @@ options,
 
     // -- Music --
 
-    Chance.prototype.note = function(options) {
-      // choices for 'notes' option:
-      // flatKey - chromatic scale with flat notes (default)
-      // sharpKey - chromatic scale with sharp notes
-      // flats - just flat notes
-      // sharps - just sharp notes
-      // naturals - just natural notes
-      // all - naturals, sharps and flats
-      options = initOptions(options, { notes : 'flatKey'});
-      var scales = {
-        naturals: ['C', 'D', 'E', 'F', 'G', 'A', 'B'],
-        flats: ['D♭', 'E♭', 'G♭', 'A♭', 'B♭'],
-        sharps: ['C♯', 'D♯', 'F♯', 'G♯', 'A♯']
-      };
-      scales.all = scales.naturals.concat(scales.flats.concat(scales.sharps))
-      scales.flatKey = scales.naturals.concat(scales.flats)
-      scales.sharpKey = scales.naturals.concat(scales.sharps)
-      return this.pickone(scales[options.notes]);
+    Chance.prototype.note = function (options) {
+        // choices for 'notes' option:
+        // flatKey - chromatic scale with flat notes (default)
+        // sharpKey - chromatic scale with sharp notes
+        // flats - just flat notes
+        // sharps - just sharp notes
+        // naturals - just natural notes
+        // all - naturals, sharps and flats
+        options = initOptions(options, {notes : 'flatKey'});
+        var scales = {
+            naturals: ['C', 'D', 'E', 'F', 'G', 'A', 'B'],
+            flats: ['D♭', 'E♭', 'G♭', 'A♭', 'B♭'],
+            sharps: ['C♯', 'D♯', 'F♯', 'G♯', 'A♯']
+        };
+        scales.all = scales.naturals.concat(scales.flats.concat(scales.sharps))
+        scales.flatKey = scales.naturals.concat(scales.flats)
+        scales.sharpKey = scales.naturals.concat(scales.sharps)
+        return this.pickone(scales[options.notes]);
     }
 
-    Chance.prototype.midi_note = function(options) {
-      var min = 0;
-      var max = 127;
-      options = initOptions(options, { min : min, max : max });
-      return this.integer({min: options.min, max: options.max});
+    Chance.prototype.midi_note = function (options) {
+        var min = 0;
+        var max = 127;
+        options = initOptions(options, {min : min, max : max});
+        return this.integer({min: options.min, max: options.max});
     }
 
-    Chance.prototype.chord_quality = function(options) {
-      options = initOptions(options, { jazz: true });
-      var chord_qualities = ['maj', 'min', 'aug', 'dim'];
-      if (options.jazz){
-        chord_qualities = [
-          'maj7',
-          'min7',
-          '7',
-          'sus',
-          'dim',
-          'ø'
-        ];
-      }
-      return this.pickone(chord_qualities);
+    Chance.prototype.chord_quality = function (options) {
+        options = initOptions(options, {jazz: true});
+        var chord_qualities = ['maj', 'min', 'aug', 'dim'];
+        if (options.jazz){
+            chord_qualities = [
+                'maj7',
+                'min7',
+                '7',
+                'sus',
+                'dim',
+                'ø'
+            ];
+        }
+        return this.pickone(chord_qualities);
     }
 
     Chance.prototype.chord = function (options) {
-      options = initOptions(options);
-      return this.note(options) + this.chord_quality(options);
+        options = initOptions(options);
+        return this.note(options) + this.chord_quality(options);
     }
 
     Chance.prototype.tempo = function (options) {
-      var min = 40;
-      var max = 320;
-      options = initOptions(options, {min: min, max: max});
-      return this.integer({min: options.min, max: options.max});
+        var min = 40;
+        var max = 320;
+        options = initOptions(options, {min: min, max: max});
+        return this.integer({min: options.min, max: options.max});
     }
 
     // -- End Music
@@ -2561,12 +2564,12 @@ options,
     // -- Miscellaneous --
 
     // Coin - Flip, flip, flipadelphia
-    Chance.prototype.coin = function() {
-      return this.bool() ? "heads" : "tails";
+    Chance.prototype.coin = function () {
+        return this.bool() ? "heads" : "tails";
     }
 
     // Dice - For all the board game geeks out there, myself included ;)
-    function diceFn (range) {
+    function diceFn(range) {
         return function () {
             return this.natural(range);
         };
@@ -2600,19 +2603,19 @@ options,
 
     // Guid
     Chance.prototype.guid = function (options) {
-        options = initOptions(options, { version: 5 });
+        options = initOptions(options, {version: 5});
 
         var guid_pool = "abcdef1234567890",
             variant_pool = "ab89",
-            guid = this.string({ pool: guid_pool, length: 8 }) + '-' +
-                   this.string({ pool: guid_pool, length: 4 }) + '-' +
+            guid = this.string({pool: guid_pool, length: 8}) + '-' +
+                   this.string({pool: guid_pool, length: 4}) + '-' +
                    // The Version
                    options.version +
-                   this.string({ pool: guid_pool, length: 3 }) + '-' +
+                   this.string({pool: guid_pool, length: 3}) + '-' +
                    // The Variant
-                   this.string({ pool: variant_pool, length: 1 }) +
-                   this.string({ pool: guid_pool, length: 3 }) + '-' +
-                   this.string({ pool: guid_pool, length: 12 });
+                   this.string({pool: variant_pool, length: 1}) +
+                   this.string({pool: guid_pool, length: 3}) + '-' +
+                   this.string({pool: guid_pool, length: 12});
         return guid;
     };
 
@@ -2648,28 +2651,25 @@ options,
     };
 
     // MD5 Hash
-    Chance.prototype.md5 = function(options) {
-        var opts = { str: '', key: null, raw: false };
+    Chance.prototype.md5 = function (options) {
+        var opts = {str: '', key: null, raw: false};
 
         if (!options) {
             opts.str = this.string();
             options = {};
-        }
-        else if (typeof options === 'string') {
+        } else if (typeof options === 'string') {
             opts.str = options;
             options = {};
-        }
-        else if (typeof options !== 'object') {
+        } else if (typeof options !== 'object') {
             return null;
-        }
-        else if(options.constructor === 'Array') {
+        } else if (options.constructor === 'Array') {
             return null;
         }
 
         opts = initOptions(options, opts);
 
-        if(!opts.str){
-            throw new Error('A parameter is required to return an md5 hash.');
+        if (!opts.str){
+            throw new Error("Change: A parameter is required to return an md5 hash.");
         }
 
         return this.bimd5.md5(opts.str, opts.key, opts.raw);
@@ -2736,52 +2736,44 @@ options,
      * @return [string]
      *
      */
-    Chance.prototype.file = function(options) {
-
+    Chance.prototype.file = function (options) {
         var fileOptions = options || {};
         var poolCollectionKey = "fileExtension";
-        var typeRange   = Object.keys(this.get("fileExtension"));//['raster', 'vector', '3d', 'document'];
+        var typeRange = Object.keys(this.get("fileExtension"));//['raster', 'vector', '3d', 'document'];
         var fileName;
         var fileExtension;
 
         // Generate random file name
-        fileName = this.word({length : fileOptions.length});
+        fileName = this.word({length: fileOptions.length});
 
         // Generate file by specific extension provided by the user
-        if(fileOptions.extension) {
-
+        if (fileOptions.extension) {
             fileExtension = fileOptions.extension;
-            return (fileName + '.' + fileExtension);
+            return fileName + '.' + fileExtension;
         }
 
         // Generate file by specific extension collection
-        if(fileOptions.extensions) {
-
-            if(Array.isArray(fileOptions.extensions)) {
-
+        if (fileOptions.extensions) {
+            if (Array.isArray(fileOptions.extensions)) {
                 fileExtension = this.pickone(fileOptions.extensions);
-                return (fileName + '.' + fileExtension);
-            }
-            else if(fileOptions.extensions.constructor === Object) {
-
+                return fileName + '.' + fileExtension;
+            } else if (fileOptions.extensions.constructor === Object) {
                 var extensionObjectCollection = fileOptions.extensions;
                 var keys = Object.keys(extensionObjectCollection);
 
                 fileExtension = this.pickone(extensionObjectCollection[this.pickone(keys)]);
-                return (fileName + '.' + fileExtension);
+                return fileName + '.' + fileExtension;
             }
 
             throw new Error("Chance: Extensions must be an Array or Object");
         }
 
         // Generate file extension based on specific file type
-        if(fileOptions.fileType) {
-
+        if (fileOptions.fileType) {
             var fileType = fileOptions.fileType;
-            if(typeRange.indexOf(fileType) !== -1) {
-
+            if (typeRange.indexOf(fileType) !== -1) {
                 fileExtension = this.pickone(this.get(poolCollectionKey)[fileType]);
-                return (fileName + '.' + fileExtension);
+                return fileName + '.' + fileExtension;
             }
 
             throw new RangeError("Chance: Expect file type value to be 'raster', 'vector', '3d' or 'document'");
@@ -2789,60 +2781,85 @@ options,
 
         // Generate random file name if no extension options are passed
         fileExtension = this.pickone(this.get(poolCollectionKey)[this.pickone(typeRange)]);
-        return (fileName + '.' + fileExtension);
+        return fileName + '.' + fileExtension;
     };
 
     var data = {
-
         firstNames: {
-            "male": {
-                "en": ["James", "John", "Robert", "Michael", "William", "David", "Richard", "Joseph", "Charles", "Thomas", "Christopher", "Daniel", "Matthew", "George", "Donald", "Anthony", "Paul", "Mark", "Edward", "Steven", "Kenneth", "Andrew", "Brian", "Joshua", "Kevin", "Ronald", "Timothy", "Jason", "Jeffrey", "Frank", "Gary", "Ryan", "Nicholas", "Eric", "Stephen", "Jacob", "Larry", "Jonathan", "Scott", "Raymond", "Justin", "Brandon", "Gregory", "Samuel", "Benjamin", "Patrick", "Jack", "Henry", "Walter", "Dennis", "Jerry", "Alexander", "Peter", "Tyler", "Douglas", "Harold", "Aaron", "Jose", "Adam", "Arthur", "Zachary", "Carl", "Nathan", "Albert", "Kyle", "Lawrence", "Joe", "Willie", "Gerald", "Roger", "Keith", "Jeremy", "Terry", "Harry", "Ralph", "Sean", "Jesse", "Roy", "Louis", "Billy", "Austin", "Bruce", "Eugene", "Christian", "Bryan", "Wayne", "Russell", "Howard", "Fred", "Ethan", "Jordan", "Philip", "Alan", "Juan", "Randy", "Vincent", "Bobby", "Dylan", "Johnny", "Phillip", "Victor", "Clarence", "Ernest", "Martin", "Craig", "Stanley", "Shawn", "Travis", "Bradley", "Leonard", "Earl", "Gabriel", "Jimmy", "Francis", "Todd", "Noah", "Danny", "Dale", "Cody", "Carlos", "Allen", "Frederick", "Logan", "Curtis", "Alex", "Joel", "Luis", "Norman", "Marvin", "Glenn", "Tony", "Nathaniel", "Rodney", "Melvin", "Alfred", "Steve", "Cameron", "Chad", "Edwin", "Caleb", "Evan", "Antonio", "Lee", "Herbert", "Jeffery", "Isaac", "Derek", "Ricky", "Marcus", "Theodore", "Elijah", "Luke", "Jesus", "Eddie", "Troy", "Mike", "Dustin", "Ray", "Adrian", "Bernard", "Leroy", "Angel", "Randall", "Wesley", "Ian", "Jared", "Mason", "Hunter", "Calvin", "Oscar", "Clifford", "Jay", "Shane", "Ronnie", "Barry", "Lucas", "Corey", "Manuel", "Leo", "Tommy", "Warren", "Jackson", "Isaiah", "Connor", "Don", "Dean", "Jon", "Julian", "Miguel", "Bill", "Lloyd", "Charlie", "Mitchell", "Leon", "Jerome", "Darrell", "Jeremiah", "Alvin", "Brett", "Seth", "Floyd", "Jim", "Blake", "Micheal", "Gordon", "Trevor", "Lewis", "Erik", "Edgar", "Vernon", "Devin", "Gavin", "Jayden", "Chris", "Clyde", "Tom", "Derrick", "Mario", "Brent", "Marc", "Herman", "Chase", "Dominic", "Ricardo", "Franklin", "Maurice", "Max", "Aiden", "Owen", "Lester", "Gilbert", "Elmer", "Gene", "Francisco", "Glen", "Cory", "Garrett", "Clayton", "Sam", "Jorge", "Chester", "Alejandro", "Jeff", "Harvey", "Milton", "Cole", "Ivan", "Andre", "Duane", "Landon"],
+            male: {
+                en: ["James","John","Robert","Michael","William","David","Richard","Joseph","Charles","Thomas","Christopher","Daniel","Matthew","George","Donald","Anthony","Paul","Mark","Edward","Steven","Kenneth","Andrew","Brian","Joshua","Kevin","Ronald","Timothy","Jason","Jeffrey","Frank","Gary","Ryan","Nicholas","Eric","Stephen","Jacob","Larry","Jonathan","Scott","Raymond","Justin","Brandon","Gregory","Samuel","Benjamin","Patrick","Jack","Henry","Walter","Dennis","Jerry","Alexander","Peter","Tyler","Douglas","Harold","Aaron","Jose","Adam","Arthur","Zachary","Carl","Nathan","Albert","Kyle","Lawrence","Joe","Willie","Gerald","Roger","Keith","Jeremy","Terry","Harry","Ralph","Sean","Jesse","Roy","Louis","Billy","Austin","Bruce","Eugene","Christian","Bryan","Wayne","Russell","Howard","Fred","Ethan","Jordan","Philip","Alan","Juan","Randy","Vincent","Bobby","Dylan","Johnny","Phillip","Victor","Clarence","Ernest","Martin","Craig","Stanley","Shawn","Travis","Bradley","Leonard","Earl","Gabriel","Jimmy","Francis","Todd","Noah","Danny","Dale","Cody","Carlos","Allen","Frederick","Logan","Curtis","Alex","Joel","Luis","Norman","Marvin","Glenn","Tony","Nathaniel","Rodney","Melvin","Alfred","Steve","Cameron","Chad","Edwin","Caleb","Evan","Antonio","Lee","Herbert","Jeffery","Isaac","Derek","Ricky","Marcus","Theodore","Elijah","Luke","Jesus","Eddie","Troy","Mike","Dustin","Ray","Adrian","Bernard","Leroy","Angel","Randall","Wesley","Ian","Jared","Mason","Hunter","Calvin","Oscar","Clifford","Jay","Shane","Ronnie","Barry","Lucas","Corey","Manuel","Leo","Tommy","Warren","Jackson","Isaiah","Connor","Don","Dean","Jon","Julian","Miguel","Bill","Lloyd","Charlie","Mitchell","Leon","Jerome","Darrell","Jeremiah","Alvin","Brett","Seth","Floyd","Jim","Blake","Micheal","Gordon","Trevor","Lewis","Erik","Edgar","Vernon","Devin","Gavin","Jayden","Chris","Clyde","Tom","Derrick","Mario","Brent","Marc","Herman","Chase","Dominic","Ricardo","Franklin","Maurice","Max","Aiden","Owen","Lester","Gilbert","Elmer","Gene","Francisco","Glen","Cory","Garrett","Clayton","Sam","Jorge","Chester","Alejandro","Jeff","Harvey","Milton","Cole","Ivan","Andre","Duane","Landon"],
                 // Data taken from http://www.dati.gov.it/dataset/comune-di-firenze_0163
-                "it": ["Adolfo", "Alberto", "Aldo", "Alessandro", "Alessio", "Alfredo", "Alvaro", "Andrea", "Angelo", "Angiolo", "Antonino", "Antonio", "Attilio", "Benito", "Bernardo", "Bruno", "Carlo", "Cesare", "Christian", "Claudio", "Corrado", "Cosimo", "Cristian", "Cristiano", "Daniele", "Dario", "David", "Davide", "Diego", "Dino", "Domenico", "Duccio", "Edoardo", "Elia", "Elio", "Emanuele", "Emiliano", "Emilio", "Enrico", "Enzo", "Ettore", "Fabio", "Fabrizio", "Federico", "Ferdinando", "Fernando", "Filippo", "Francesco", "Franco", "Gabriele", "Giacomo", "Giampaolo", "Giampiero", "Giancarlo", "Gianfranco", "Gianluca", "Gianmarco", "Gianni", "Gino", "Giorgio", "Giovanni", "Giuliano", "Giulio", "Giuseppe", "Graziano", "Gregorio", "Guido", "Iacopo", "Jacopo", "Lapo", "Leonardo", "Lorenzo", "Luca", "Luciano", "Luigi", "Manuel", "Marcello", "Marco", "Marino", "Mario", "Massimiliano", "Massimo", "Matteo", "Mattia", "Maurizio", "Mauro", "Michele", "Mirko", "Mohamed", "Nello", "Neri", "Niccolò", "Nicola", "Osvaldo", "Otello", "Paolo", "Pier Luigi", "Piero", "Pietro", "Raffaele", "Remo", "Renato", "Renzo", "Riccardo", "Roberto", "Rolando", "Romano", "Salvatore", "Samuele", "Sandro", "Sergio", "Silvano", "Simone", "Stefano", "Thomas", "Tommaso", "Ubaldo", "Ugo", "Umberto", "Valerio", "Valter", "Vasco", "Vincenzo", "Vittorio"],
+                it: ["Adolfo","Alberto","Aldo","Alessandro","Alessio","Alfredo","Alvaro","Andrea","Angelo","Angiolo","Antonino","Antonio","Attilio","Benito","Bernardo","Bruno","Carlo","Cesare","Christian","Claudio","Corrado","Cosimo","Cristian","Cristiano","Daniele","Dario","David","Davide","Diego","Dino","Domenico","Duccio","Edoardo","Elia","Elio","Emanuele","Emiliano","Emilio","Enrico","Enzo","Ettore","Fabio","Fabrizio","Federico","Ferdinando","Fernando","Filippo","Francesco","Franco","Gabriele","Giacomo","Giampaolo","Giampiero","Giancarlo","Gianfranco","Gianluca","Gianmarco","Gianni","Gino","Giorgio","Giovanni","Giuliano","Giulio","Giuseppe","Graziano","Gregorio","Guido","Iacopo","Jacopo","Lapo","Leonardo","Lorenzo","Luca","Luciano","Luigi","Manuel","Marcello","Marco","Marino","Mario","Massimiliano","Massimo","Matteo","Mattia","Maurizio","Mauro","Michele","Mirko","Mohamed","Nello","Neri","Niccolò","Nicola","Osvaldo","Otello","Paolo","Pier Luigi","Piero","Pietro","Raffaele","Remo","Renato","Renzo","Riccardo","Roberto","Rolando","Romano","Salvatore","Samuele","Sandro","Sergio","Silvano","Simone","Stefano","Thomas","Tommaso","Ubaldo","Ugo","Umberto","Valerio","Valter","Vasco","Vincenzo","Vittorio"],
                 // Data taken from http://www.svbkindernamen.nl/int/nl/kindernamen/index.html
                 "nl": ["Aaron","Abel","Adam","Adriaan","Albert","Alexander","Ali","Arjen","Arno","Bart","Bas","Bastiaan","Benjamin","Bob", "Boris","Bram","Brent","Cas","Casper","Chris","Christiaan","Cornelis","Daan","Daley","Damian","Dani","Daniel","Daniël","David","Dean","Dirk","Dylan","Egbert","Elijah","Erik","Erwin","Evert","Ezra","Fabian","Fedde","Finn","Florian","Floris","Frank","Frans","Frederik","Freek","Geert","Gerard","Gerben","Gerrit","Gijs","Guus","Hans","Hendrik","Henk","Herman","Hidde","Hugo","Jaap","Jan Jaap","Jan-Willem","Jack","Jacob","Jan","Jason","Jasper","Jayden","Jelle","Jelte","Jens","Jeroen","Jesse","Jim","Job","Joep","Johannes","John","Jonathan","Joris","Joshua","Joël","Julian","Kees","Kevin","Koen","Lars","Laurens","Leendert","Lennard","Lodewijk","Luc","Luca","Lucas","Lukas","Luuk","Maarten","Marcus","Martijn","Martin","Matthijs","Maurits","Max","Mees","Melle","Mick","Mika","Milan","Mohamed","Mohammed","Morris","Muhammed","Nathan","Nick","Nico","Niek","Niels","Noah","Noud","Olivier","Oscar","Owen","Paul","Pepijn","Peter","Pieter","Pim","Quinten","Reinier","Rens","Robin","Ruben","Sam","Samuel","Sander","Sebastiaan","Sem","Sep","Sepp","Siem","Simon","Stan","Stef","Steven","Stijn","Sven","Teun","Thijmen","Thijs","Thomas","Tijn","Tim","Timo","Tobias","Tom","Victor","Vince","Willem","Wim","Wouter","Yusuf"],
                 // Data taken from https://fr.wikipedia.org/wiki/Liste_de_pr%C3%A9noms_fran%C3%A7ais_et_de_la_francophonie
-                "fr": ["Aaron","Abdon","Abel","Abélard","Abelin","Abondance","Abraham","Absalon","Acace","Achaire","Achille","Adalard","Adalbald","Adalbéron","Adalbert","Adalric","Adam","Adegrin","Adel","Adelin","Andelin","Adelphe","Adam","Adéodat","Adhémar","Adjutor","Adolphe","Adonis","Adon","Adrien","Agapet","Agathange","Agathon","Agilbert","Agénor","Agnan","Aignan","Agrippin","Aimable","Aimé","Alain","Alban","Albin","Aubin","Albéric","Albert","Albertet","Alcibiade","Alcide","Alcée","Alcime","Aldonce","Aldric","Aldéric","Aleaume","Alexandre","Alexis","Alix","Alliaume","Aleaume","Almine","Almire","Aloïs","Alphée","Alphonse","Alpinien","Alverède","Amalric","Amaury","Amandin","Amant","Ambroise","Amédée","Amélien","Amiel","Amour","Anaël","Anastase","Anatole","Ancelin","Andéol","Andoche","André","Andoche","Ange","Angelin","Angilbe","Anglebert","Angoustan","Anicet","Anne","Annibal","Ansbert","Anselme","Anthelme","Antheaume","Anthime","Antide","Antoine","Antonius","Antonin","Apollinaire","Apollon","Aquilin","Arcade","Archambaud","Archambeau","Archange","Archibald","Arian","Ariel","Ariste","Aristide","Armand","Armel","Armin","Arnould","Arnaud","Arolde","Arsène","Arsinoé","Arthaud","Arthème","Arthur","Ascelin","Athanase","Aubry","Audebert","Audouin","Audran","Audric","Auguste","Augustin","Aurèle","Aurélien","Aurian","Auxence","Axel","Aymard","Aymeric","Aymon","Aymond","Balthazar","Baptiste","Barnabé","Barthélemy","Bartimée","Basile","Bastien","Baudouin","Bénigne","Benjamin","Benoît","Bérenger","Bérard","Bernard","Bertrand","Blaise","Bon","Boniface","Bouchard","Brice","Brieuc","Bruno","Brunon","Calixte","Calliste","Camélien","Camille","Camillien","Candide","Caribert","Carloman","Cassandre","Cassien","Cédric","Céleste","Célestin","Célien","Césaire","César","Charles","Charlemagne","Childebert","Chilpéric","Chrétien","Christian","Christodule","Christophe","Chrysostome","Clarence","Claude","Claudien","Cléandre","Clément","Clotaire","Côme","Constance","Constant","Constantin","Corentin","Cyprien","Cyriaque","Cyrille","Cyril","Damien","Daniel","David","Delphin","Denis","Désiré","Didier","Dieudonné","Dimitri","Dominique","Dorian","Dorothée","Edgard","Edmond","Édouard","Éleuthère","Élie","Élisée","Émeric","Émile","Émilien","Emmanuel","Enguerrand","Épiphane","Éric","Esprit","Ernest","Étienne","Eubert","Eudes","Eudoxe","Eugène","Eusèbe","Eustache","Évariste","Évrard","Fabien","Fabrice","Falba","Félicité","Félix","Ferdinand","Fiacre","Fidèle","Firmin","Flavien","Flodoard","Florent","Florentin","Florestan","Florian","Fortuné","Foulques","Francisque","François","Français","Franciscus","Francs","Frédéric","Fulbert","Fulcran","Fulgence","Gabin","Gabriel","Gaël","Garnier","Gaston","Gaspard","Gatien","Gaud","Gautier","Gédéon","Geoffroy","Georges","Géraud","Gérard","Gerbert","Germain","Gervais","Ghislain","Gilbert","Gilles","Girart","Gislebert","Gondebaud","Gonthier","Gontran","Gonzague","Grégoire","Guérin","Gui","Guillaume","Gustave","Guy","Guyot","Hardouin","Hector","Hédelin","Hélier","Henri","Herbert","Herluin","Hervé","Hilaire","Hildebert","Hincmar","Hippolyte","Honoré","Hubert","Hugues","Innocent","Isabeau","Isidore","Jacques","Japhet","Jason","Jean","Jeannel","Jeannot","Jérémie","Jérôme","Joachim","Joanny","Job","Jocelyn","Joël","Johan","Jonas","Jonathan","Joseph","Josse","Josselin","Jourdain","Jude","Judicaël","Jules","Julien","Juste","Justin","Lambert","Landry","Laurent","Lazare","Léandre","Léon","Léonard","Léopold","Leu","Loup","Leufroy","Libère","Liétald","Lionel","Loïc","Longin","Lorrain","Lorraine","Lothaire","Louis","Loup","Luc","Lucas","Lucien","Ludolphe","Ludovic","Macaire","Malo","Mamert","Manassé","Marc","Marceau","Marcel","Marcelin","Marius","Marseille","Martial","Martin","Mathurin","Matthias","Mathias","Matthieu","Maugis","Maurice","Mauricet","Maxence","Maxime","Maximilien","Mayeul","Médéric","Melchior","Mence","Merlin","Mérovée","Michaël","Michel","Moïse","Morgan","Nathan","Nathanaël","Narcisse","Néhémie","Nestor","Nestor","Nicéphore","Nicolas","Noé","Noël","Norbert","Normand","Normands","Octave","Odilon","Odon","Oger","Olivier","Oury","Pacôme","Palémon","Parfait","Pascal","Paterne","Patrice","Paul","Pépin","Perceval","Philémon","Philibert","Philippe","Philothée","Pie","Pierre","Pierrick","Prosper","Quentin","Raoul","Raphaël","Raymond","Régis","Réjean","Rémi","Renaud","René","Reybaud","Richard","Robert","Roch","Rodolphe","Rodrigue","Roger","Roland","Romain","Romuald","Roméo","Rome","Ronan","Roselin","Salomon","Samuel","Savin","Savinien","Scholastique","Sébastien","Séraphin","Serge","Séverin","Sidoine","Sigebert","Sigismond","Silvère","Simon","Siméon","Sixte","Stanislas","Stéphane","Stephan","Sylvain","Sylvestre","Tancrède","Tanguy","Taurin","Théodore","Théodose","Théophile","Théophraste","Thibault","Thibert","Thierry","Thomas","Timoléon","Timothée","Titien","Tonnin","Toussaint","Trajan","Tristan","Turold","Tim","Ulysse","Urbain","Valentin","Valère","Valéry","Venance","Venant","Venceslas","Vianney","Victor","Victorien","Victorin","Vigile","Vincent","Vital","Vitalien","Vivien","Waleran","Wandrille","Xavier","Xénophon","Yves","Zacharie","Zaché","Zéphirin"]
+                fr: ["Aaron","Abdon","Abel","Abélard","Abelin","Abondance","Abraham","Absalon","Acace","Achaire","Achille","Adalard","Adalbald","Adalbéron","Adalbert","Adalric","Adam","Adegrin","Adel","Adelin","Andelin","Adelphe","Adam","Adéodat","Adhémar","Adjutor","Adolphe","Adonis","Adon","Adrien","Agapet","Agathange","Agathon","Agilbert","Agénor","Agnan","Aignan","Agrippin","Aimable","Aimé","Alain","Alban","Albin","Aubin","Albéric","Albert","Albertet","Alcibiade","Alcide","Alcée","Alcime","Aldonce","Aldric","Aldéric","Aleaume","Alexandre","Alexis","Alix","Alliaume","Aleaume","Almine","Almire","Aloïs","Alphée","Alphonse","Alpinien","Alverède","Amalric","Amaury","Amandin","Amant","Ambroise","Amédée","Amélien","Amiel","Amour","Anaël","Anastase","Anatole","Ancelin","Andéol","Andoche","André","Andoche","Ange","Angelin","Angilbe","Anglebert","Angoustan","Anicet","Anne","Annibal","Ansbert","Anselme","Anthelme","Antheaume","Anthime","Antide","Antoine","Antonius","Antonin","Apollinaire","Apollon","Aquilin","Arcade","Archambaud","Archambeau","Archange","Archibald","Arian","Ariel","Ariste","Aristide","Armand","Armel","Armin","Arnould","Arnaud","Arolde","Arsène","Arsinoé","Arthaud","Arthème","Arthur","Ascelin","Athanase","Aubry","Audebert","Audouin","Audran","Audric","Auguste","Augustin","Aurèle","Aurélien","Aurian","Auxence","Axel","Aymard","Aymeric","Aymon","Aymond","Balthazar","Baptiste","Barnabé","Barthélemy","Bartimée","Basile","Bastien","Baudouin","Bénigne","Benjamin","Benoît","Bérenger","Bérard","Bernard","Bertrand","Blaise","Bon","Boniface","Bouchard","Brice","Brieuc","Bruno","Brunon","Calixte","Calliste","Camélien","Camille","Camillien","Candide","Caribert","Carloman","Cassandre","Cassien","Cédric","Céleste","Célestin","Célien","Césaire","César","Charles","Charlemagne","Childebert","Chilpéric","Chrétien","Christian","Christodule","Christophe","Chrysostome","Clarence","Claude","Claudien","Cléandre","Clément","Clotaire","Côme","Constance","Constant","Constantin","Corentin","Cyprien","Cyriaque","Cyrille","Cyril","Damien","Daniel","David","Delphin","Denis","Désiré","Didier","Dieudonné","Dimitri","Dominique","Dorian","Dorothée","Edgard","Edmond","Édouard","Éleuthère","Élie","Élisée","Émeric","Émile","Émilien","Emmanuel","Enguerrand","Épiphane","Éric","Esprit","Ernest","Étienne","Eubert","Eudes","Eudoxe","Eugène","Eusèbe","Eustache","Évariste","Évrard","Fabien","Fabrice","Falba","Félicité","Félix","Ferdinand","Fiacre","Fidèle","Firmin","Flavien","Flodoard","Florent","Florentin","Florestan","Florian","Fortuné","Foulques","Francisque","François","Français","Franciscus","Francs","Frédéric","Fulbert","Fulcran","Fulgence","Gabin","Gabriel","Gaël","Garnier","Gaston","Gaspard","Gatien","Gaud","Gautier","Gédéon","Geoffroy","Georges","Géraud","Gérard","Gerbert","Germain","Gervais","Ghislain","Gilbert","Gilles","Girart","Gislebert","Gondebaud","Gonthier","Gontran","Gonzague","Grégoire","Guérin","Gui","Guillaume","Gustave","Guy","Guyot","Hardouin","Hector","Hédelin","Hélier","Henri","Herbert","Herluin","Hervé","Hilaire","Hildebert","Hincmar","Hippolyte","Honoré","Hubert","Hugues","Innocent","Isabeau","Isidore","Jacques","Japhet","Jason","Jean","Jeannel","Jeannot","Jérémie","Jérôme","Joachim","Joanny","Job","Jocelyn","Joël","Johan","Jonas","Jonathan","Joseph","Josse","Josselin","Jourdain","Jude","Judicaël","Jules","Julien","Juste","Justin","Lambert","Landry","Laurent","Lazare","Léandre","Léon","Léonard","Léopold","Leu","Loup","Leufroy","Libère","Liétald","Lionel","Loïc","Longin","Lorrain","Lorraine","Lothaire","Louis","Loup","Luc","Lucas","Lucien","Ludolphe","Ludovic","Macaire","Malo","Mamert","Manassé","Marc","Marceau","Marcel","Marcelin","Marius","Marseille","Martial","Martin","Mathurin","Matthias","Mathias","Matthieu","Maugis","Maurice","Mauricet","Maxence","Maxime","Maximilien","Mayeul","Médéric","Melchior","Mence","Merlin","Mérovée","Michaël","Michel","Moïse","Morgan","Nathan","Nathanaël","Narcisse","Néhémie","Nestor","Nestor","Nicéphore","Nicolas","Noé","Noël","Norbert","Normand","Normands","Octave","Odilon","Odon","Oger","Olivier","Oury","Pacôme","Palémon","Parfait","Pascal","Paterne","Patrice","Paul","Pépin","Perceval","Philémon","Philibert","Philippe","Philothée","Pie","Pierre","Pierrick","Prosper","Quentin","Raoul","Raphaël","Raymond","Régis","Réjean","Rémi","Renaud","René","Reybaud","Richard","Robert","Roch","Rodolphe","Rodrigue","Roger","Roland","Romain","Romuald","Roméo","Rome","Ronan","Roselin","Salomon","Samuel","Savin","Savinien","Scholastique","Sébastien","Séraphin","Serge","Séverin","Sidoine","Sigebert","Sigismond","Silvère","Simon","Siméon","Sixte","Stanislas","Stéphane","Stephan","Sylvain","Sylvestre","Tancrède","Tanguy","Taurin","Théodore","Théodose","Théophile","Théophraste","Thibault","Thibert","Thierry","Thomas","Timoléon","Timothée","Titien","Tonnin","Toussaint","Trajan","Tristan","Turold","Tim","Ulysse","Urbain","Valentin","Valère","Valéry","Venance","Venant","Venceslas","Vianney","Victor","Victorien","Victorin","Vigile","Vincent","Vital","Vitalien","Vivien","Waleran","Wandrille","Xavier","Xénophon","Yves","Zacharie","Zaché","Zéphirin"],
             },
 
-            "female": {
-                "en": ["Mary", "Emma", "Elizabeth", "Minnie", "Margaret", "Ida", "Alice", "Bertha", "Sarah", "Annie", "Clara", "Ella", "Florence", "Cora", "Martha", "Laura", "Nellie", "Grace", "Carrie", "Maude", "Mabel", "Bessie", "Jennie", "Gertrude", "Julia", "Hattie", "Edith", "Mattie", "Rose", "Catherine", "Lillian", "Ada", "Lillie", "Helen", "Jessie", "Louise", "Ethel", "Lula", "Myrtle", "Eva", "Frances", "Lena", "Lucy", "Edna", "Maggie", "Pearl", "Daisy", "Fannie", "Josephine", "Dora", "Rosa", "Katherine", "Agnes", "Marie", "Nora", "May", "Mamie", "Blanche", "Stella", "Ellen", "Nancy", "Effie", "Sallie", "Nettie", "Della", "Lizzie", "Flora", "Susie", "Maud", "Mae", "Etta", "Harriet", "Sadie", "Caroline", "Katie", "Lydia", "Elsie", "Kate", "Susan", "Mollie", "Alma", "Addie", "Georgia", "Eliza", "Lulu", "Nannie", "Lottie", "Amanda", "Belle", "Charlotte", "Rebecca", "Ruth", "Viola", "Olive", "Amelia", "Hannah", "Jane", "Virginia", "Emily", "Matilda", "Irene", "Kathryn", "Esther", "Willie", "Henrietta", "Ollie", "Amy", "Rachel", "Sara", "Estella", "Theresa", "Augusta", "Ora", "Pauline", "Josie", "Lola", "Sophia", "Leona", "Anne", "Mildred", "Ann", "Beulah", "Callie", "Lou", "Delia", "Eleanor", "Barbara", "Iva", "Louisa", "Maria", "Mayme", "Evelyn", "Estelle", "Nina", "Betty", "Marion", "Bettie", "Dorothy", "Luella", "Inez", "Lela", "Rosie", "Allie", "Millie", "Janie", "Cornelia", "Victoria", "Ruby", "Winifred", "Alta", "Celia", "Christine", "Beatrice", "Birdie", "Harriett", "Mable", "Myra", "Sophie", "Tillie", "Isabel", "Sylvia", "Carolyn", "Isabelle", "Leila", "Sally", "Ina", "Essie", "Bertie", "Nell", "Alberta", "Katharine", "Lora", "Rena", "Mina", "Rhoda", "Mathilda", "Abbie", "Eula", "Dollie", "Hettie", "Eunice", "Fanny", "Ola", "Lenora", "Adelaide", "Christina", "Lelia", "Nelle", "Sue", "Johanna", "Lilly", "Lucinda", "Minerva", "Lettie", "Roxie", "Cynthia", "Helena", "Hilda", "Hulda", "Bernice", "Genevieve", "Jean", "Cordelia", "Marian", "Francis", "Jeanette", "Adeline", "Gussie", "Leah", "Lois", "Lura", "Mittie", "Hallie", "Isabella", "Olga", "Phoebe", "Teresa", "Hester", "Lida", "Lina", "Winnie", "Claudia", "Marguerite", "Vera", "Cecelia", "Bess", "Emilie", "Rosetta", "Verna", "Myrtie", "Cecilia", "Elva", "Olivia", "Ophelia", "Georgie", "Elnora", "Violet", "Adele", "Lily", "Linnie", "Loretta", "Madge", "Polly", "Virgie", "Eugenia", "Lucile", "Lucille", "Mabelle", "Rosalie"],
+            female: {
+                en: ["Mary","Emma","Elizabeth","Minnie","Margaret","Ida","Alice","Bertha","Sarah","Annie","Clara","Ella","Florence","Cora","Martha","Laura","Nellie","Grace","Carrie","Maude","Mabel","Bessie","Jennie","Gertrude","Julia","Hattie","Edith","Mattie","Rose","Catherine","Lillian","Ada","Lillie","Helen","Jessie","Louise","Ethel","Lula","Myrtle","Eva","Frances","Lena","Lucy","Edna","Maggie","Pearl","Daisy","Fannie","Josephine","Dora","Rosa","Katherine","Agnes","Marie","Nora","May","Mamie","Blanche","Stella","Ellen","Nancy","Effie","Sallie","Nettie","Della","Lizzie","Flora","Susie","Maud","Mae","Etta","Harriet","Sadie","Caroline","Katie","Lydia","Elsie","Kate","Susan","Mollie","Alma","Addie","Georgia","Eliza","Lulu","Nannie","Lottie","Amanda","Belle","Charlotte","Rebecca","Ruth","Viola","Olive","Amelia","Hannah","Jane","Virginia","Emily","Matilda","Irene","Kathryn","Esther","Willie","Henrietta","Ollie","Amy","Rachel","Sara","Estella","Theresa","Augusta","Ora","Pauline","Josie","Lola","Sophia","Leona","Anne","Mildred","Ann","Beulah","Callie","Lou","Delia","Eleanor","Barbara","Iva","Louisa","Maria","Mayme","Evelyn","Estelle","Nina","Betty","Marion","Bettie","Dorothy","Luella","Inez","Lela","Rosie","Allie","Millie","Janie","Cornelia","Victoria","Ruby","Winifred","Alta","Celia","Christine","Beatrice","Birdie","Harriett","Mable","Myra","Sophie","Tillie","Isabel","Sylvia","Carolyn","Isabelle","Leila","Sally","Ina","Essie","Bertie","Nell","Alberta","Katharine","Lora","Rena","Mina","Rhoda","Mathilda","Abbie","Eula","Dollie","Hettie","Eunice","Fanny","Ola","Lenora","Adelaide","Christina","Lelia","Nelle","Sue","Johanna","Lilly","Lucinda","Minerva","Lettie","Roxie","Cynthia","Helena","Hilda","Hulda","Bernice","Genevieve","Jean","Cordelia","Marian","Francis","Jeanette","Adeline","Gussie","Leah","Lois","Lura","Mittie","Hallie","Isabella","Olga","Phoebe","Teresa","Hester","Lida","Lina","Winnie","Claudia","Marguerite","Vera","Cecelia","Bess","Emilie","Rosetta","Verna","Myrtie","Cecilia","Elva","Olivia","Ophelia","Georgie","Elnora","Violet","Adele","Lily","Linnie","Loretta","Madge","Polly","Virgie","Eugenia","Lucile","Lucille","Mabelle","Rosalie"],
                 // Data taken from http://www.dati.gov.it/dataset/comune-di-firenze_0162
-                "it": ["Ada", "Adriana", "Alessandra", "Alessia", "Alice", "Angela", "Anna", "Anna Maria", "Annalisa", "Annita", "Annunziata", "Antonella", "Arianna", "Asia", "Assunta", "Aurora", "Barbara", "Beatrice", "Benedetta", "Bianca", "Bruna", "Camilla", "Carla", "Carlotta", "Carmela", "Carolina", "Caterina", "Catia", "Cecilia", "Chiara", "Cinzia", "Clara", "Claudia", "Costanza", "Cristina", "Daniela", "Debora", "Diletta", "Dina", "Donatella", "Elena", "Eleonora", "Elisa", "Elisabetta", "Emanuela", "Emma", "Eva", "Federica", "Fernanda", "Fiorella", "Fiorenza", "Flora", "Franca", "Francesca", "Gabriella", "Gaia", "Gemma", "Giada", "Gianna", "Gina", "Ginevra", "Giorgia", "Giovanna", "Giulia", "Giuliana", "Giuseppa", "Giuseppina", "Grazia", "Graziella", "Greta", "Ida", "Ilaria", "Ines", "Iolanda", "Irene", "Irma", "Isabella", "Jessica", "Laura", "Lea", "Letizia", "Licia", "Lidia", "Liliana", "Lina", "Linda", "Lisa", "Livia", "Loretta", "Luana", "Lucia", "Luciana", "Lucrezia", "Luisa", "Manuela", "Mara", "Marcella", "Margherita", "Maria", "Maria Cristina", "Maria Grazia", "Maria Luisa", "Maria Pia", "Maria Teresa", "Marina", "Marisa", "Marta", "Martina", "Marzia", "Matilde", "Melissa", "Michela", "Milena", "Mirella", "Monica", "Natalina", "Nella", "Nicoletta", "Noemi", "Olga", "Paola", "Patrizia", "Piera", "Pierina", "Raffaella", "Rebecca", "Renata", "Rina", "Rita", "Roberta", "Rosa", "Rosanna", "Rossana", "Rossella", "Sabrina", "Sandra", "Sara", "Serena", "Silvana", "Silvia", "Simona", "Simonetta", "Sofia", "Sonia", "Stefania", "Susanna", "Teresa", "Tina", "Tiziana", "Tosca", "Valentina", "Valeria", "Vanda", "Vanessa", "Vanna", "Vera", "Veronica", "Vilma", "Viola", "Virginia", "Vittoria"],
+                it: ["Ada","Adriana","Alessandra","Alessia","Alice","Angela","Anna","Anna Maria","Annalisa","Annita","Annunziata","Antonella","Arianna","Asia","Assunta","Aurora","Barbara","Beatrice","Benedetta","Bianca","Bruna","Camilla","Carla","Carlotta","Carmela","Carolina","Caterina","Catia","Cecilia","Chiara","Cinzia","Clara","Claudia","Costanza","Cristina","Daniela","Debora","Diletta","Dina","Donatella","Elena","Eleonora","Elisa","Elisabetta","Emanuela","Emma","Eva","Federica","Fernanda","Fiorella","Fiorenza","Flora","Franca","Francesca","Gabriella","Gaia","Gemma","Giada","Gianna","Gina","Ginevra","Giorgia","Giovanna","Giulia","Giuliana","Giuseppa","Giuseppina","Grazia","Graziella","Greta","Ida","Ilaria","Ines","Iolanda","Irene","Irma","Isabella","Jessica","Laura","Lea","Letizia","Licia","Lidia","Liliana","Lina","Linda","Lisa","Livia","Loretta","Luana","Lucia","Luciana","Lucrezia","Luisa","Manuela","Mara","Marcella","Margherita","Maria","Maria Cristina","Maria Grazia","Maria Luisa","Maria Pia","Maria Teresa","Marina","Marisa","Marta","Martina","Marzia","Matilde","Melissa","Michela","Milena","Mirella","Monica","Natalina","Nella","Nicoletta","Noemi","Olga","Paola","Patrizia","Piera","Pierina","Raffaella","Rebecca","Renata","Rina","Rita","Roberta","Rosa","Rosanna","Rossana","Rossella","Sabrina","Sandra","Sara","Serena","Silvana","Silvia","Simona","Simonetta","Sofia","Sonia","Stefania","Susanna","Teresa","Tina","Tiziana","Tosca","Valentina","Valeria","Vanda","Vanessa","Vanna","Vera","Veronica","Vilma","Viola","Virginia","Vittoria"],
                 // Data taken from http://www.svbkindernamen.nl/int/nl/kindernamen/index.html
-                "nl": ["Ada", "Arianne", "Afke", "Amanda", "Amber", "Amy", "Aniek", "Anita", "Anja", "Anna", "Anne", "Annelies", "Annemarie", "Annette", "Anouk", "Astrid", "Aukje", "Barbara", "Bianca", "Carla", "Carlijn", "Carolien", "Chantal", "Charlotte", "Claudia", "Daniëlle", "Debora", "Diane", "Dora", "Eline", "Elise", "Ella", "Ellen", "Emma", "Esmee", "Evelien", "Esther", "Erica", "Eva", "Femke", "Fleur", "Floor", "Froukje", "Gea", "Gerda", "Hanna", "Hanneke", "Heleen", "Hilde", "Ilona", "Ina", "Inge", "Ingrid", "Iris", "Isabel", "Isabelle", "Janneke", "Jasmijn", "Jeanine", "Jennifer", "Jessica", "Johanna", "Joke", "Julia", "Julie", "Karen", "Karin", "Katja", "Kim", "Lara", "Laura", "Lena", "Lianne", "Lieke", "Lilian", "Linda", "Lisa", "Lisanne", "Lotte", "Louise", "Maaike", "Manon", "Marga", "Maria", "Marissa", "Marit", "Marjolein", "Martine", "Marleen", "Melissa", "Merel", "Miranda", "Michelle", "Mirjam", "Mirthe", "Naomi", "Natalie", 'Nienke', "Nina", "Noortje", "Olivia", "Patricia", "Paula", "Paulien", "Ramona", "Ria", "Rianne", "Roos", "Rosanne", "Ruth", "Sabrina", "Sandra", "Sanne", "Sara", "Saskia", "Silvia", "Sofia", "Sophie", "Sonja", "Suzanne", "Tamara", "Tess", "Tessa", "Tineke", "Valerie", "Vanessa", "Veerle", "Vera", "Victoria", "Wendy", "Willeke", "Yvonne", "Zoë"],
+                "nl": ["Ada","Arianne","Afke","Amanda","Amber","Amy","Aniek","Anita","Anja","Anna","Anne","Annelies","Annemarie","Annette","Anouk","Astrid","Aukje","Barbara","Bianca","Carla","Carlijn","Carolien","Chantal","Charlotte","Claudia","Daniëlle","Debora","Diane","Dora","Eline","Elise","Ella","Ellen","Emma","Esmee","Evelien","Esther","Erica","Eva","Femke","Fleur","Floor","Froukje","Gea","Gerda","Hanna","Hanneke","Heleen","Hilde","Ilona","Ina","Inge","Ingrid","Iris","Isabel","Isabelle","Janneke","Jasmijn","Jeanine","Jennifer","Jessica","Johanna","Joke","Julia","Julie","Karen","Karin","Katja","Kim","Lara","Laura","Lena","Lianne","Lieke","Lilian","Linda","Lisa","Lisanne","Lotte","Louise","Maaike","Manon","Marga","Maria","Marissa","Marit","Marjolein","Martine","Marleen","Melissa","Merel","Miranda","Michelle","Mirjam","Mirthe","Naomi","Natalie","Nienke","Nina","Noortje","Olivia","Patricia","Paula","Paulien","Ramona","Ria","Rianne","Roos","Rosanne","Ruth","Sabrina","Sandra","Sanne","Sara","Saskia","Silvia","Sofia","Sophie","Sonja","Suzanne","Tamara","Tess","Tessa","Tineke","Valerie","Vanessa","Veerle","Vera","Victoria","Wendy","Willeke","Yvonne","Zoë"],
                 // Data taken from https://fr.wikipedia.org/wiki/Liste_de_pr%C3%A9noms_fran%C3%A7ais_et_de_la_francophonie
-                "fr": ["Abdon","Abel","Abigaëlle","Abigaïl","Acacius","Acanthe","Adalbert","Adalsinde","Adegrine","Adélaïde","Adèle","Adélie","Adeline","Adeltrude","Adolphe","Adonis","Adrastée","Adrehilde","Adrienne","Agathe","Agilbert","Aglaé","Aignan","Agneflète","Agnès","Agrippine","Aimé","Alaine","Alaïs","Albane","Albérade","Alberte","Alcide","Alcine","Alcyone","Aldegonde","Aleth","Alexandrine","Alexine","Alice","Aliénor","Aliette","Aline","Alix","Alizé","Aloïse","Aloyse","Alphonsine","Althée","Amaliane","Amalthée","Amande","Amandine","Amant","Amarande","Amaranthe","Amaryllis","Ambre","Ambroisie","Amélie","Améthyste","Aminte","Anaël","Anaïs","Anastasie","Anatole","Ancelin","Andrée","Anémone","Angadrême","Angèle","Angeline","Angélique","Angilbert","Anicet","Annabelle","Anne","Annette","Annick","Annie","Annonciade","Ansbert","Anstrudie","Anthelme","Antigone","Antoinette","Antonine","Aphélie","Apolline","Apollonie","Aquiline","Arabelle","Arcadie","Archange","Argine","Ariane","Aricie","Ariel","Arielle","Arlette","Armance","Armande","Armandine","Armelle","Armide","Armelle","Armin","Arnaud","Arsène","Arsinoé","Artémis","Arthur","Ascelin","Ascension","Assomption","Astarté","Astérie","Astrée","Astrid","Athalie","Athanasie","Athina","Aube","Albert","Aude","Audrey","Augustine","Aure","Aurélie","Aurélien","Aurèle","Aurore","Auxence","Aveline","Abigaëlle","Avoye","Axelle","Aymard","Azalée","Adèle","Adeline","Barbe","Basilisse","Bathilde","Béatrice","Béatrix","Bénédicte","Bérengère","Bernadette","Berthe","Bertille","Beuve","Blanche","Blanc","Blandine","Brigitte","Brune","Brunehilde","Callista","Camille","Capucine","Carine","Caroline","Cassandre","Catherine","Cécile","Céleste","Célestine","Céline","Chantal","Charlène","Charline","Charlotte","Chloé","Christelle","Christiane","Christine","Claire","Clara","Claude","Claudine","Clarisse","Clémence","Clémentine","Cléo","Clio","Clotilde","Coline","Conception","Constance","Coralie","Coraline","Corentine","Corinne","Cyrielle","Daniel","Daniel","Daphné","Débora","Delphine","Denise","Diane","Dieudonné","Dominique","Doriane","Dorothée","Douce","Édith","Edmée","Éléonore","Éliane","Élia","Éliette","Élisabeth","Élise","Ella","Élodie","Éloïse","Elsa","Émeline","Émérance","Émérentienne","Émérencie","Émilie","Emma","Emmanuelle","Emmelie","Ernestine","Esther","Estelle","Eudoxie","Eugénie","Eulalie","Euphrasie","Eusébie","Évangéline","Eva","Ève","Évelyne","Fanny","Fantine","Faustine","Félicie","Fernande","Flavie","Fleur","Flore","Florence","Florie","Fortuné","France","Francia","Françoise","Francine","Gabrielle","Gaëlle","Garance","Geneviève","Georgette","Gerberge","Germaine","Gertrude","Gisèle","Guenièvre","Guilhemine","Guillemette","Gustave","Gwenael","Hélène","Héloïse","Henriette","Hermine","Hermione","Hippolyte","Honorine","Hortense","Huguette","Ines","Irène","Irina","Iris","Isabeau","Isabelle","Iseult","Isolde","Ismérie","Jacinthe","Jacqueline","Jade","Janine","Jeanne","Jocelyne","Joëlle","Joséphine","Judith","Julia","Julie","Jules","Juliette","Justine","Katy","Kathy","Katie","Laura","Laure","Laureline","Laurence","Laurene","Lauriane","Laurianne","Laurine","Léa","Léna","Léonie","Léon","Léontine","Lorraine","Lucie","Lucienne","Lucille","Ludivine","Lydie","Lydie","Megane","Madeleine","Magali","Maguelone","Mallaury","Manon","Marceline","Margot","Marguerite","Marianne","Marie","Myriam","Marie","Marine","Marion","Marlène","Marthe","Martine","Mathilde","Maud","Maureen","Mauricette","Maxime","Mélanie","Melissa","Mélissandre","Mélisande","Mélodie","Michel","Micheline","Mireille","Miriam","Moïse","Monique","Morgane","Muriel","Mylène","Nadège","Nadine","Nathalie","Nicole","Nicolette","Nine","Noël","Noémie","Océane","Odette","Odile","Olive","Olivia","Olympe","Ombline","Ombeline","Ophélie","Oriande","Oriane","Ozanne","Pascale","Pascaline","Paule","Paulette","Pauline","Priscille","Prisca","Prisque","Pécine","Pélagie","Pénélope","Perrine","Pétronille","Philippine","Philomène","Philothée","Primerose","Prudence","Pulchérie","Quentine","Quiéta","Quintia","Quintilla","Rachel","Raphaëlle","Raymonde","Rebecca","Régine","Réjeanne","René","Rita","Rita","Rolande","Romane","Rosalie","Rose","Roseline","Sabine","Salomé","Sandra","Sandrine","Sarah","Ségolène","Séverine","Sibylle","Simone","Sixt","Solange","Soline","Solène","Sophie","Stéphanie","Suzanne","Sylvain","Sylvie","Tatiana","Thaïs","Théodora","Thérèse","Tiphaine","Ursule","Valentine","Valérie","Véronique","Victoire","Victorine","Vinciane","Violette","Virginie","Viviane","Xavière","Yolande","Ysaline","Yvette","Yvonne","Zélie","Zita","Zoé"]
-            }
+                fr: ["Abdon","Abel","Abigaëlle","Abigaïl","Acacius","Acanthe","Adalbert","Adalsinde","Adegrine","Adélaïde","Adèle","Adélie","Adeline","Adeltrude","Adolphe","Adonis","Adrastée","Adrehilde","Adrienne","Agathe","Agilbert","Aglaé","Aignan","Agneflète","Agnès","Agrippine","Aimé","Alaine","Alaïs","Albane","Albérade","Alberte","Alcide","Alcine","Alcyone","Aldegonde","Aleth","Alexandrine","Alexine","Alice","Aliénor","Aliette","Aline","Alix","Alizé","Aloïse","Aloyse","Alphonsine","Althée","Amaliane","Amalthée","Amande","Amandine","Amant","Amarande","Amaranthe","Amaryllis","Ambre","Ambroisie","Amélie","Améthyste","Aminte","Anaël","Anaïs","Anastasie","Anatole","Ancelin","Andrée","Anémone","Angadrême","Angèle","Angeline","Angélique","Angilbert","Anicet","Annabelle","Anne","Annette","Annick","Annie","Annonciade","Ansbert","Anstrudie","Anthelme","Antigone","Antoinette","Antonine","Aphélie","Apolline","Apollonie","Aquiline","Arabelle","Arcadie","Archange","Argine","Ariane","Aricie","Ariel","Arielle","Arlette","Armance","Armande","Armandine","Armelle","Armide","Armelle","Armin","Arnaud","Arsène","Arsinoé","Artémis","Arthur","Ascelin","Ascension","Assomption","Astarté","Astérie","Astrée","Astrid","Athalie","Athanasie","Athina","Aube","Albert","Aude","Audrey","Augustine","Aure","Aurélie","Aurélien","Aurèle","Aurore","Auxence","Aveline","Abigaëlle","Avoye","Axelle","Aymard","Azalée","Adèle","Adeline","Barbe","Basilisse","Bathilde","Béatrice","Béatrix","Bénédicte","Bérengère","Bernadette","Berthe","Bertille","Beuve","Blanche","Blanc","Blandine","Brigitte","Brune","Brunehilde","Callista","Camille","Capucine","Carine","Caroline","Cassandre","Catherine","Cécile","Céleste","Célestine","Céline","Chantal","Charlène","Charline","Charlotte","Chloé","Christelle","Christiane","Christine","Claire","Clara","Claude","Claudine","Clarisse","Clémence","Clémentine","Cléo","Clio","Clotilde","Coline","Conception","Constance","Coralie","Coraline","Corentine","Corinne","Cyrielle","Daniel","Daniel","Daphné","Débora","Delphine","Denise","Diane","Dieudonné","Dominique","Doriane","Dorothée","Douce","Édith","Edmée","Éléonore","Éliane","Élia","Éliette","Élisabeth","Élise","Ella","Élodie","Éloïse","Elsa","Émeline","Émérance","Émérentienne","Émérencie","Émilie","Emma","Emmanuelle","Emmelie","Ernestine","Esther","Estelle","Eudoxie","Eugénie","Eulalie","Euphrasie","Eusébie","Évangéline","Eva","Ève","Évelyne","Fanny","Fantine","Faustine","Félicie","Fernande","Flavie","Fleur","Flore","Florence","Florie","Fortuné","France","Francia","Françoise","Francine","Gabrielle","Gaëlle","Garance","Geneviève","Georgette","Gerberge","Germaine","Gertrude","Gisèle","Guenièvre","Guilhemine","Guillemette","Gustave","Gwenael","Hélène","Héloïse","Henriette","Hermine","Hermione","Hippolyte","Honorine","Hortense","Huguette","Ines","Irène","Irina","Iris","Isabeau","Isabelle","Iseult","Isolde","Ismérie","Jacinthe","Jacqueline","Jade","Janine","Jeanne","Jocelyne","Joëlle","Joséphine","Judith","Julia","Julie","Jules","Juliette","Justine","Katy","Kathy","Katie","Laura","Laure","Laureline","Laurence","Laurene","Lauriane","Laurianne","Laurine","Léa","Léna","Léonie","Léon","Léontine","Lorraine","Lucie","Lucienne","Lucille","Ludivine","Lydie","Lydie","Megane","Madeleine","Magali","Maguelone","Mallaury","Manon","Marceline","Margot","Marguerite","Marianne","Marie","Myriam","Marie","Marine","Marion","Marlène","Marthe","Martine","Mathilde","Maud","Maureen","Mauricette","Maxime","Mélanie","Melissa","Mélissandre","Mélisande","Mélodie","Michel","Micheline","Mireille","Miriam","Moïse","Monique","Morgane","Muriel","Mylène","Nadège","Nadine","Nathalie","Nicole","Nicolette","Nine","Noël","Noémie","Océane","Odette","Odile","Olive","Olivia","Olympe","Ombline","Ombeline","Ophélie","Oriande","Oriane","Ozanne","Pascale","Pascaline","Paule","Paulette","Pauline","Priscille","Prisca","Prisque","Pécine","Pélagie","Pénélope","Perrine","Pétronille","Philippine","Philomène","Philothée","Primerose","Prudence","Pulchérie","Quentine","Quiéta","Quintia","Quintilla","Rachel","Raphaëlle","Raymonde","Rebecca","Régine","Réjeanne","René","Rita","Rita","Rolande","Romane","Rosalie","Rose","Roseline","Sabine","Salomé","Sandra","Sandrine","Sarah","Ségolène","Séverine","Sibylle","Simone","Sixt","Solange","Soline","Solène","Sophie","Stéphanie","Suzanne","Sylvain","Sylvie","Tatiana","Thaïs","Théodora","Thérèse","Tiphaine","Ursule","Valentine","Valérie","Véronique","Victoire","Victorine","Vinciane","Violette","Virginie","Viviane","Xavière","Yolande","Ysaline","Yvette","Yvonne","Zélie","Zita","Zoé"],
+            },
         },
 
         lastNames: {
-            "en": ['Smith', 'Johnson', 'Williams', 'Jones', 'Brown', 'Davis', 'Miller', 'Wilson', 'Moore', 'Taylor', 'Anderson', 'Thomas', 'Jackson', 'White', 'Harris', 'Martin', 'Thompson', 'Garcia', 'Martinez', 'Robinson', 'Clark', 'Rodriguez', 'Lewis', 'Lee', 'Walker', 'Hall', 'Allen', 'Young', 'Hernandez', 'King', 'Wright', 'Lopez', 'Hill', 'Scott', 'Green', 'Adams', 'Baker', 'Gonzalez', 'Nelson', 'Carter', 'Mitchell', 'Perez', 'Roberts', 'Turner', 'Phillips', 'Campbell', 'Parker', 'Evans', 'Edwards', 'Collins', 'Stewart', 'Sanchez', 'Morris', 'Rogers', 'Reed', 'Cook', 'Morgan', 'Bell', 'Murphy', 'Bailey', 'Rivera', 'Cooper', 'Richardson', 'Cox', 'Howard', 'Ward', 'Torres', 'Peterson', 'Gray', 'Ramirez', 'James', 'Watson', 'Brooks', 'Kelly', 'Sanders', 'Price', 'Bennett', 'Wood', 'Barnes', 'Ross', 'Henderson', 'Coleman', 'Jenkins', 'Perry', 'Powell', 'Long', 'Patterson', 'Hughes', 'Flores', 'Washington', 'Butler', 'Simmons', 'Foster', 'Gonzales', 'Bryant', 'Alexander', 'Russell', 'Griffin', 'Diaz', 'Hayes', 'Myers', 'Ford', 'Hamilton', 'Graham', 'Sullivan', 'Wallace', 'Woods', 'Cole', 'West', 'Jordan', 'Owens', 'Reynolds', 'Fisher', 'Ellis', 'Harrison', 'Gibson', 'McDonald', 'Cruz', 'Marshall', 'Ortiz', 'Gomez', 'Murray', 'Freeman', 'Wells', 'Webb', 'Simpson', 'Stevens', 'Tucker', 'Porter', 'Hunter', 'Hicks', 'Crawford', 'Henry', 'Boyd', 'Mason', 'Morales', 'Kennedy', 'Warren', 'Dixon', 'Ramos', 'Reyes', 'Burns', 'Gordon', 'Shaw', 'Holmes', 'Rice', 'Robertson', 'Hunt', 'Black', 'Daniels', 'Palmer', 'Mills', 'Nichols', 'Grant', 'Knight', 'Ferguson', 'Rose', 'Stone', 'Hawkins', 'Dunn', 'Perkins', 'Hudson', 'Spencer', 'Gardner', 'Stephens', 'Payne', 'Pierce', 'Berry', 'Matthews', 'Arnold', 'Wagner', 'Willis', 'Ray', 'Watkins', 'Olson', 'Carroll', 'Duncan', 'Snyder', 'Hart', 'Cunningham', 'Bradley', 'Lane', 'Andrews', 'Ruiz', 'Harper', 'Fox', 'Riley', 'Armstrong', 'Carpenter', 'Weaver', 'Greene', 'Lawrence', 'Elliott', 'Chavez', 'Sims', 'Austin', 'Peters', 'Kelley', 'Franklin', 'Lawson', 'Fields', 'Gutierrez', 'Ryan', 'Schmidt', 'Carr', 'Vasquez', 'Castillo', 'Wheeler', 'Chapman', 'Oliver', 'Montgomery', 'Richards', 'Williamson', 'Johnston', 'Banks', 'Meyer', 'Bishop', 'McCoy', 'Howell', 'Alvarez', 'Morrison', 'Hansen', 'Fernandez', 'Garza', 'Harvey', 'Little', 'Burton', 'Stanley', 'Nguyen', 'George', 'Jacobs', 'Reid', 'Kim', 'Fuller', 'Lynch', 'Dean', 'Gilbert', 'Garrett', 'Romero', 'Welch', 'Larson', 'Frazier', 'Burke', 'Hanson', 'Day', 'Mendoza', 'Moreno', 'Bowman', 'Medina', 'Fowler', 'Brewer', 'Hoffman', 'Carlson', 'Silva', 'Pearson', 'Holland', 'Douglas', 'Fleming', 'Jensen', 'Vargas', 'Byrd', 'Davidson', 'Hopkins', 'May', 'Terry', 'Herrera', 'Wade', 'Soto', 'Walters', 'Curtis', 'Neal', 'Caldwell', 'Lowe', 'Jennings', 'Barnett', 'Graves', 'Jimenez', 'Horton', 'Shelton', 'Barrett', 'Obrien', 'Castro', 'Sutton', 'Gregory', 'McKinney', 'Lucas', 'Miles', 'Craig', 'Rodriquez', 'Chambers', 'Holt', 'Lambert', 'Fletcher', 'Watts', 'Bates', 'Hale', 'Rhodes', 'Pena', 'Beck', 'Newman', 'Haynes', 'McDaniel', 'Mendez', 'Bush', 'Vaughn', 'Parks', 'Dawson', 'Santiago', 'Norris', 'Hardy', 'Love', 'Steele', 'Curry', 'Powers', 'Schultz', 'Barker', 'Guzman', 'Page', 'Munoz', 'Ball', 'Keller', 'Chandler', 'Weber', 'Leonard', 'Walsh', 'Lyons', 'Ramsey', 'Wolfe', 'Schneider', 'Mullins', 'Benson', 'Sharp', 'Bowen', 'Daniel', 'Barber', 'Cummings', 'Hines', 'Baldwin', 'Griffith', 'Valdez', 'Hubbard', 'Salazar', 'Reeves', 'Warner', 'Stevenson', 'Burgess', 'Santos', 'Tate', 'Cross', 'Garner', 'Mann', 'Mack', 'Moss', 'Thornton', 'Dennis', 'McGee', 'Farmer', 'Delgado', 'Aguilar', 'Vega', 'Glover', 'Manning', 'Cohen', 'Harmon', 'Rodgers', 'Robbins', 'Newton', 'Todd', 'Blair', 'Higgins', 'Ingram', 'Reese', 'Cannon', 'Strickland', 'Townsend', 'Potter', 'Goodwin', 'Walton', 'Rowe', 'Hampton', 'Ortega', 'Patton', 'Swanson', 'Joseph', 'Francis', 'Goodman', 'Maldonado', 'Yates', 'Becker', 'Erickson', 'Hodges', 'Rios', 'Conner', 'Adkins', 'Webster', 'Norman', 'Malone', 'Hammond', 'Flowers', 'Cobb', 'Moody', 'Quinn', 'Blake', 'Maxwell', 'Pope', 'Floyd', 'Osborne', 'Paul', 'McCarthy', 'Guerrero', 'Lindsey', 'Estrada', 'Sandoval', 'Gibbs', 'Tyler', 'Gross', 'Fitzgerald', 'Stokes', 'Doyle', 'Sherman', 'Saunders', 'Wise', 'Colon', 'Gill', 'Alvarado', 'Greer', 'Padilla', 'Simon', 'Waters', 'Nunez', 'Ballard', 'Schwartz', 'McBride', 'Houston', 'Christensen', 'Klein', 'Pratt', 'Briggs', 'Parsons', 'McLaughlin', 'Zimmerman', 'French', 'Buchanan', 'Moran', 'Copeland', 'Roy', 'Pittman', 'Brady', 'McCormick', 'Holloway', 'Brock', 'Poole', 'Frank', 'Logan', 'Owen', 'Bass', 'Marsh', 'Drake', 'Wong', 'Jefferson', 'Park', 'Morton', 'Abbott', 'Sparks', 'Patrick', 'Norton', 'Huff', 'Clayton', 'Massey', 'Lloyd', 'Figueroa', 'Carson', 'Bowers', 'Roberson', 'Barton', 'Tran', 'Lamb', 'Harrington', 'Casey', 'Boone', 'Cortez', 'Clarke', 'Mathis', 'Singleton', 'Wilkins', 'Cain', 'Bryan', 'Underwood', 'Hogan', 'McKenzie', 'Collier', 'Luna', 'Phelps', 'McGuire', 'Allison', 'Bridges', 'Wilkerson', 'Nash', 'Summers', 'Atkins'],
-                // Data taken from http://www.dati.gov.it/dataset/comune-di-firenze_0164 (first 1000)
-            "it": ["Acciai", "Aglietti", "Agostini", "Agresti", "Ahmed", "Aiazzi", "Albanese", "Alberti", "Alessi", "Alfani", "Alinari", "Alterini", "Amato", "Ammannati", "Ancillotti", "Andrei", "Andreini", "Andreoni", "Angeli", "Anichini", "Antonelli", "Antonini", "Arena", "Ariani", "Arnetoli", "Arrighi", "Baccani", "Baccetti", "Bacci", "Bacherini", "Badii", "Baggiani", "Baglioni", "Bagni", "Bagnoli", "Baldassini", "Baldi", "Baldini", "Ballerini", "Balli", "Ballini", "Balloni", "Bambi", "Banchi", "Bandinelli", "Bandini", "Bani", "Barbetti", "Barbieri", "Barchielli", "Bardazzi", "Bardelli", "Bardi", "Barducci", "Bargellini", "Bargiacchi", "Barni", "Baroncelli", "Baroncini", "Barone", "Baroni", "Baronti", "Bartalesi", "Bartoletti", "Bartoli", "Bartolini", "Bartoloni", "Bartolozzi", "Basagni", "Basile", "Bassi", "Batacchi", "Battaglia", "Battaglini", "Bausi", "Becagli", "Becattini", "Becchi", "Becucci", "Bellandi", "Bellesi", "Belli", "Bellini", "Bellucci", "Bencini", "Benedetti", "Benelli", "Beni", "Benini", "Bensi", "Benucci", "Benvenuti", "Berlincioni", "Bernacchioni", "Bernardi", "Bernardini", "Berni", "Bernini", "Bertelli", "Berti", "Bertini", "Bessi", "Betti", "Bettini", "Biagi", "Biagini", "Biagioni", "Biagiotti", "Biancalani", "Bianchi", "Bianchini", "Bianco", "Biffoli", "Bigazzi", "Bigi", "Biliotti", "Billi", "Binazzi", "Bindi", "Bini", "Biondi", "Bizzarri", "Bocci", "Bogani", "Bolognesi", "Bonaiuti", "Bonanni", "Bonciani", "Boncinelli", "Bondi", "Bonechi", "Bongini", "Boni", "Bonini", "Borchi", "Boretti", "Borghi", "Borghini", "Borgioli", "Borri", "Borselli", "Boschi", "Bottai", "Bracci", "Braccini", "Brandi", "Braschi", "Bravi", "Brazzini", "Breschi", "Brilli", "Brizzi", "Brogelli", "Brogi", "Brogioni", "Brunelli", "Brunetti", "Bruni", "Bruno", "Brunori", "Bruschi", "Bucci", "Bucciarelli", "Buccioni", "Bucelli", "Bulli", "Burberi", "Burchi", "Burgassi", "Burroni", "Bussotti", "Buti", "Caciolli", "Caiani", "Calabrese", "Calamai", "Calamandrei", "Caldini", "Calo'", "Calonaci", "Calosi", "Calvelli", "Cambi", "Camiciottoli", "Cammelli", "Cammilli", "Campolmi", "Cantini", "Capanni", "Capecchi", "Caponi", "Cappelletti", "Cappelli", "Cappellini", "Cappugi", "Capretti", "Caputo", "Carbone", "Carboni", "Cardini", "Carlesi", "Carletti", "Carli", "Caroti", "Carotti", "Carrai", "Carraresi", "Carta", "Caruso", "Casalini", "Casati", "Caselli", "Casini", "Castagnoli", "Castellani", "Castelli", "Castellucci", "Catalano", "Catarzi", "Catelani", "Cavaciocchi", "Cavallaro", "Cavallini", "Cavicchi", "Cavini", "Ceccarelli", "Ceccatelli", "Ceccherelli", "Ceccherini", "Cecchi", "Cecchini", "Cecconi", "Cei", "Cellai", "Celli", "Cellini", "Cencetti", "Ceni", "Cenni", "Cerbai", "Cesari", "Ceseri", "Checcacci", "Checchi", "Checcucci", "Cheli", "Chellini", "Chen", "Cheng", "Cherici", "Cherubini", "Chiaramonti", "Chiarantini", "Chiarelli", "Chiari", "Chiarini", "Chiarugi", "Chiavacci", "Chiesi", "Chimenti", "Chini", "Chirici", "Chiti", "Ciabatti", "Ciampi", "Cianchi", "Cianfanelli", "Cianferoni", "Ciani", "Ciapetti", "Ciappi", "Ciardi", "Ciatti", "Cicali", "Ciccone", "Cinelli", "Cini", "Ciobanu", "Ciolli", "Cioni", "Cipriani", "Cirillo", "Cirri", "Ciucchi", "Ciuffi", "Ciulli", "Ciullini", "Clemente", "Cocchi", "Cognome", "Coli", "Collini", "Colombo", "Colzi", "Comparini", "Conforti", "Consigli", "Conte", "Conti", "Contini", "Coppini", "Coppola", "Corsi", "Corsini", "Corti", "Cortini", "Cosi", "Costa", "Costantini", "Costantino", "Cozzi", "Cresci", "Crescioli", "Cresti", "Crini", "Curradi", "D'Agostino", "D'Alessandro", "D'Amico", "D'Angelo", "Daddi", "Dainelli", "Dallai", "Danti", "Davitti", "De Angelis", "De Luca", "De Marco", "De Rosa", "De Santis", "De Simone", "De Vita", "Degl'Innocenti", "Degli Innocenti", "Dei", "Del Lungo", "Del Re", "Di Marco", "Di Stefano", "Dini", "Diop", "Dobre", "Dolfi", "Donati", "Dondoli", "Dong", "Donnini", "Ducci", "Dumitru", "Ermini", "Esposito", "Evangelisti", "Fabbri", "Fabbrini", "Fabbrizzi", "Fabbroni", "Fabbrucci", "Fabiani", "Facchini", "Faggi", "Fagioli", "Failli", "Faini", "Falciani", "Falcini", "Falcone", "Fallani", "Falorni", "Falsini", "Falugiani", "Fancelli", "Fanelli", "Fanetti", "Fanfani", "Fani", "Fantappie'", "Fantechi", "Fanti", "Fantini", "Fantoni", "Farina", "Fattori", "Favilli", "Fedi", "Fei", "Ferrante", "Ferrara", "Ferrari", "Ferraro", "Ferretti", "Ferri", "Ferrini", "Ferroni", "Fiaschi", "Fibbi", "Fiesoli", "Filippi", "Filippini", "Fini", "Fioravanti", "Fiore", "Fiorentini", "Fiorini", "Fissi", "Focardi", "Foggi", "Fontana", "Fontanelli", "Fontani", "Forconi", "Formigli", "Forte", "Forti", "Fortini", "Fossati", "Fossi", "Francalanci", "Franceschi", "Franceschini", "Franchi", "Franchini", "Franci", "Francini", "Francioni", "Franco", "Frassineti", "Frati", "Fratini", "Frilli", "Frizzi", "Frosali", "Frosini", "Frullini", "Fusco", "Fusi", "Gabbrielli", "Gabellini", "Gagliardi", "Galanti", "Galardi", "Galeotti", "Galletti", "Galli", "Gallo", "Gallori", "Gambacciani", "Gargani", "Garofalo", "Garuglieri", "Gashi", "Gasperini", "Gatti", "Gelli", "Gensini", "Gentile", "Gentili", "Geri", "Gerini", "Gheri", "Ghini", "Giachetti", "Giachi", "Giacomelli", "Gianassi", "Giani", "Giannelli", "Giannetti", "Gianni", "Giannini", "Giannoni", "Giannotti", "Giannozzi", "Gigli", "Giordano", "Giorgetti", "Giorgi", "Giovacchini", "Giovannelli", "Giovannetti", "Giovannini", "Giovannoni", "Giuliani", "Giunti", "Giuntini", "Giusti", "Gonnelli", "Goretti", "Gori", "Gradi", "Gramigni", "Grassi", "Grasso", "Graziani", "Grazzini", "Greco", "Grifoni", "Grillo", "Grimaldi", "Grossi", "Gualtieri", "Guarducci", "Guarino", "Guarnieri", "Guasti", "Guerra", "Guerri", "Guerrini", "Guidi", "Guidotti", "He", "Hoxha", "Hu", "Huang", "Iandelli", "Ignesti", "Innocenti", "Jin", "La Rosa", "Lai", "Landi", "Landini", "Lanini", "Lapi", "Lapini", "Lari", "Lascialfari", "Lastrucci", "Latini", "Lazzeri", "Lazzerini", "Lelli", "Lenzi", "Leonardi", "Leoncini", "Leone", "Leoni", "Lepri", "Li", "Liao", "Lin", "Linari", "Lippi", "Lisi", "Livi", "Lombardi", "Lombardini", "Lombardo", "Longo", "Lopez", "Lorenzi", "Lorenzini", "Lorini", "Lotti", "Lu", "Lucchesi", "Lucherini", "Lunghi", "Lupi", "Madiai", "Maestrini", "Maffei", "Maggi", "Maggini", "Magherini", "Magini", "Magnani", "Magnelli", "Magni", "Magnolfi", "Magrini", "Malavolti", "Malevolti", "Manca", "Mancini", "Manetti", "Manfredi", "Mangani", "Mannelli", "Manni", "Mannini", "Mannucci", "Manuelli", "Manzini", "Marcelli", "Marchese", "Marchetti", "Marchi", "Marchiani", "Marchionni", "Marconi", "Marcucci", "Margheri", "Mari", "Mariani", "Marilli", "Marinai", "Marinari", "Marinelli", "Marini", "Marino", "Mariotti", "Marsili", "Martelli", "Martinelli", "Martini", "Martino", "Marzi", "Masi", "Masini", "Masoni", "Massai", "Materassi", "Mattei", "Matteini", "Matteucci", "Matteuzzi", "Mattioli", "Mattolini", "Matucci", "Mauro", "Mazzanti", "Mazzei", "Mazzetti", "Mazzi", "Mazzini", "Mazzocchi", "Mazzoli", "Mazzoni", "Mazzuoli", "Meacci", "Mecocci", "Meini", "Melani", "Mele", "Meli", "Mengoni", "Menichetti", "Meoni", "Merlini", "Messeri", "Messina", "Meucci", "Miccinesi", "Miceli", "Micheli", "Michelini", "Michelozzi", "Migliori", "Migliorini", "Milani", "Miniati", "Misuri", "Monaco", "Montagnani", "Montagni", "Montanari", "Montelatici", "Monti", "Montigiani", "Montini", "Morandi", "Morandini", "Morelli", "Moretti", "Morganti", "Mori", "Morini", "Moroni", "Morozzi", "Mugnai", "Mugnaini", "Mustafa", "Naldi", "Naldini", "Nannelli", "Nanni", "Nannini", "Nannucci", "Nardi", "Nardini", "Nardoni", "Natali", "Ndiaye", "Nencetti", "Nencini", "Nencioni", "Neri", "Nesi", "Nesti", "Niccolai", "Niccoli", "Niccolini", "Nigi", "Nistri", "Nocentini", "Noferini", "Novelli", "Nucci", "Nuti", "Nutini", "Oliva", "Olivieri", "Olmi", "Orlandi", "Orlandini", "Orlando", "Orsini", "Ortolani", "Ottanelli", "Pacciani", "Pace", "Paci", "Pacini", "Pagani", "Pagano", "Paggetti", "Pagliai", "Pagni", "Pagnini", "Paladini", "Palagi", "Palchetti", "Palloni", "Palmieri", "Palumbo", "Pampaloni", "Pancani", "Pandolfi", "Pandolfini", "Panerai", "Panichi", "Paoletti", "Paoli", "Paolini", "Papi", "Papini", "Papucci", "Parenti", "Parigi", "Parisi", "Parri", "Parrini", "Pasquini", "Passeri", "Pecchioli", "Pecorini", "Pellegrini", "Pepi", "Perini", "Perrone", "Peruzzi", "Pesci", "Pestelli", "Petri", "Petrini", "Petrucci", "Pettini", "Pezzati", "Pezzatini", "Piani", "Piazza", "Piazzesi", "Piazzini", "Piccardi", "Picchi", "Piccini", "Piccioli", "Pieraccini", "Pieraccioni", "Pieralli", "Pierattini", "Pieri", "Pierini", "Pieroni", "Pietrini", "Pini", "Pinna", "Pinto", "Pinzani", "Pinzauti", "Piras", "Pisani", "Pistolesi", "Poggesi", "Poggi", "Poggiali", "Poggiolini", "Poli", "Pollastri", "Porciani", "Pozzi", "Pratellesi", "Pratesi", "Prosperi", "Pruneti", "Pucci", "Puccini", "Puccioni", "Pugi", "Pugliese", "Puliti", "Querci", "Quercioli", "Raddi", "Radu", "Raffaelli", "Ragazzini", "Ranfagni", "Ranieri", "Rastrelli", "Raugei", "Raveggi", "Renai", "Renzi", "Rettori", "Ricci", "Ricciardi", "Ridi", "Ridolfi", "Rigacci", "Righi", "Righini", "Rinaldi", "Risaliti", "Ristori", "Rizzo", "Rocchi", "Rocchini", "Rogai", "Romagnoli", "Romanelli", "Romani", "Romano", "Romei", "Romeo", "Romiti", "Romoli", "Romolini", "Rontini", "Rosati", "Roselli", "Rosi", "Rossetti", "Rossi", "Rossini", "Rovai", "Ruggeri", "Ruggiero", "Russo", "Sabatini", "Saccardi", "Sacchetti", "Sacchi", "Sacco", "Salerno", "Salimbeni", "Salucci", "Salvadori", "Salvestrini", "Salvi", "Salvini", "Sanesi", "Sani", "Sanna", "Santi", "Santini", "Santoni", "Santoro", "Santucci", "Sardi", "Sarri", "Sarti", "Sassi", "Sbolci", "Scali", "Scarpelli", "Scarselli", "Scopetani", "Secci", "Selvi", "Senatori", "Senesi", "Serafini", "Sereni", "Serra", "Sestini", "Sguanci", "Sieni", "Signorini", "Silvestri", "Simoncini", "Simonetti", "Simoni", "Singh", "Sodi", "Soldi", "Somigli", "Sorbi", "Sorelli", "Sorrentino", "Sottili", "Spina", "Spinelli", "Staccioli", "Staderini", "Stefanelli", "Stefani", "Stefanini", "Stella", "Susini", "Tacchi", "Tacconi", "Taddei", "Tagliaferri", "Tamburini", "Tanganelli", "Tani", "Tanini", "Tapinassi", "Tarchi", "Tarchiani", "Targioni", "Tassi", "Tassini", "Tempesti", "Terzani", "Tesi", "Testa", "Testi", "Tilli", "Tinti", "Tirinnanzi", "Toccafondi", "Tofanari", "Tofani", "Tognaccini", "Tonelli", "Tonini", "Torelli", "Torrini", "Tosi", "Toti", "Tozzi", "Trambusti", "Trapani", "Tucci", "Turchi", "Ugolini", "Ulivi", "Valente", "Valenti", "Valentini", "Vangelisti", "Vanni", "Vannini", "Vannoni", "Vannozzi", "Vannucchi", "Vannucci", "Ventura", "Venturi", "Venturini", "Vestri", "Vettori", "Vichi", "Viciani", "Vieri", "Vigiani", "Vignoli", "Vignolini", "Vignozzi", "Villani", "Vinci", "Visani", "Vitale", "Vitali", "Viti", "Viviani", "Vivoli", "Volpe", "Volpi", "Wang", "Wu", "Xu", "Yang", "Ye", "Zagli", "Zani", "Zanieri", "Zanobini", "Zecchi", "Zetti", "Zhang", "Zheng", "Zhou", "Zhu", "Zingoni", "Zini", "Zoppi"],
+            en: ["Smith","Johnson","Williams","Jones","Brown","Davis","Miller","Wilson","Moore","Taylor","Anderson","Thomas","Jackson","White","Harris","Martin","Thompson","Garcia","Martinez","Robinson","Clark","Rodriguez","Lewis","Lee","Walker","Hall","Allen","Young","Hernandez","King","Wright","Lopez","Hill","Scott","Green","Adams","Baker","Gonzalez","Nelson","Carter","Mitchell","Perez","Roberts","Turner","Phillips","Campbell","Parker","Evans","Edwards","Collins","Stewart","Sanchez","Morris","Rogers","Reed","Cook","Morgan","Bell","Murphy","Bailey","Rivera","Cooper","Richardson","Cox","Howard","Ward","Torres","Peterson","Gray","Ramirez","James","Watson","Brooks","Kelly","Sanders","Price","Bennett","Wood","Barnes","Ross","Henderson","Coleman","Jenkins","Perry","Powell","Long","Patterson","Hughes","Flores","Washington","Butler","Simmons","Foster","Gonzales","Bryant","Alexander","Russell","Griffin","Diaz","Hayes","Myers","Ford","Hamilton","Graham","Sullivan","Wallace","Woods","Cole","West","Jordan","Owens","Reynolds","Fisher","Ellis","Harrison","Gibson","McDonald","Cruz","Marshall","Ortiz","Gomez","Murray","Freeman","Wells","Webb","Simpson","Stevens","Tucker","Porter","Hunter","Hicks","Crawford","Henry","Boyd","Mason","Morales","Kennedy","Warren","Dixon","Ramos","Reyes","Burns","Gordon","Shaw","Holmes","Rice","Robertson","Hunt","Black","Daniels","Palmer","Mills","Nichols","Grant","Knight","Ferguson","Rose","Stone","Hawkins","Dunn","Perkins","Hudson","Spencer","Gardner","Stephens","Payne","Pierce","Berry","Matthews","Arnold","Wagner","Willis","Ray","Watkins","Olson","Carroll","Duncan","Snyder","Hart","Cunningham","Bradley","Lane","Andrews","Ruiz","Harper","Fox","Riley","Armstrong","Carpenter","Weaver","Greene","Lawrence","Elliott","Chavez","Sims","Austin","Peters","Kelley","Franklin","Lawson","Fields","Gutierrez","Ryan","Schmidt","Carr","Vasquez","Castillo","Wheeler","Chapman","Oliver","Montgomery","Richards","Williamson","Johnston","Banks","Meyer","Bishop","McCoy","Howell","Alvarez","Morrison","Hansen","Fernandez","Garza","Harvey","Little","Burton","Stanley","Nguyen","George","Jacobs","Reid","Kim","Fuller","Lynch","Dean","Gilbert","Garrett","Romero","Welch","Larson","Frazier","Burke","Hanson","Day","Mendoza","Moreno","Bowman","Medina","Fowler","Brewer","Hoffman","Carlson","Silva","Pearson","Holland","Douglas","Fleming","Jensen","Vargas","Byrd","Davidson","Hopkins","May","Terry","Herrera","Wade","Soto","Walters","Curtis","Neal","Caldwell","Lowe","Jennings","Barnett","Graves","Jimenez","Horton","Shelton","Barrett","Obrien","Castro","Sutton","Gregory","McKinney","Lucas","Miles","Craig","Rodriquez","Chambers","Holt","Lambert","Fletcher","Watts","Bates","Hale","Rhodes","Pena","Beck","Newman","Haynes","McDaniel","Mendez","Bush","Vaughn","Parks","Dawson","Santiago","Norris","Hardy","Love","Steele","Curry","Powers","Schultz","Barker","Guzman","Page","Munoz","Ball","Keller","Chandler","Weber","Leonard","Walsh","Lyons","Ramsey","Wolfe","Schneider","Mullins","Benson","Sharp","Bowen","Daniel","Barber","Cummings","Hines","Baldwin","Griffith","Valdez","Hubbard","Salazar","Reeves","Warner","Stevenson","Burgess","Santos","Tate","Cross","Garner","Mann","Mack","Moss","Thornton","Dennis","McGee","Farmer","Delgado","Aguilar","Vega","Glover","Manning","Cohen","Harmon","Rodgers","Robbins","Newton","Todd","Blair","Higgins","Ingram","Reese","Cannon","Strickland","Townsend","Potter","Goodwin","Walton","Rowe","Hampton","Ortega","Patton","Swanson","Joseph","Francis","Goodman","Maldonado","Yates","Becker","Erickson","Hodges","Rios","Conner","Adkins","Webster","Norman","Malone","Hammond","Flowers","Cobb","Moody","Quinn","Blake","Maxwell","Pope","Floyd","Osborne","Paul","McCarthy","Guerrero","Lindsey","Estrada","Sandoval","Gibbs","Tyler","Gross","Fitzgerald","Stokes","Doyle","Sherman","Saunders","Wise","Colon","Gill","Alvarado","Greer","Padilla","Simon","Waters","Nunez","Ballard","Schwartz","McBride","Houston","Christensen","Klein","Pratt","Briggs","Parsons","McLaughlin","Zimmerman","French","Buchanan","Moran","Copeland","Roy","Pittman","Brady","McCormick","Holloway","Brock","Poole","Frank","Logan","Owen","Bass","Marsh","Drake","Wong","Jefferson","Park","Morton","Abbott","Sparks","Patrick","Norton","Huff","Clayton","Massey","Lloyd","Figueroa","Carson","Bowers","Roberson","Barton","Tran","Lamb","Harrington","Casey","Boone","Cortez","Clarke","Mathis","Singleton","Wilkins","Cain","Bryan","Underwood","Hogan","McKenzie","Collier","Luna","Phelps","McGuire","Allison","Bridges","Wilkerson","Nash","Summers","Atkins"],
+            // Data taken from http://www.dati.gov.it/dataset/comune-di-firenze_0164 (first 1000)
+            it: ["Acciai","Aglietti","Agostini","Agresti","Ahmed","Aiazzi","Albanese","Alberti","Alessi","Alfani","Alinari","Alterini","Amato","Ammannati","Ancillotti","Andrei","Andreini","Andreoni","Angeli","Anichini","Antonelli","Antonini","Arena","Ariani","Arnetoli","Arrighi","Baccani","Baccetti","Bacci","Bacherini","Badii","Baggiani","Baglioni","Bagni","Bagnoli","Baldassini","Baldi","Baldini","Ballerini","Balli","Ballini","Balloni","Bambi","Banchi","Bandinelli","Bandini","Bani","Barbetti","Barbieri","Barchielli","Bardazzi","Bardelli","Bardi","Barducci","Bargellini","Bargiacchi","Barni","Baroncelli","Baroncini","Barone","Baroni","Baronti","Bartalesi","Bartoletti","Bartoli","Bartolini","Bartoloni","Bartolozzi","Basagni","Basile","Bassi","Batacchi","Battaglia","Battaglini","Bausi","Becagli","Becattini","Becchi","Becucci","Bellandi","Bellesi","Belli","Bellini","Bellucci","Bencini","Benedetti","Benelli","Beni","Benini","Bensi","Benucci","Benvenuti","Berlincioni","Bernacchioni","Bernardi","Bernardini","Berni","Bernini","Bertelli","Berti","Bertini","Bessi","Betti","Bettini","Biagi","Biagini","Biagioni","Biagiotti","Biancalani","Bianchi","Bianchini","Bianco","Biffoli","Bigazzi","Bigi","Biliotti","Billi","Binazzi","Bindi","Bini","Biondi","Bizzarri","Bocci","Bogani","Bolognesi","Bonaiuti","Bonanni","Bonciani","Boncinelli","Bondi","Bonechi","Bongini","Boni","Bonini","Borchi","Boretti","Borghi","Borghini","Borgioli","Borri","Borselli","Boschi","Bottai","Bracci","Braccini","Brandi","Braschi","Bravi","Brazzini","Breschi","Brilli","Brizzi","Brogelli","Brogi","Brogioni","Brunelli","Brunetti","Bruni","Bruno","Brunori","Bruschi","Bucci","Bucciarelli","Buccioni","Bucelli","Bulli","Burberi","Burchi","Burgassi","Burroni","Bussotti","Buti","Caciolli","Caiani","Calabrese","Calamai","Calamandrei","Caldini","Calo'","Calonaci","Calosi","Calvelli","Cambi","Camiciottoli","Cammelli","Cammilli","Campolmi","Cantini","Capanni","Capecchi","Caponi","Cappelletti","Cappelli","Cappellini","Cappugi","Capretti","Caputo","Carbone","Carboni","Cardini","Carlesi","Carletti","Carli","Caroti","Carotti","Carrai","Carraresi","Carta","Caruso","Casalini","Casati","Caselli","Casini","Castagnoli","Castellani","Castelli","Castellucci","Catalano","Catarzi","Catelani","Cavaciocchi","Cavallaro","Cavallini","Cavicchi","Cavini","Ceccarelli","Ceccatelli","Ceccherelli","Ceccherini","Cecchi","Cecchini","Cecconi","Cei","Cellai","Celli","Cellini","Cencetti","Ceni","Cenni","Cerbai","Cesari","Ceseri","Checcacci","Checchi","Checcucci","Cheli","Chellini","Chen","Cheng","Cherici","Cherubini","Chiaramonti","Chiarantini","Chiarelli","Chiari","Chiarini","Chiarugi","Chiavacci","Chiesi","Chimenti","Chini","Chirici","Chiti","Ciabatti","Ciampi","Cianchi","Cianfanelli","Cianferoni","Ciani","Ciapetti","Ciappi","Ciardi","Ciatti","Cicali","Ciccone","Cinelli","Cini","Ciobanu","Ciolli","Cioni","Cipriani","Cirillo","Cirri","Ciucchi","Ciuffi","Ciulli","Ciullini","Clemente","Cocchi","Cognome","Coli","Collini","Colombo","Colzi","Comparini","Conforti","Consigli","Conte","Conti","Contini","Coppini","Coppola","Corsi","Corsini","Corti","Cortini","Cosi","Costa","Costantini","Costantino","Cozzi","Cresci","Crescioli","Cresti","Crini","Curradi","D'Agostino","D'Alessandro","D'Amico","D'Angelo","Daddi","Dainelli","Dallai","Danti","Davitti","De Angelis","De Luca","De Marco","De Rosa","De Santis","De Simone","De Vita","Degl'Innocenti","Degli Innocenti","Dei","Del Lungo","Del Re","Di Marco","Di Stefano","Dini","Diop","Dobre","Dolfi","Donati","Dondoli","Dong","Donnini","Ducci","Dumitru","Ermini","Esposito","Evangelisti","Fabbri","Fabbrini","Fabbrizzi","Fabbroni","Fabbrucci","Fabiani","Facchini","Faggi","Fagioli","Failli","Faini","Falciani","Falcini","Falcone","Fallani","Falorni","Falsini","Falugiani","Fancelli","Fanelli","Fanetti","Fanfani","Fani","Fantappie'","Fantechi","Fanti","Fantini","Fantoni","Farina","Fattori","Favilli","Fedi","Fei","Ferrante","Ferrara","Ferrari","Ferraro","Ferretti","Ferri","Ferrini","Ferroni","Fiaschi","Fibbi","Fiesoli","Filippi","Filippini","Fini","Fioravanti","Fiore","Fiorentini","Fiorini","Fissi","Focardi","Foggi","Fontana","Fontanelli","Fontani","Forconi","Formigli","Forte","Forti","Fortini","Fossati","Fossi","Francalanci","Franceschi","Franceschini","Franchi","Franchini","Franci","Francini","Francioni","Franco","Frassineti","Frati","Fratini","Frilli","Frizzi","Frosali","Frosini","Frullini","Fusco","Fusi","Gabbrielli","Gabellini","Gagliardi","Galanti","Galardi","Galeotti","Galletti","Galli","Gallo","Gallori","Gambacciani","Gargani","Garofalo","Garuglieri","Gashi","Gasperini","Gatti","Gelli","Gensini","Gentile","Gentili","Geri","Gerini","Gheri","Ghini","Giachetti","Giachi","Giacomelli","Gianassi","Giani","Giannelli","Giannetti","Gianni","Giannini","Giannoni","Giannotti","Giannozzi","Gigli","Giordano","Giorgetti","Giorgi","Giovacchini","Giovannelli","Giovannetti","Giovannini","Giovannoni","Giuliani","Giunti","Giuntini","Giusti","Gonnelli","Goretti","Gori","Gradi","Gramigni","Grassi","Grasso","Graziani","Grazzini","Greco","Grifoni","Grillo","Grimaldi","Grossi","Gualtieri","Guarducci","Guarino","Guarnieri","Guasti","Guerra","Guerri","Guerrini","Guidi","Guidotti","He","Hoxha","Hu","Huang","Iandelli","Ignesti","Innocenti","Jin","La Rosa","Lai","Landi","Landini","Lanini","Lapi","Lapini","Lari","Lascialfari","Lastrucci","Latini","Lazzeri","Lazzerini","Lelli","Lenzi","Leonardi","Leoncini","Leone","Leoni","Lepri","Li","Liao","Lin","Linari","Lippi","Lisi","Livi","Lombardi","Lombardini","Lombardo","Longo","Lopez","Lorenzi","Lorenzini","Lorini","Lotti","Lu","Lucchesi","Lucherini","Lunghi","Lupi","Madiai","Maestrini","Maffei","Maggi","Maggini","Magherini","Magini","Magnani","Magnelli","Magni","Magnolfi","Magrini","Malavolti","Malevolti","Manca","Mancini","Manetti","Manfredi","Mangani","Mannelli","Manni","Mannini","Mannucci","Manuelli","Manzini","Marcelli","Marchese","Marchetti","Marchi","Marchiani","Marchionni","Marconi","Marcucci","Margheri","Mari","Mariani","Marilli","Marinai","Marinari","Marinelli","Marini","Marino","Mariotti","Marsili","Martelli","Martinelli","Martini","Martino","Marzi","Masi","Masini","Masoni","Massai","Materassi","Mattei","Matteini","Matteucci","Matteuzzi","Mattioli","Mattolini","Matucci","Mauro","Mazzanti","Mazzei","Mazzetti","Mazzi","Mazzini","Mazzocchi","Mazzoli","Mazzoni","Mazzuoli","Meacci","Mecocci","Meini","Melani","Mele","Meli","Mengoni","Menichetti","Meoni","Merlini","Messeri","Messina","Meucci","Miccinesi","Miceli","Micheli","Michelini","Michelozzi","Migliori","Migliorini","Milani","Miniati","Misuri","Monaco","Montagnani","Montagni","Montanari","Montelatici","Monti","Montigiani","Montini","Morandi","Morandini","Morelli","Moretti","Morganti","Mori","Morini","Moroni","Morozzi","Mugnai","Mugnaini","Mustafa","Naldi","Naldini","Nannelli","Nanni","Nannini","Nannucci","Nardi","Nardini","Nardoni","Natali","Ndiaye","Nencetti","Nencini","Nencioni","Neri","Nesi","Nesti","Niccolai","Niccoli","Niccolini","Nigi","Nistri","Nocentini","Noferini","Novelli","Nucci","Nuti","Nutini","Oliva","Olivieri","Olmi","Orlandi","Orlandini","Orlando","Orsini","Ortolani","Ottanelli","Pacciani","Pace","Paci","Pacini","Pagani","Pagano","Paggetti","Pagliai","Pagni","Pagnini","Paladini","Palagi","Palchetti","Palloni","Palmieri","Palumbo","Pampaloni","Pancani","Pandolfi","Pandolfini","Panerai","Panichi","Paoletti","Paoli","Paolini","Papi","Papini","Papucci","Parenti","Parigi","Parisi","Parri","Parrini","Pasquini","Passeri","Pecchioli","Pecorini","Pellegrini","Pepi","Perini","Perrone","Peruzzi","Pesci","Pestelli","Petri","Petrini","Petrucci","Pettini","Pezzati","Pezzatini","Piani","Piazza","Piazzesi","Piazzini","Piccardi","Picchi","Piccini","Piccioli","Pieraccini","Pieraccioni","Pieralli","Pierattini","Pieri","Pierini","Pieroni","Pietrini","Pini","Pinna","Pinto","Pinzani","Pinzauti","Piras","Pisani","Pistolesi","Poggesi","Poggi","Poggiali","Poggiolini","Poli","Pollastri","Porciani","Pozzi","Pratellesi","Pratesi","Prosperi","Pruneti","Pucci","Puccini","Puccioni","Pugi","Pugliese","Puliti","Querci","Quercioli","Raddi","Radu","Raffaelli","Ragazzini","Ranfagni","Ranieri","Rastrelli","Raugei","Raveggi","Renai","Renzi","Rettori","Ricci","Ricciardi","Ridi","Ridolfi","Rigacci","Righi","Righini","Rinaldi","Risaliti","Ristori","Rizzo","Rocchi","Rocchini","Rogai","Romagnoli","Romanelli","Romani","Romano","Romei","Romeo","Romiti","Romoli","Romolini","Rontini","Rosati","Roselli","Rosi","Rossetti","Rossi","Rossini","Rovai","Ruggeri","Ruggiero","Russo","Sabatini","Saccardi","Sacchetti","Sacchi","Sacco","Salerno","Salimbeni","Salucci","Salvadori","Salvestrini","Salvi","Salvini","Sanesi","Sani","Sanna","Santi","Santini","Santoni","Santoro","Santucci","Sardi","Sarri","Sarti","Sassi","Sbolci","Scali","Scarpelli","Scarselli","Scopetani","Secci","Selvi","Senatori","Senesi","Serafini","Sereni","Serra","Sestini","Sguanci","Sieni","Signorini","Silvestri","Simoncini","Simonetti","Simoni","Singh","Sodi","Soldi","Somigli","Sorbi","Sorelli","Sorrentino","Sottili","Spina","Spinelli","Staccioli","Staderini","Stefanelli","Stefani","Stefanini","Stella","Susini","Tacchi","Tacconi","Taddei","Tagliaferri","Tamburini","Tanganelli","Tani","Tanini","Tapinassi","Tarchi","Tarchiani","Targioni","Tassi","Tassini","Tempesti","Terzani","Tesi","Testa","Testi","Tilli","Tinti","Tirinnanzi","Toccafondi","Tofanari","Tofani","Tognaccini","Tonelli","Tonini","Torelli","Torrini","Tosi","Toti","Tozzi","Trambusti","Trapani","Tucci","Turchi","Ugolini","Ulivi","Valente","Valenti","Valentini","Vangelisti","Vanni","Vannini","Vannoni","Vannozzi","Vannucchi","Vannucci","Ventura","Venturi","Venturini","Vestri","Vettori","Vichi","Viciani","Vieri","Vigiani","Vignoli","Vignolini","Vignozzi","Villani","Vinci","Visani","Vitale","Vitali","Viti","Viviani","Vivoli","Volpe","Volpi","Wang","Wu","Xu","Yang","Ye","Zagli","Zani","Zanieri","Zanobini","Zecchi","Zetti","Zhang","Zheng","Zhou","Zhu","Zingoni","Zini","Zoppi"],
             // http://www.voornamelijk.nl/meest-voorkomende-achternamen-in-nederland-en-amsterdam/
-            "nl":["Albers", "Alblas", "Appelman", "Baars", "Baas", "Bakker", "Blank", "Bleeker", "Blok", "Blom", "Boer", "Boers", "Boldewijn", "Boon", "Boot", "Bos", "Bosch", "Bosma", "Bosman", "Bouma", "Bouman", "Bouwman", "Brands", "Brouwer", "Burger", "Buijs", "Buitenhuis", "Ceder", "Cohen", "Dekker", "Dekkers", "Dijkman", "Dijkstra", "Driessen", "Drost", "Engel", "Evers", "Faber", "Franke", "Gerritsen", "Goedhart", "Goossens", "Groen", "Groenenberg", "Groot", "Haan", "Hart", "Heemskerk", "Hendriks", "Hermans", "Hoekstra", "Hofman", "Hopman", "Huisman", "Jacobs", "Jansen", "Janssen", "Jonker", "Jaspers", "Keijzer", "Klaassen", "Klein", "Koek", "Koenders", "Kok", "Kool", "Koopman", "Koopmans", "Koning", "Koster", "Kramer", "Kroon", "Kuijpers", "Kuiper", "Kuipers", "Kurt", "Koster", "Kwakman", "Los", "Lubbers", "Maas", "Markus", "Martens", "Meijer", "Mol", "Molenaar", "Mulder", "Nieuwenhuis", "Peeters", "Peters", "Pengel", "Pieters", "Pool", "Post", "Postma", "Prins", "Pronk", "Reijnders", "Rietveld", "Roest", "Roos", "Sanders", "Schaap", "Scheffer", "Schenk", "Schilder", "Schipper", "Schmidt", "Scholten", "Schouten", "Schut", "Schutte", "Schuurman", "Simons", "Smeets", "Smit", "Smits", "Snel", "Swinkels", "Tas", "Terpstra", "Timmermans", "Tol", "Tromp", "Troost", "Valk", "Veenstra", "Veldkamp", "Verbeek", "Verheul", "Verhoeven", "Vermeer", "Vermeulen", "Verweij", "Vink", "Visser", "Voorn", "Vos", "Wagenaar", "Wiersema", "Willems", "Willemsen", "Witteveen", "Wolff", "Wolters", "Zijlstra", "Zwart", "de Beer", "de Boer", "de Bruijn", "de Bruin", "de Graaf", "de Groot", "de Haan", "de Haas", "de Jager", "de Jong", "de Jonge", "de Koning", "de Lange", "de Leeuw", "de Ridder", "de Rooij", "de Ruiter", "de Vos", "de Vries", "de Waal", "de Wit", "de Zwart", "van Beek", "van Boven", "van Dam", "van Dijk", "van Dongen", "van Doorn", "van Egmond", "van Eijk", "van Es", "van Gelder", "van Gelderen", "van Houten", "van Hulst", "van Kempen", "van Kesteren", "van Leeuwen", "van Loon", "van Mill", "van Noord", "van Ommen", "van Ommeren", "van Oosten", "van Oostveen", "van Rijn", "van Schaik", "van Veen", "van Vliet", "van Wijk", "van Wijngaarden", "van den Poel", "van de Pol", "van den Ploeg", "van de Ven", "van den Berg", "van den Bosch", "van den Brink", "van den Broek", "van den Heuvel", "van der Heijden", "van der Horst", "van der Hulst", "van der Kroon", "van der Laan", "van der Linden", "van der Meer", "van der Meij", "van der Meulen", "van der Molen", "van der Sluis", "van der Spek", "van der Veen", "van der Velde", "van der Velden", "van der Vliet", "van der Wal"],
+            nl: ["Albers","Alblas","Appelman","Baars","Baas","Bakker","Blank","Bleeker","Blok","Blom","Boer","Boers","Boldewijn","Boon","Boot","Bos","Bosch","Bosma","Bosman","Bouma","Bouman","Bouwman","Brands","Brouwer","Burger","Buijs","Buitenhuis","Ceder","Cohen","Dekker","Dekkers","Dijkman","Dijkstra","Driessen","Drost","Engel","Evers","Faber","Franke","Gerritsen","Goedhart","Goossens","Groen","Groenenberg","Groot","Haan","Hart","Heemskerk","Hendriks","Hermans","Hoekstra","Hofman","Hopman","Huisman","Jacobs","Jansen","Janssen","Jonker","Jaspers","Keijzer","Klaassen","Klein","Koek","Koenders","Kok","Kool","Koopman","Koopmans","Koning","Koster","Kramer","Kroon","Kuijpers","Kuiper","Kuipers","Kurt","Koster","Kwakman","Los","Lubbers","Maas","Markus","Martens","Meijer","Mol","Molenaar","Mulder","Nieuwenhuis","Peeters","Peters","Pengel","Pieters","Pool","Post","Postma","Prins","Pronk","Reijnders","Rietveld","Roest","Roos","Sanders","Schaap","Scheffer","Schenk","Schilder","Schipper","Schmidt","Scholten","Schouten","Schut","Schutte","Schuurman","Simons","Smeets","Smit","Smits","Snel","Swinkels","Tas","Terpstra","Timmermans","Tol","Tromp","Troost","Valk","Veenstra","Veldkamp","Verbeek","Verheul","Verhoeven","Vermeer","Vermeulen","Verweij","Vink","Visser","Voorn","Vos","Wagenaar","Wiersema","Willems","Willemsen","Witteveen","Wolff","Wolters","Zijlstra","Zwart","de Beer","de Boer","de Bruijn","de Bruin","de Graaf","de Groot","de Haan","de Haas","de Jager","de Jong","de Jonge","de Koning","de Lange","de Leeuw","de Ridder","de Rooij","de Ruiter","de Vos","de Vries","de Waal","de Wit","de Zwart","van Beek","van Boven","van Dam","van Dijk","van Dongen","van Doorn","van Egmond","van Eijk","van Es","van Gelder","van Gelderen","van Houten","van Hulst","van Kempen","van Kesteren","van Leeuwen","van Loon","van Mill","van Noord","van Ommen","van Ommeren","van Oosten","van Oostveen","van Rijn","van Schaik","van Veen","van Vliet","van Wijk","van Wijngaarden","van den Poel","van de Pol","van den Ploeg","van de Ven","van den Berg","van den Bosch","van den Brink","van den Broek","van den Heuvel","van der Heijden","van der Horst","van der Hulst","van der Kroon","van der Laan","van der Linden","van der Meer","van der Meij","van der Meulen","van der Molen","van der Sluis","van der Spek","van der Veen","van der Velde","van der Velden","van der Vliet","van der Wal"],
             // https://surnames.behindthename.com/top/lists/england-wales/1991
-            "uk":["Smith","Jones","Williams","Taylor","Brown","Davies","Evans","Wilson","Thomas","Johnson","Roberts","Robinson","Thompson","Wright","Walker","White","Edwards","Hughes","Green","Hall","Lewis","Harris","Clarke","Patel","Jackson","Wood","Turner","Martin","Cooper","Hill","Ward","Morris","Moore","Clark","Lee","King","Baker","Harrison","Morgan","Allen","James","Scott","Phillips","Watson","Davis","Parker","Price","Bennett","Young","Griffiths","Mitchell","Kelly","Cook","Carter","Richardson","Bailey","Collins","Bell","Shaw","Murphy","Miller","Cox","Richards","Khan","Marshall","Anderson","Simpson","Ellis","Adams","Singh","Begum","Wilkinson","Foster","Chapman","Powell","Webb","Rogers","Gray","Mason","Ali","Hunt","Hussain","Campbell","Matthews","Owen","Palmer","Holmes","Mills","Barnes","Knight","Lloyd","Butler","Russell","Barker","Fisher","Stevens","Jenkins","Murray","Dixon","Harvey","Graham","Pearson","Ahmed","Fletcher","Walsh","Kaur","Gibson","Howard","Andrews","Stewart","Elliott","Reynolds","Saunders","Payne","Fox","Ford","Pearce","Day","Brooks","West","Lawrence","Cole","Atkinson","Bradley","Spencer","Gill","Dawson","Ball","Burton","O'brien","Watts","Rose","Booth","Perry","Ryan","Grant","Wells","Armstrong","Francis","Rees","Hayes","Hart","Hudson","Newman","Barrett","Webster","Hunter","Gregory","Carr","Lowe","Page","Marsh","Riley","Dunn","Woods","Parsons","Berry","Stone","Reid","Holland","Hawkins","Harding","Porter","Robertson","Newton","Oliver","Reed","Kennedy","Williamson","Bird","Gardner","Shah","Dean","Lane","Cooke","Bates","Henderson","Parry","Burgess","Bishop","Walton","Burns","Nicholson","Shepherd","Ross","Cross","Long","Freeman","Warren","Nicholls","Hamilton","Byrne","Sutton","Mcdonald","Yates","Hodgson","Robson","Curtis","Hopkins","O'connor","Harper","Coleman","Watkins","Moss","Mccarthy","Chambers","O'neill","Griffin","Sharp","Hardy","Wheeler","Potter","Osborne","Johnston","Gordon","Doyle","Wallace","George","Jordan","Hutchinson","Rowe","Burke","May","Pritchard","Gilbert","Willis","Higgins","Read","Miles","Stevenson","Stephenson","Hammond","Arnold","Buckley","Walters","Hewitt","Barber","Nelson","Slater","Austin","Sullivan","Whitehead","Mann","Frost","Lambert","Stephens","Blake","Akhtar","Lynch","Goodwin","Barton","Woodward","Thomson","Cunningham","Quinn","Barnett","Baxter","Bibi","Clayton","Nash","Greenwood","Jennings","Holt","Kemp","Poole","Gallagher","Bond","Stokes","Tucker","Davidson","Fowler","Heath","Norman","Middleton","Lawson","Banks","French","Stanley","Jarvis","Gibbs","Ferguson","Hayward","Carroll","Douglas","Dickinson","Todd","Barlow","Peters","Lucas","Knowles","Hartley","Miah","Simmons","Morton","Alexander","Field","Morrison","Norris","Townsend","Preston","Hancock","Thornton","Baldwin","Burrows","Briggs","Parkinson","Reeves","Macdonald","Lamb","Black","Abbott","Sanders","Thorpe","Holden","Tomlinson","Perkins","Ashton","Rhodes","Fuller","Howe","Bryant","Vaughan","Dale","Davey","Weston","Bartlett","Whittaker","Davison","Kent","Skinner","Birch","Morley","Daniels","Glover","Howell","Cartwright","Pugh","Humphreys","Goddard","Brennan","Wall","Kirby","Bowen","Savage","Bull","Wong","Dobson","Smart","Wilkins","Kirk","Fraser","Duffy","Hicks","Patterson","Bradshaw","Little","Archer","Warner","Waters","O'sullivan","Farrell","Brookes","Atkins","Kay","Dodd","Bentley","Flynn","John","Schofield","Short","Haynes","Wade","Butcher","Henry","Sanderson","Crawford","Sheppard","Bolton","Coates","Giles","Gould","Houghton","Gibbons","Pratt","Manning","Law","Hooper","Noble","Dyer","Rahman","Clements","Moran","Sykes","Chan","Doherty","Connolly","Joyce","Franklin","Hobbs","Coles","Herbert","Steele","Kerr","Leach","Winter","Owens","Duncan","Naylor","Fleming","Horton","Finch","Fitzgerald","Randall","Carpenter","Marsden","Browne","Garner","Pickering","Hale","Dennis","Vincent","Chadwick","Chandler","Sharpe","Nolan","Lyons","Hurst","Collier","Peacock","Howarth","Faulkner","Rice","Pollard","Welch","Norton","Gough","Sinclair","Blackburn","Bryan","Conway","Power","Cameron","Daly","Allan","Hanson","Gardiner","Boyle","Myers","Turnbull","Wallis","Mahmood","Sims","Swift","Iqbal","Pope","Brady","Chamberlain","Rowley","Tyler","Farmer","Metcalfe","Hilton","Godfrey","Holloway","Parkin","Bray","Talbot","Donnelly","Nixon","Charlton","Benson","Whitehouse","Barry","Hope","Lord","North","Storey","Connor","Potts","Bevan","Hargreaves","Mclean","Mistry","Bruce","Howells","Hyde","Parkes","Wyatt","Fry","Lees","O'donnell","Craig","Forster","Mckenzie","Humphries","Mellor","Carey","Ingram","Summers","Leonard"],
+            uk: ["Smith","Jones","Williams","Taylor","Brown","Davies","Evans","Wilson","Thomas","Johnson","Roberts","Robinson","Thompson","Wright","Walker","White","Edwards","Hughes","Green","Hall","Lewis","Harris","Clarke","Patel","Jackson","Wood","Turner","Martin","Cooper","Hill","Ward","Morris","Moore","Clark","Lee","King","Baker","Harrison","Morgan","Allen","James","Scott","Phillips","Watson","Davis","Parker","Price","Bennett","Young","Griffiths","Mitchell","Kelly","Cook","Carter","Richardson","Bailey","Collins","Bell","Shaw","Murphy","Miller","Cox","Richards","Khan","Marshall","Anderson","Simpson","Ellis","Adams","Singh","Begum","Wilkinson","Foster","Chapman","Powell","Webb","Rogers","Gray","Mason","Ali","Hunt","Hussain","Campbell","Matthews","Owen","Palmer","Holmes","Mills","Barnes","Knight","Lloyd","Butler","Russell","Barker","Fisher","Stevens","Jenkins","Murray","Dixon","Harvey","Graham","Pearson","Ahmed","Fletcher","Walsh","Kaur","Gibson","Howard","Andrews","Stewart","Elliott","Reynolds","Saunders","Payne","Fox","Ford","Pearce","Day","Brooks","West","Lawrence","Cole","Atkinson","Bradley","Spencer","Gill","Dawson","Ball","Burton","O'brien","Watts","Rose","Booth","Perry","Ryan","Grant","Wells","Armstrong","Francis","Rees","Hayes","Hart","Hudson","Newman","Barrett","Webster","Hunter","Gregory","Carr","Lowe","Page","Marsh","Riley","Dunn","Woods","Parsons","Berry","Stone","Reid","Holland","Hawkins","Harding","Porter","Robertson","Newton","Oliver","Reed","Kennedy","Williamson","Bird","Gardner","Shah","Dean","Lane","Cooke","Bates","Henderson","Parry","Burgess","Bishop","Walton","Burns","Nicholson","Shepherd","Ross","Cross","Long","Freeman","Warren","Nicholls","Hamilton","Byrne","Sutton","Mcdonald","Yates","Hodgson","Robson","Curtis","Hopkins","O'connor","Harper","Coleman","Watkins","Moss","Mccarthy","Chambers","O'neill","Griffin","Sharp","Hardy","Wheeler","Potter","Osborne","Johnston","Gordon","Doyle","Wallace","George","Jordan","Hutchinson","Rowe","Burke","May","Pritchard","Gilbert","Willis","Higgins","Read","Miles","Stevenson","Stephenson","Hammond","Arnold","Buckley","Walters","Hewitt","Barber","Nelson","Slater","Austin","Sullivan","Whitehead","Mann","Frost","Lambert","Stephens","Blake","Akhtar","Lynch","Goodwin","Barton","Woodward","Thomson","Cunningham","Quinn","Barnett","Baxter","Bibi","Clayton","Nash","Greenwood","Jennings","Holt","Kemp","Poole","Gallagher","Bond","Stokes","Tucker","Davidson","Fowler","Heath","Norman","Middleton","Lawson","Banks","French","Stanley","Jarvis","Gibbs","Ferguson","Hayward","Carroll","Douglas","Dickinson","Todd","Barlow","Peters","Lucas","Knowles","Hartley","Miah","Simmons","Morton","Alexander","Field","Morrison","Norris","Townsend","Preston","Hancock","Thornton","Baldwin","Burrows","Briggs","Parkinson","Reeves","Macdonald","Lamb","Black","Abbott","Sanders","Thorpe","Holden","Tomlinson","Perkins","Ashton","Rhodes","Fuller","Howe","Bryant","Vaughan","Dale","Davey","Weston","Bartlett","Whittaker","Davison","Kent","Skinner","Birch","Morley","Daniels","Glover","Howell","Cartwright","Pugh","Humphreys","Goddard","Brennan","Wall","Kirby","Bowen","Savage","Bull","Wong","Dobson","Smart","Wilkins","Kirk","Fraser","Duffy","Hicks","Patterson","Bradshaw","Little","Archer","Warner","Waters","O'sullivan","Farrell","Brookes","Atkins","Kay","Dodd","Bentley","Flynn","John","Schofield","Short","Haynes","Wade","Butcher","Henry","Sanderson","Crawford","Sheppard","Bolton","Coates","Giles","Gould","Houghton","Gibbons","Pratt","Manning","Law","Hooper","Noble","Dyer","Rahman","Clements","Moran","Sykes","Chan","Doherty","Connolly","Joyce","Franklin","Hobbs","Coles","Herbert","Steele","Kerr","Leach","Winter","Owens","Duncan","Naylor","Fleming","Horton","Finch","Fitzgerald","Randall","Carpenter","Marsden","Browne","Garner","Pickering","Hale","Dennis","Vincent","Chadwick","Chandler","Sharpe","Nolan","Lyons","Hurst","Collier","Peacock","Howarth","Faulkner","Rice","Pollard","Welch","Norton","Gough","Sinclair","Blackburn","Bryan","Conway","Power","Cameron","Daly","Allan","Hanson","Gardiner","Boyle","Myers","Turnbull","Wallis","Mahmood","Sims","Swift","Iqbal","Pope","Brady","Chamberlain","Rowley","Tyler","Farmer","Metcalfe","Hilton","Godfrey","Holloway","Parkin","Bray","Talbot","Donnelly","Nixon","Charlton","Benson","Whitehouse","Barry","Hope","Lord","North","Storey","Connor","Potts","Bevan","Hargreaves","Mclean","Mistry","Bruce","Howells","Hyde","Parkes","Wyatt","Fry","Lees","O'donnell","Craig","Forster","Mckenzie","Humphries","Mellor","Carey","Ingram","Summers","Leonard"],
             // https://surnames.behindthename.com/top/lists/germany/2017
-            "de": ["Müller","Schmidt","Schneider","Fischer","Weber","Meyer","Wagner","Becker","Schulz","Hoffmann","Schäfer","Koch","Bauer","Richter","Klein","Wolf","Schröder","Neumann","Schwarz","Zimmermann","Braun","Krüger","Hofmann","Hartmann","Lange","Schmitt","Werner","Schmitz","Krause","Meier","Lehmann","Schmid","Schulze","Maier","Köhler","Herrmann","König","Walter","Mayer","Huber","Kaiser","Fuchs","Peters","Lang","Scholz","Möller","Weiß","Jung","Hahn","Schubert","Vogel","Friedrich","Keller","Günther","Frank","Berger","Winkler","Roth","Beck","Lorenz","Baumann","Franke","Albrecht","Schuster","Simon","Ludwig","Böhm","Winter","Kraus","Martin","Schumacher","Krämer","Vogt","Stein","Jäger","Otto","Sommer","Groß","Seidel","Heinrich","Brandt","Haas","Schreiber","Graf","Schulte","Dietrich","Ziegler","Kuhn","Kühn","Pohl","Engel","Horn","Busch","Bergmann","Thomas","Voigt","Sauer","Arnold","Wolff","Pfeiffer"],
+            de: ["Müller","Schmidt","Schneider","Fischer","Weber","Meyer","Wagner","Becker","Schulz","Hoffmann","Schäfer","Koch","Bauer","Richter","Klein","Wolf","Schröder","Neumann","Schwarz","Zimmermann","Braun","Krüger","Hofmann","Hartmann","Lange","Schmitt","Werner","Schmitz","Krause","Meier","Lehmann","Schmid","Schulze","Maier","Köhler","Herrmann","König","Walter","Mayer","Huber","Kaiser","Fuchs","Peters","Lang","Scholz","Möller","Weiß","Jung","Hahn","Schubert","Vogel","Friedrich","Keller","Günther","Frank","Berger","Winkler","Roth","Beck","Lorenz","Baumann","Franke","Albrecht","Schuster","Simon","Ludwig","Böhm","Winter","Kraus","Martin","Schumacher","Krämer","Vogt","Stein","Jäger","Otto","Sommer","Groß","Seidel","Heinrich","Brandt","Haas","Schreiber","Graf","Schulte","Dietrich","Ziegler","Kuhn","Kühn","Pohl","Engel","Horn","Busch","Bergmann","Thomas","Voigt","Sauer","Arnold","Wolff","Pfeiffer"],
             // http://www.japantimes.co.jp/life/2009/10/11/lifestyle/japans-top-100-most-common-family-names/
-            "jp": ["Sato","Suzuki","Takahashi","Tanaka","Watanabe","Ito","Yamamoto","Nakamura","Kobayashi","Kato","Yoshida","Yamada","Sasaki","Yamaguchi","Saito","Matsumoto","Inoue","Kimura","Hayashi","Shimizu","Yamazaki","Mori","Abe","Ikeda","Hashimoto","Yamashita","Ishikawa","Nakajima","Maeda","Fujita","Ogawa","Goto","Okada","Hasegawa","Murakami","Kondo","Ishii","Saito","Sakamoto","Endo","Aoki","Fujii","Nishimura","Fukuda","Ota","Miura","Fujiwara","Okamoto","Matsuda","Nakagawa","Nakano","Harada","Ono","Tamura","Takeuchi","Kaneko","Wada","Nakayama","Ishida","Ueda","Morita","Hara","Shibata","Sakai","Kudo","Yokoyama","Miyazaki","Miyamoto","Uchida","Takagi","Ando","Taniguchi","Ohno","Maruyama","Imai","Takada","Fujimoto","Takeda","Murata","Ueno","Sugiyama","Masuda","Sugawara","Hirano","Kojima","Otsuka","Chiba","Kubo","Matsui","Iwasaki","Sakurai","Kinoshita","Noguchi","Matsuo","Nomura","Kikuchi","Sano","Onishi","Sugimoto","Arai"],
+            jp: ["Sato","Suzuki","Takahashi","Tanaka","Watanabe","Ito","Yamamoto","Nakamura","Kobayashi","Kato","Yoshida","Yamada","Sasaki","Yamaguchi","Saito","Matsumoto","Inoue","Kimura","Hayashi","Shimizu","Yamazaki","Mori","Abe","Ikeda","Hashimoto","Yamashita","Ishikawa","Nakajima","Maeda","Fujita","Ogawa","Goto","Okada","Hasegawa","Murakami","Kondo","Ishii","Saito","Sakamoto","Endo","Aoki","Fujii","Nishimura","Fukuda","Ota","Miura","Fujiwara","Okamoto","Matsuda","Nakagawa","Nakano","Harada","Ono","Tamura","Takeuchi","Kaneko","Wada","Nakayama","Ishida","Ueda","Morita","Hara","Shibata","Sakai","Kudo","Yokoyama","Miyazaki","Miyamoto","Uchida","Takagi","Ando","Taniguchi","Ohno","Maruyama","Imai","Takada","Fujimoto","Takeda","Murata","Ueno","Sugiyama","Masuda","Sugawara","Hirano","Kojima","Otsuka","Chiba","Kubo","Matsui","Iwasaki","Sakurai","Kinoshita","Noguchi","Matsuo","Nomura","Kikuchi","Sano","Onishi","Sugimoto","Arai"],
             // http://www.lowchensaustralia.com/names/popular-spanish-names.htm
-            "es": ["Garcia","Fernandez","Lopez","Martinez","Gonzalez","Rodriguez","Sanchez","Perez","Martin","Gomez","Ruiz","Diaz","Hernandez","Alvarez","Jimenez","Moreno","Munoz","Alonso","Romero","Navarro","Gutierrez","Torres","Dominguez","Gil","Vazquez","Blanco","Serrano","Ramos","Castro","Suarez","Sanz","Rubio","Ortega","Molina","Delgado","Ortiz","Morales","Ramirez","Marin","Iglesias","Santos","Castillo","Garrido","Calvo","Pena","Cruz","Cano","Nunez","Prieto","Diez","Lozano","Vidal","Pascual","Ferrer","Medina","Vega","Leon","Herrero","Vicente","Mendez","Guerrero","Fuentes","Campos","Nieto","Cortes","Caballero","Ibanez","Lorenzo","Pastor","Gimenez","Saez","Soler","Marquez","Carrasco","Herrera","Montero","Arias","Crespo","Flores","Andres","Aguilar","Hidalgo","Cabrera","Mora","Duran","Velasco","Rey","Pardo","Roman","Vila","Bravo","Merino","Moya","Soto","Izquierdo","Reyes","Redondo","Marcos","Carmona","Menendez"],
+            es: ["Garcia","Fernandez","Lopez","Martinez","Gonzalez","Rodriguez","Sanchez","Perez","Martin","Gomez","Ruiz","Diaz","Hernandez","Alvarez","Jimenez","Moreno","Munoz","Alonso","Romero","Navarro","Gutierrez","Torres","Dominguez","Gil","Vazquez","Blanco","Serrano","Ramos","Castro","Suarez","Sanz","Rubio","Ortega","Molina","Delgado","Ortiz","Morales","Ramirez","Marin","Iglesias","Santos","Castillo","Garrido","Calvo","Pena","Cruz","Cano","Nunez","Prieto","Diez","Lozano","Vidal","Pascual","Ferrer","Medina","Vega","Leon","Herrero","Vicente","Mendez","Guerrero","Fuentes","Campos","Nieto","Cortes","Caballero","Ibanez","Lorenzo","Pastor","Gimenez","Saez","Soler","Marquez","Carrasco","Herrera","Montero","Arias","Crespo","Flores","Andres","Aguilar","Hidalgo","Cabrera","Mora","Duran","Velasco","Rey","Pardo","Roman","Vila","Bravo","Merino","Moya","Soto","Izquierdo","Reyes","Redondo","Marcos","Carmona","Menendez"],
             // Data taken from https://fr.wikipedia.org/wiki/Liste_des_noms_de_famille_les_plus_courants_en_France
-            "fr": ["Martin","Bernard","Thomas","Petit","Robert","Richard","Durand","Dubois","Moreau","Laurent","Simon","Michel","Lefèvre","Leroy","Roux","David","Bertrand","Morel","Fournier","Girard","Bonnet","Dupont","Lambert","Fontaine","Rousseau","Vincent","Müller","Lefèvre","Faure","André","Mercier","Blanc","Guérin","Boyer","Garnier","Chevalier","François","Legrand","Gauthier","Garcia","Perrin","Robin","Clément","Morin","Nicolas","Henry","Roussel","Matthieu","Gautier","Masson","Marchand","Duval","Denis","Dumont","Marie","Lemaire","Noël","Meyer","Dufour","Meunier","Brun","Blanchard","Giraud","Joly","Rivière","Lucas","Brunet","Gaillard","Barbier","Arnaud","Martínez","Gérard","Roche","Renard","Schmitt","Roy","Leroux","Colin","Vidal","Caron","Picard","Roger","Fabre","Aubert","Lemoine","Renaud","Dumas","Lacroix","Olivier","Philippe","Bourgeois","Pierre","Benoît","Rey","Leclerc","Payet","Rolland","Leclercq","Guillaume","Lecomte","López","Jean","Dupuy","Guillot","Hubert","Berger","Carpentier","Sánchez","Dupuis","Moulin","Louis","Deschamps","Huet","Vasseur","Perez","Boucher","Fleury","Royer","Klein","Jacquet","Adam","Paris","Poirier","Marty","Aubry","Guyot","Carré","Charles","Renault","Charpentier","Ménard","Maillard","Baron","Bertin","Bailly","Hervé","Schneider","Fernández","Le GallGall","Collet","Léger","Bouvier","Julien","Prévost","Millet","Perrot","Daniel","Le RouxRoux","Cousin","Germain","Breton","Besson","Langlois","Rémi","Le GoffGoff","Pelletier","Lévêque","Perrier","Leblanc","Barré","Lebrun","Marchal","Weber","Mallet","Hamon","Boulanger","Jacob","Monnier","Michaud","Rodríguez","Guichard","Gillet","Étienne","Grondin","Poulain","Tessier","Chevallier","Collin","Chauvin","Da SilvaSilva","Bouchet","Gay","Lemaître","Bénard","Maréchal","Humbert","Reynaud","Antoine","Hoarau","Perret","Barthélemy","Cordier","Pichon","Lejeune","Gilbert","Lamy","Delaunay","Pasquier","Carlier","LaporteLaporte"]
+            fr: ["Martin","Bernard","Thomas","Petit","Robert","Richard","Durand","Dubois","Moreau","Laurent","Simon","Michel","Lefèvre","Leroy","Roux","David","Bertrand","Morel","Fournier","Girard","Bonnet","Dupont","Lambert","Fontaine","Rousseau","Vincent","Müller","Lefèvre","Faure","André","Mercier","Blanc","Guérin","Boyer","Garnier","Chevalier","François","Legrand","Gauthier","Garcia","Perrin","Robin","Clément","Morin","Nicolas","Henry","Roussel","Matthieu","Gautier","Masson","Marchand","Duval","Denis","Dumont","Marie","Lemaire","Noël","Meyer","Dufour","Meunier","Brun","Blanchard","Giraud","Joly","Rivière","Lucas","Brunet","Gaillard","Barbier","Arnaud","Martínez","Gérard","Roche","Renard","Schmitt","Roy","Leroux","Colin","Vidal","Caron","Picard","Roger","Fabre","Aubert","Lemoine","Renaud","Dumas","Lacroix","Olivier","Philippe","Bourgeois","Pierre","Benoît","Rey","Leclerc","Payet","Rolland","Leclercq","Guillaume","Lecomte","López","Jean","Dupuy","Guillot","Hubert","Berger","Carpentier","Sánchez","Dupuis","Moulin","Louis","Deschamps","Huet","Vasseur","Perez","Boucher","Fleury","Royer","Klein","Jacquet","Adam","Paris","Poirier","Marty","Aubry","Guyot","Carré","Charles","Renault","Charpentier","Ménard","Maillard","Baron","Bertin","Bailly","Hervé","Schneider","Fernández","Le Gall","Collet","Léger","Bouvier","Julien","Prévost","Millet","Perrot","Daniel","Le Roux","Cousin","Germain","Breton","Besson","Langlois","Rémi","Le Goff","Pelletier","Lévêque","Perrier","Leblanc","Barré","Lebrun","Marchal","Weber","Mallet","Hamon","Boulanger","Jacob","Monnier","Michaud","Rodríguez","Guichard","Gillet","Étienne","Grondin","Poulain","Tessier","Chevallier","Collin","Chauvin","Da Silva","Bouchet","Gay","Lemaître","Bénard","Maréchal","Humbert","Reynaud","Antoine","Hoarau","Perret","Barthélemy","Cordier","Pichon","Lejeune","Gilbert","Lamy","Delaunay","Pasquier","Carlier","Laporte"],
         },
 
         // Data taken from http://geoportal.statistics.gov.uk/datasets/ons-postcode-directory-latest-centroids
         postcodeAreas: [{code: 'AB'}, {code: 'AL'}, {code: 'B'}, {code: 'BA'}, {code: 'BB'}, {code: 'BD'}, {code: 'BH'}, {code: 'BL'}, {code: 'BN'}, {code: 'BR'}, {code: 'BS'}, {code: 'BT'}, {code: 'CA'}, {code: 'CB'}, {code: 'CF'}, {code: 'CH'}, {code: 'CM'}, {code: 'CO'}, {code: 'CR'}, {code: 'CT'}, {code: 'CV'}, {code: 'CW'}, {code: 'DA'}, {code: 'DD'}, {code: 'DE'}, {code: 'DG'}, {code: 'DH'}, {code: 'DL'}, {code: 'DN'}, {code: 'DT'}, {code: 'DY'}, {code: 'E'}, {code: 'EC'}, {code: 'EH'}, {code: 'EN'}, {code: 'EX'}, {code: 'FK'}, {code: 'FY'}, {code: 'G'}, {code: 'GL'}, {code: 'GU'}, {code: 'GY'}, {code: 'HA'}, {code: 'HD'}, {code: 'HG'}, {code: 'HP'}, {code: 'HR'}, {code: 'HS'}, {code: 'HU'}, {code: 'HX'}, {code: 'IG'}, {code: 'IM'}, {code: 'IP'}, {code: 'IV'}, {code: 'JE'}, {code: 'KA'}, {code: 'KT'}, {code: 'KW'}, {code: 'KY'}, {code: 'L'}, {code: 'LA'}, {code: 'LD'}, {code: 'LE'}, {code: 'LL'}, {code: 'LN'}, {code: 'LS'}, {code: 'LU'}, {code: 'M'}, {code: 'ME'}, {code: 'MK'}, {code: 'ML'}, {code: 'N'}, {code: 'NE'}, {code: 'NG'}, {code: 'NN'}, {code: 'NP'}, {code: 'NR'}, {code: 'NW'}, {code: 'OL'}, {code: 'OX'}, {code: 'PA'}, {code: 'PE'}, {code: 'PH'}, {code: 'PL'}, {code: 'PO'}, {code: 'PR'}, {code: 'RG'}, {code: 'RH'}, {code: 'RM'}, {code: 'S'}, {code: 'SA'}, {code: 'SE'}, {code: 'SG'}, {code: 'SK'}, {code: 'SL'}, {code: 'SM'}, {code: 'SN'}, {code: 'SO'}, {code: 'SP'}, {code: 'SR'}, {code: 'SS'}, {code: 'ST'}, {code: 'SW'}, {code: 'SY'}, {code: 'TA'}, {code: 'TD'}, {code: 'TF'}, {code: 'TN'}, {code: 'TQ'}, {code: 'TR'}, {code: 'TS'}, {code: 'TW'}, {code: 'UB'}, {code: 'W'}, {code: 'WA'}, {code: 'WC'}, {code: 'WD'}, {code: 'WF'}, {code: 'WN'}, {code: 'WR'}, {code: 'WS'}, {code: 'WV'}, {code: 'YO'}, {code: 'ZE'}],
 
         // Data taken from https://github.com/umpirsky/country-list/blob/master/data/en_US/country.json
-        countries: [{"name":"Afghanistan","abbreviation":"AF"},{"name":"Åland Islands","abbreviation":"AX"},{"name":"Albania","abbreviation":"AL"},{"name":"Algeria","abbreviation":"DZ"},{"name":"American Samoa","abbreviation":"AS"},{"name":"Andorra","abbreviation":"AD"},{"name":"Angola","abbreviation":"AO"},{"name":"Anguilla","abbreviation":"AI"},{"name":"Antarctica","abbreviation":"AQ"},{"name":"Antigua & Barbuda","abbreviation":"AG"},{"name":"Argentina","abbreviation":"AR"},{"name":"Armenia","abbreviation":"AM"},{"name":"Aruba","abbreviation":"AW"},{"name":"Ascension Island","abbreviation":"AC"},{"name":"Australia","abbreviation":"AU"},{"name":"Austria","abbreviation":"AT"},{"name":"Azerbaijan","abbreviation":"AZ"},{"name":"Bahamas","abbreviation":"BS"},{"name":"Bahrain","abbreviation":"BH"},{"name":"Bangladesh","abbreviation":"BD"},{"name":"Barbados","abbreviation":"BB"},{"name":"Belarus","abbreviation":"BY"},{"name":"Belgium","abbreviation":"BE"},{"name":"Belize","abbreviation":"BZ"},{"name":"Benin","abbreviation":"BJ"},{"name":"Bermuda","abbreviation":"BM"},{"name":"Bhutan","abbreviation":"BT"},{"name":"Bolivia","abbreviation":"BO"},{"name":"Bosnia & Herzegovina","abbreviation":"BA"},{"name":"Botswana","abbreviation":"BW"},{"name":"Brazil","abbreviation":"BR"},{"name":"British Indian Ocean Territory","abbreviation":"IO"},{"name":"British Virgin Islands","abbreviation":"VG"},{"name":"Brunei","abbreviation":"BN"},{"name":"Bulgaria","abbreviation":"BG"},{"name":"Burkina Faso","abbreviation":"BF"},{"name":"Burundi","abbreviation":"BI"},{"name":"Cambodia","abbreviation":"KH"},{"name":"Cameroon","abbreviation":"CM"},{"name":"Canada","abbreviation":"CA"},{"name":"Canary Islands","abbreviation":"IC"},{"name":"Cape Verde","abbreviation":"CV"},{"name":"Caribbean Netherlands","abbreviation":"BQ"},{"name":"Cayman Islands","abbreviation":"KY"},{"name":"Central African Republic","abbreviation":"CF"},{"name":"Ceuta & Melilla","abbreviation":"EA"},{"name":"Chad","abbreviation":"TD"},{"name":"Chile","abbreviation":"CL"},{"name":"China","abbreviation":"CN"},{"name":"Christmas Island","abbreviation":"CX"},{"name":"Cocos (Keeling) Islands","abbreviation":"CC"},{"name":"Colombia","abbreviation":"CO"},{"name":"Comoros","abbreviation":"KM"},{"name":"Congo - Brazzaville","abbreviation":"CG"},{"name":"Congo - Kinshasa","abbreviation":"CD"},{"name":"Cook Islands","abbreviation":"CK"},{"name":"Costa Rica","abbreviation":"CR"},{"name":"Côte d'Ivoire","abbreviation":"CI"},{"name":"Croatia","abbreviation":"HR"},{"name":"Cuba","abbreviation":"CU"},{"name":"Curaçao","abbreviation":"CW"},{"name":"Cyprus","abbreviation":"CY"},{"name":"Czech Republic","abbreviation":"CZ"},{"name":"Denmark","abbreviation":"DK"},{"name":"Diego Garcia","abbreviation":"DG"},{"name":"Djibouti","abbreviation":"DJ"},{"name":"Dominica","abbreviation":"DM"},{"name":"Dominican Republic","abbreviation":"DO"},{"name":"Ecuador","abbreviation":"EC"},{"name":"Egypt","abbreviation":"EG"},{"name":"El Salvador","abbreviation":"SV"},{"name":"Equatorial Guinea","abbreviation":"GQ"},{"name":"Eritrea","abbreviation":"ER"},{"name":"Estonia","abbreviation":"EE"},{"name":"Ethiopia","abbreviation":"ET"},{"name":"Falkland Islands","abbreviation":"FK"},{"name":"Faroe Islands","abbreviation":"FO"},{"name":"Fiji","abbreviation":"FJ"},{"name":"Finland","abbreviation":"FI"},{"name":"France","abbreviation":"FR"},{"name":"French Guiana","abbreviation":"GF"},{"name":"French Polynesia","abbreviation":"PF"},{"name":"French Southern Territories","abbreviation":"TF"},{"name":"Gabon","abbreviation":"GA"},{"name":"Gambia","abbreviation":"GM"},{"name":"Georgia","abbreviation":"GE"},{"name":"Germany","abbreviation":"DE"},{"name":"Ghana","abbreviation":"GH"},{"name":"Gibraltar","abbreviation":"GI"},{"name":"Greece","abbreviation":"GR"},{"name":"Greenland","abbreviation":"GL"},{"name":"Grenada","abbreviation":"GD"},{"name":"Guadeloupe","abbreviation":"GP"},{"name":"Guam","abbreviation":"GU"},{"name":"Guatemala","abbreviation":"GT"},{"name":"Guernsey","abbreviation":"GG"},{"name":"Guinea","abbreviation":"GN"},{"name":"Guinea-Bissau","abbreviation":"GW"},{"name":"Guyana","abbreviation":"GY"},{"name":"Haiti","abbreviation":"HT"},{"name":"Honduras","abbreviation":"HN"},{"name":"Hong Kong SAR China","abbreviation":"HK"},{"name":"Hungary","abbreviation":"HU"},{"name":"Iceland","abbreviation":"IS"},{"name":"India","abbreviation":"IN"},{"name":"Indonesia","abbreviation":"ID"},{"name":"Iran","abbreviation":"IR"},{"name":"Iraq","abbreviation":"IQ"},{"name":"Ireland","abbreviation":"IE"},{"name":"Isle of Man","abbreviation":"IM"},{"name":"Israel","abbreviation":"IL"},{"name":"Italy","abbreviation":"IT"},{"name":"Jamaica","abbreviation":"JM"},{"name":"Japan","abbreviation":"JP"},{"name":"Jersey","abbreviation":"JE"},{"name":"Jordan","abbreviation":"JO"},{"name":"Kazakhstan","abbreviation":"KZ"},{"name":"Kenya","abbreviation":"KE"},{"name":"Kiribati","abbreviation":"KI"},{"name":"Kosovo","abbreviation":"XK"},{"name":"Kuwait","abbreviation":"KW"},{"name":"Kyrgyzstan","abbreviation":"KG"},{"name":"Laos","abbreviation":"LA"},{"name":"Latvia","abbreviation":"LV"},{"name":"Lebanon","abbreviation":"LB"},{"name":"Lesotho","abbreviation":"LS"},{"name":"Liberia","abbreviation":"LR"},{"name":"Libya","abbreviation":"LY"},{"name":"Liechtenstein","abbreviation":"LI"},{"name":"Lithuania","abbreviation":"LT"},{"name":"Luxembourg","abbreviation":"LU"},{"name":"Macau SAR China","abbreviation":"MO"},{"name":"Macedonia","abbreviation":"MK"},{"name":"Madagascar","abbreviation":"MG"},{"name":"Malawi","abbreviation":"MW"},{"name":"Malaysia","abbreviation":"MY"},{"name":"Maldives","abbreviation":"MV"},{"name":"Mali","abbreviation":"ML"},{"name":"Malta","abbreviation":"MT"},{"name":"Marshall Islands","abbreviation":"MH"},{"name":"Martinique","abbreviation":"MQ"},{"name":"Mauritania","abbreviation":"MR"},{"name":"Mauritius","abbreviation":"MU"},{"name":"Mayotte","abbreviation":"YT"},{"name":"Mexico","abbreviation":"MX"},{"name":"Micronesia","abbreviation":"FM"},{"name":"Moldova","abbreviation":"MD"},{"name":"Monaco","abbreviation":"MC"},{"name":"Mongolia","abbreviation":"MN"},{"name":"Montenegro","abbreviation":"ME"},{"name":"Montserrat","abbreviation":"MS"},{"name":"Morocco","abbreviation":"MA"},{"name":"Mozambique","abbreviation":"MZ"},{"name":"Myanmar (Burma)","abbreviation":"MM"},{"name":"Namibia","abbreviation":"NA"},{"name":"Nauru","abbreviation":"NR"},{"name":"Nepal","abbreviation":"NP"},{"name":"Netherlands","abbreviation":"NL"},{"name":"New Caledonia","abbreviation":"NC"},{"name":"New Zealand","abbreviation":"NZ"},{"name":"Nicaragua","abbreviation":"NI"},{"name":"Niger","abbreviation":"NE"},{"name":"Nigeria","abbreviation":"NG"},{"name":"Niue","abbreviation":"NU"},{"name":"Norfolk Island","abbreviation":"NF"},{"name":"North Korea","abbreviation":"KP"},{"name":"Northern Mariana Islands","abbreviation":"MP"},{"name":"Norway","abbreviation":"NO"},{"name":"Oman","abbreviation":"OM"},{"name":"Pakistan","abbreviation":"PK"},{"name":"Palau","abbreviation":"PW"},{"name":"Palestinian Territories","abbreviation":"PS"},{"name":"Panama","abbreviation":"PA"},{"name":"Papua New Guinea","abbreviation":"PG"},{"name":"Paraguay","abbreviation":"PY"},{"name":"Peru","abbreviation":"PE"},{"name":"Philippines","abbreviation":"PH"},{"name":"Pitcairn Islands","abbreviation":"PN"},{"name":"Poland","abbreviation":"PL"},{"name":"Portugal","abbreviation":"PT"},{"name":"Puerto Rico","abbreviation":"PR"},{"name":"Qatar","abbreviation":"QA"},{"name":"Réunion","abbreviation":"RE"},{"name":"Romania","abbreviation":"RO"},{"name":"Russia","abbreviation":"RU"},{"name":"Rwanda","abbreviation":"RW"},{"name":"Samoa","abbreviation":"WS"},{"name":"San Marino","abbreviation":"SM"},{"name":"São Tomé and Príncipe","abbreviation":"ST"},{"name":"Saudi Arabia","abbreviation":"SA"},{"name":"Senegal","abbreviation":"SN"},{"name":"Serbia","abbreviation":"RS"},{"name":"Seychelles","abbreviation":"SC"},{"name":"Sierra Leone","abbreviation":"SL"},{"name":"Singapore","abbreviation":"SG"},{"name":"Sint Maarten","abbreviation":"SX"},{"name":"Slovakia","abbreviation":"SK"},{"name":"Slovenia","abbreviation":"SI"},{"name":"Solomon Islands","abbreviation":"SB"},{"name":"Somalia","abbreviation":"SO"},{"name":"South Africa","abbreviation":"ZA"},{"name":"South Georgia & South Sandwich Islands","abbreviation":"GS"},{"name":"South Korea","abbreviation":"KR"},{"name":"South Sudan","abbreviation":"SS"},{"name":"Spain","abbreviation":"ES"},{"name":"Sri Lanka","abbreviation":"LK"},{"name":"St. Barthélemy","abbreviation":"BL"},{"name":"St. Helena","abbreviation":"SH"},{"name":"St. Kitts & Nevis","abbreviation":"KN"},{"name":"St. Lucia","abbreviation":"LC"},{"name":"St. Martin","abbreviation":"MF"},{"name":"St. Pierre & Miquelon","abbreviation":"PM"},{"name":"St. Vincent & Grenadines","abbreviation":"VC"},{"name":"Sudan","abbreviation":"SD"},{"name":"Suriname","abbreviation":"SR"},{"name":"Svalbard & Jan Mayen","abbreviation":"SJ"},{"name":"Swaziland","abbreviation":"SZ"},{"name":"Sweden","abbreviation":"SE"},{"name":"Switzerland","abbreviation":"CH"},{"name":"Syria","abbreviation":"SY"},{"name":"Taiwan","abbreviation":"TW"},{"name":"Tajikistan","abbreviation":"TJ"},{"name":"Tanzania","abbreviation":"TZ"},{"name":"Thailand","abbreviation":"TH"},{"name":"Timor-Leste","abbreviation":"TL"},{"name":"Togo","abbreviation":"TG"},{"name":"Tokelau","abbreviation":"TK"},{"name":"Tonga","abbreviation":"TO"},{"name":"Trinidad & Tobago","abbreviation":"TT"},{"name":"Tristan da Cunha","abbreviation":"TA"},{"name":"Tunisia","abbreviation":"TN"},{"name":"Turkey","abbreviation":"TR"},{"name":"Turkmenistan","abbreviation":"TM"},{"name":"Turks & Caicos Islands","abbreviation":"TC"},{"name":"Tuvalu","abbreviation":"TV"},{"name":"U.S. Outlying Islands","abbreviation":"UM"},{"name":"U.S. Virgin Islands","abbreviation":"VI"},{"name":"Uganda","abbreviation":"UG"},{"name":"Ukraine","abbreviation":"UA"},{"name":"United Arab Emirates","abbreviation":"AE"},{"name":"United Kingdom","abbreviation":"GB"},{"name":"United States","abbreviation":"US"},{"name":"Uruguay","abbreviation":"UY"},{"name":"Uzbekistan","abbreviation":"UZ"},{"name":"Vanuatu","abbreviation":"VU"},{"name":"Vatican City","abbreviation":"VA"},{"name":"Venezuela","abbreviation":"VE"},{"name":"Vietnam","abbreviation":"VN"},{"name":"Wallis & Futuna","abbreviation":"WF"},{"name":"Western Sahara","abbreviation":"EH"},{"name":"Yemen","abbreviation":"YE"},{"name":"Zambia","abbreviation":"ZM"},{"name":"Zimbabwe","abbreviation":"ZW"}],
+        countries: [
+        {name:"Afghanistan",abbreviation:"AF"},{name:"Åland Islands",abbreviation:"AX"},{name:"Albania",abbreviation:"AL"},{name:"Algeria",abbreviation:"DZ"},{name:"American Samoa",abbreviation:"AS"},{name:"Andorra",abbreviation:"AD"},{name:"Angola",abbreviation:"AO"},{name:"Anguilla",abbreviation:"AI"},{name:"Antarctica",abbreviation:"AQ"},{name:"Antigua & Barbuda",abbreviation:"AG"},{name:"Argentina",abbreviation:"AR"},{name:"Armenia",abbreviation:"AM"},{name:"Aruba",abbreviation:"AW"},{name:"Ascension Island",abbreviation:"AC"},{name:"Australia",abbreviation:"AU"},{name:"Austria",abbreviation:"AT"},{name:"Azerbaijan",abbreviation:"AZ"},
+        {name:"Bahamas",abbreviation:"BS"},{name:"Bahrain",abbreviation:"BH"},{name:"Bangladesh",abbreviation:"BD"},{name:"Barbados",abbreviation:"BB"},{name:"Belarus",abbreviation:"BY"},{name:"Belgium",abbreviation:"BE"},{name:"Belize",abbreviation:"BZ"},{name:"Benin",abbreviation:"BJ"},{name:"Bermuda",abbreviation:"BM"},{name:"Bhutan",abbreviation:"BT"},{name:"Bolivia",abbreviation:"BO"},{name:"Bosnia & Herzegovina",abbreviation:"BA"},{name:"Botswana",abbreviation:"BW"},{name:"Brazil",abbreviation:"BR"},{name:"British Indian Ocean Territory",abbreviation:"IO"},{name:"British Virgin Islands",abbreviation:"VG"},{name:"Brunei",abbreviation:"BN"},{name:"Bulgaria",abbreviation:"BG"},{name:"Burkina Faso",abbreviation:"BF"},{name:"Burundi",abbreviation:"BI"},
+        {name:"Cambodia",abbreviation:"KH"},{name:"Cameroon",abbreviation:"CM"},{name:"Canada",abbreviation:"CA"},{name:"Canary Islands",abbreviation:"IC"},{name:"Cape Verde",abbreviation:"CV"},{name:"Caribbean Netherlands",abbreviation:"BQ"},{name:"Cayman Islands",abbreviation:"KY"},{name:"Central African Republic",abbreviation:"CF"},{name:"Ceuta & Melilla",abbreviation:"EA"},{name:"Chad",abbreviation:"TD"},{name:"Chile",abbreviation:"CL"},{name:"China",abbreviation:"CN"},{name:"Christmas Island",abbreviation:"CX"},{name:"Cocos (Keeling) Islands",abbreviation:"CC"},{name:"Colombia",abbreviation:"CO"},{name:"Comoros",abbreviation:"KM"},{name:"Congo - Brazzaville",abbreviation:"CG"},{name:"Congo - Kinshasa",abbreviation:"CD"},{name:"Cook Islands",abbreviation:"CK"},{name:"Costa Rica",abbreviation:"CR"},{name:"Côte d'Ivoire",abbreviation:"CI"},{name:"Croatia",abbreviation:"HR"},{name:"Cuba",abbreviation:"CU"},{name:"Curaçao",abbreviation:"CW"},{name:"Cyprus",abbreviation:"CY"},{name:"Czech Republic",abbreviation:"CZ"},
+        {name:"Denmark",abbreviation:"DK"},{name:"Diego Garcia",abbreviation:"DG"},{name:"Djibouti",abbreviation:"DJ"},{name:"Dominica",abbreviation:"DM"},{name:"Dominican Republic",abbreviation:"DO"},
+        {name:"Ecuador",abbreviation:"EC"},{name:"Egypt",abbreviation:"EG"},{name:"El Salvador",abbreviation:"SV"},{name:"Equatorial Guinea",abbreviation:"GQ"},{name:"Eritrea",abbreviation:"ER"},{name:"Estonia",abbreviation:"EE"},{name:"Ethiopia",abbreviation:"ET"},
+        {name:"Falkland Islands",abbreviation:"FK"},{name:"Faroe Islands",abbreviation:"FO"},{name:"Fiji",abbreviation:"FJ"},{name:"Finland",abbreviation:"FI"},{name:"France",abbreviation:"FR"},{name:"French Guiana",abbreviation:"GF"},{name:"French Polynesia",abbreviation:"PF"},{name:"French Southern Territories",abbreviation:"TF"},
+        {name:"Gabon",abbreviation:"GA"},{name:"Gambia",abbreviation:"GM"},{name:"Georgia",abbreviation:"GE"},{name:"Germany",abbreviation:"DE"},{name:"Ghana",abbreviation:"GH"},{name:"Gibraltar",abbreviation:"GI"},{name:"Greece",abbreviation:"GR"},{name:"Greenland",abbreviation:"GL"},{name:"Grenada",abbreviation:"GD"},{name:"Guadeloupe",abbreviation:"GP"},{name:"Guam",abbreviation:"GU"},{name:"Guatemala",abbreviation:"GT"},{name:"Guernsey",abbreviation:"GG"},{name:"Guinea",abbreviation:"GN"},{name:"Guinea-Bissau",abbreviation:"GW"},{name:"Guyana",abbreviation:"GY"},
+        {name:"Haiti",abbreviation:"HT"},{name:"Honduras",abbreviation:"HN"},{name:"Hong Kong SAR China",abbreviation:"HK"},{name:"Hungary",abbreviation:"HU"},
+        {name:"Iceland",abbreviation:"IS"},{name:"India",abbreviation:"IN"},{name:"Indonesia",abbreviation:"ID"},{name:"Iran",abbreviation:"IR"},{name:"Iraq",abbreviation:"IQ"},{name:"Ireland",abbreviation:"IE"},{name:"Isle of Man",abbreviation:"IM"},{name:"Israel",abbreviation:"IL"},{name:"Italy",abbreviation:"IT"},
+        {name:"Jamaica",abbreviation:"JM"},{name:"Japan",abbreviation:"JP"},{name:"Jersey",abbreviation:"JE"},{name:"Jordan",abbreviation:"JO"},
+        {name:"Kazakhstan",abbreviation:"KZ"},{name:"Kenya",abbreviation:"KE"},{name:"Kiribati",abbreviation:"KI"},{name:"Kosovo",abbreviation:"XK"},{name:"Kuwait",abbreviation:"KW"},{name:"Kyrgyzstan",abbreviation:"KG"},
+        {name:"Laos",abbreviation:"LA"},{name:"Latvia",abbreviation:"LV"},{name:"Lebanon",abbreviation:"LB"},{name:"Lesotho",abbreviation:"LS"},{name:"Liberia",abbreviation:"LR"},{name:"Libya",abbreviation:"LY"},{name:"Liechtenstein",abbreviation:"LI"},{name:"Lithuania",abbreviation:"LT"},{name:"Luxembourg",abbreviation:"LU"},
+        {name:"Macau SAR China",abbreviation:"MO"},{name:"Macedonia",abbreviation:"MK"},{name:"Madagascar",abbreviation:"MG"},{name:"Malawi",abbreviation:"MW"},{name:"Malaysia",abbreviation:"MY"},{name:"Maldives",abbreviation:"MV"},{name:"Mali",abbreviation:"ML"},{name:"Malta",abbreviation:"MT"},{name:"Marshall Islands",abbreviation:"MH"},{name:"Martinique",abbreviation:"MQ"},{name:"Mauritania",abbreviation:"MR"},{name:"Mauritius",abbreviation:"MU"},{name:"Mayotte",abbreviation:"YT"},{name:"Mexico",abbreviation:"MX"},{name:"Micronesia",abbreviation:"FM"},{name:"Moldova",abbreviation:"MD"},{name:"Monaco",abbreviation:"MC"},{name:"Mongolia",abbreviation:"MN"},{name:"Montenegro",abbreviation:"ME"},{name:"Montserrat",abbreviation:"MS"},{name:"Morocco",abbreviation:"MA"},{name:"Mozambique",abbreviation:"MZ"},{name:"Myanmar (Burma)",abbreviation:"MM"},
+        {name:"Namibia",abbreviation:"NA"},{name:"Nauru",abbreviation:"NR"},{name:"Nepal",abbreviation:"NP"},{name:"Netherlands",abbreviation:"NL"},{name:"New Caledonia",abbreviation:"NC"},{name:"New Zealand",abbreviation:"NZ"},{name:"Nicaragua",abbreviation:"NI"},{name:"Niger",abbreviation:"NE"},{name:"Nigeria",abbreviation:"NG"},{name:"Niue",abbreviation:"NU"},{name:"Norfolk Island",abbreviation:"NF"},{name:"North Korea",abbreviation:"KP"},{name:"Northern Mariana Islands",abbreviation:"MP"},{name:"Norway",abbreviation:"NO"},
+        {name:"Oman",abbreviation:"OM"},
+        {name:"Pakistan",abbreviation:"PK"},{name:"Palau",abbreviation:"PW"},{name:"Palestinian Territories",abbreviation:"PS"},{name:"Panama",abbreviation:"PA"},{name:"Papua New Guinea",abbreviation:"PG"},{name:"Paraguay",abbreviation:"PY"},{name:"Peru",abbreviation:"PE"},{name:"Philippines",abbreviation:"PH"},{name:"Pitcairn Islands",abbreviation:"PN"},{name:"Poland",abbreviation:"PL"},{name:"Portugal",abbreviation:"PT"},{name:"Puerto Rico",abbreviation:"PR"},
+        {name:"Qatar",abbreviation:"QA"},
+        {name:"Réunion",abbreviation:"RE"},{name:"Romania",abbreviation:"RO"},{name:"Russia",abbreviation:"RU"},{name:"Rwanda",abbreviation:"RW"},
+        {name:"Samoa",abbreviation:"WS"},{name:"San Marino",abbreviation:"SM"},{name:"São Tomé and Príncipe",abbreviation:"ST"},{name:"Saudi Arabia",abbreviation:"SA"},{name:"Senegal",abbreviation:"SN"},{name:"Serbia",abbreviation:"RS"},{name:"Seychelles",abbreviation:"SC"},{name:"Sierra Leone",abbreviation:"SL"},{name:"Singapore",abbreviation:"SG"},{name:"Sint Maarten",abbreviation:"SX"},{name:"Slovakia",abbreviation:"SK"},{name:"Slovenia",abbreviation:"SI"},{name:"Solomon Islands",abbreviation:"SB"},{name:"Somalia",abbreviation:"SO"},{name:"South Africa",abbreviation:"ZA"},{name:"South Georgia & South Sandwich Islands",abbreviation:"GS"},{name:"South Korea",abbreviation:"KR"},{name:"South Sudan",abbreviation:"SS"},{name:"Spain",abbreviation:"ES"},{name:"Sri Lanka",abbreviation:"LK"},{name:"St. Barthélemy",abbreviation:"BL"},{name:"St. Helena",abbreviation:"SH"},{name:"St. Kitts & Nevis",abbreviation:"KN"},{name:"St. Lucia",abbreviation:"LC"},{name:"St. Martin",abbreviation:"MF"},{name:"St. Pierre & Miquelon",abbreviation:"PM"},{name:"St. Vincent & Grenadines",abbreviation:"VC"},{name:"Sudan",abbreviation:"SD"},{name:"Suriname",abbreviation:"SR"},{name:"Svalbard & Jan Mayen",abbreviation:"SJ"},{name:"Swaziland",abbreviation:"SZ"},{name:"Sweden",abbreviation:"SE"},{name:"Switzerland",abbreviation:"CH"},{name:"Syria",abbreviation:"SY"},
+        {name:"Taiwan",abbreviation:"TW"},{name:"Tajikistan",abbreviation:"TJ"},{name:"Tanzania",abbreviation:"TZ"},{name:"Thailand",abbreviation:"TH"},{name:"Timor-Leste",abbreviation:"TL"},{name:"Togo",abbreviation:"TG"},{name:"Tokelau",abbreviation:"TK"},{name:"Tonga",abbreviation:"TO"},{name:"Trinidad & Tobago",abbreviation:"TT"},{name:"Tristan da Cunha",abbreviation:"TA"},{name:"Tunisia",abbreviation:"TN"},{name:"Turkey",abbreviation:"TR"},{name:"Turkmenistan",abbreviation:"TM"},{name:"Turks & Caicos Islands",abbreviation:"TC"},{name:"Tuvalu",abbreviation:"TV"},
+        {name:"U.S. Outlying Islands",abbreviation:"UM"},{name:"U.S. Virgin Islands",abbreviation:"VI"},{name:"Uganda",abbreviation:"UG"},{name:"Ukraine",abbreviation:"UA"},{name:"United Arab Emirates",abbreviation:"AE"},{name:"United Kingdom",abbreviation:"GB"},{name:"United States",abbreviation:"US"},{name:"Uruguay",abbreviation:"UY"},{name:"Uzbekistan",abbreviation:"UZ"},
+        {name:"Vanuatu",abbreviation:"VU"},{name:"Vatican City",abbreviation:"VA"},{name:"Venezuela",abbreviation:"VE"},{name:"Vietnam",abbreviation:"VN"},
+        {name:"Wallis & Futuna",abbreviation:"WF"},{name:"Western Sahara",abbreviation:"EH"},
+        {name:"Yemen",abbreviation:"YE"},
+        {name:"Zambia",abbreviation:"ZM"},{name:"Zimbabwe",abbreviation:"ZW"},
+        ],
 
-                counties: {
+        counties: {
             // Data taken from http://www.downloadexcelfiles.com/gb_en/download-excel-file-list-counties-uk
-            "uk": [
+            uk: [
                 {name: 'Bath and North East Somerset'},
                 {name: 'Aberdeenshire'},
                 {name: 'Anglesey'},
@@ -2971,10 +2988,12 @@ options,
                 {name: 'Wokingham'},
                 {name: 'Worcestershire'},
                 {name: 'Wrexham'},
-                {name: 'York'}]
-                                },
+                {name: 'York'},
+            ],
+        },
+
         provinces: {
-            "ca": [
+            ca: [
                 {name: 'Alberta', abbreviation: 'AB'},
                 {name: 'British Columbia', abbreviation: 'BC'},
                 {name: 'Manitoba', abbreviation: 'MB'},
@@ -2991,1009 +3010,844 @@ options,
                 // look the same on an envelope!
                 {name: 'Northwest Territories', abbreviation: 'NT'},
                 {name: 'Nunavut', abbreviation: 'NU'},
-                {name: 'Yukon', abbreviation: 'YT'}
+                {name: 'Yukon', abbreviation: 'YT'},
             ],
-            "it": [
-                { name: "Agrigento", abbreviation: "AG", code: 84 },
-                { name: "Alessandria", abbreviation: "AL", code: 6 },
-                { name: "Ancona", abbreviation: "AN", code: 42 },
-                { name: "Aosta", abbreviation: "AO", code: 7 },
-                { name: "L'Aquila", abbreviation: "AQ", code: 66 },
-                { name: "Arezzo", abbreviation: "AR", code: 51 },
-                { name: "Ascoli-Piceno", abbreviation: "AP", code: 44 },
-                { name: "Asti", abbreviation: "AT", code: 5 },
-                { name: "Avellino", abbreviation: "AV", code: 64 },
-                { name: "Bari", abbreviation: "BA", code: 72 },
-                { name: "Barletta-Andria-Trani", abbreviation: "BT", code: 72 },
-                { name: "Belluno", abbreviation: "BL", code: 25 },
-                { name: "Benevento", abbreviation: "BN", code: 62 },
-                { name: "Bergamo", abbreviation: "BG", code: 16 },
-                { name: "Biella", abbreviation: "BI", code: 96 },
-                { name: "Bologna", abbreviation: "BO", code: 37 },
-                { name: "Bolzano", abbreviation: "BZ", code: 21 },
-                { name: "Brescia", abbreviation: "BS", code: 17 },
-                { name: "Brindisi", abbreviation: "BR", code: 74 },
-                { name: "Cagliari", abbreviation: "CA", code: 92 },
-                { name: "Caltanissetta", abbreviation: "CL", code: 85 },
-                { name: "Campobasso", abbreviation: "CB", code: 70 },
-                { name: "Carbonia Iglesias", abbreviation: "CI", code: 70 },
-                { name: "Caserta", abbreviation: "CE", code: 61 },
-                { name: "Catania", abbreviation: "CT", code: 87 },
-                { name: "Catanzaro", abbreviation: "CZ", code: 79 },
-                { name: "Chieti", abbreviation: "CH", code: 69 },
-                { name: "Como", abbreviation: "CO", code: 13 },
-                { name: "Cosenza", abbreviation: "CS", code: 78 },
-                { name: "Cremona", abbreviation: "CR", code: 19 },
-                { name: "Crotone", abbreviation: "KR", code: 101 },
-                { name: "Cuneo", abbreviation: "CN", code: 4 },
-                { name: "Enna", abbreviation: "EN", code: 86 },
-                { name: "Fermo", abbreviation: "FM", code: 86 },
-                { name: "Ferrara", abbreviation: "FE", code: 38 },
-                { name: "Firenze", abbreviation: "FI", code: 48 },
-                { name: "Foggia", abbreviation: "FG", code: 71 },
-                { name: "Forli-Cesena", abbreviation: "FC", code: 71 },
-                { name: "Frosinone", abbreviation: "FR", code: 60 },
-                { name: "Genova", abbreviation: "GE", code: 10 },
-                { name: "Gorizia", abbreviation: "GO", code: 31 },
-                { name: "Grosseto", abbreviation: "GR", code: 53 },
-                { name: "Imperia", abbreviation: "IM", code: 8 },
-                { name: "Isernia", abbreviation: "IS", code: 94 },
-                { name: "La-Spezia", abbreviation: "SP", code: 66 },
-                { name: "Latina", abbreviation: "LT", code: 59 },
-                { name: "Lecce", abbreviation: "LE", code: 75 },
-                { name: "Lecco", abbreviation: "LC", code: 97 },
-                { name: "Livorno", abbreviation: "LI", code: 49 },
-                { name: "Lodi", abbreviation: "LO", code: 98 },
-                { name: "Lucca", abbreviation: "LU", code: 46 },
-                { name: "Macerata", abbreviation: "MC", code: 43 },
-                { name: "Mantova", abbreviation: "MN", code: 20 },
-                { name: "Massa-Carrara", abbreviation: "MS", code: 45 },
-                { name: "Matera", abbreviation: "MT", code: 77 },
-                { name: "Medio Campidano", abbreviation: "VS", code: 77 },
-                { name: "Messina", abbreviation: "ME", code: 83 },
-                { name: "Milano", abbreviation: "MI", code: 15 },
-                { name: "Modena", abbreviation: "MO", code: 36 },
-                { name: "Monza-Brianza", abbreviation: "MB", code: 36 },
-                { name: "Napoli", abbreviation: "NA", code: 63 },
-                { name: "Novara", abbreviation: "NO", code: 3 },
-                { name: "Nuoro", abbreviation: "NU", code: 91 },
-                { name: "Ogliastra", abbreviation: "OG", code: 91 },
-                { name: "Olbia Tempio", abbreviation: "OT", code: 91 },
-                { name: "Oristano", abbreviation: "OR", code: 95 },
-                { name: "Padova", abbreviation: "PD", code: 28 },
-                { name: "Palermo", abbreviation: "PA", code: 82 },
-                { name: "Parma", abbreviation: "PR", code: 34 },
-                { name: "Pavia", abbreviation: "PV", code: 18 },
-                { name: "Perugia", abbreviation: "PG", code: 54 },
-                { name: "Pesaro-Urbino", abbreviation: "PU", code: 41 },
-                { name: "Pescara", abbreviation: "PE", code: 68 },
-                { name: "Piacenza", abbreviation: "PC", code: 33 },
-                { name: "Pisa", abbreviation: "PI", code: 50 },
-                { name: "Pistoia", abbreviation: "PT", code: 47 },
-                { name: "Pordenone", abbreviation: "PN", code: 93 },
-                { name: "Potenza", abbreviation: "PZ", code: 76 },
-                { name: "Prato", abbreviation: "PO", code: 100 },
-                { name: "Ragusa", abbreviation: "RG", code: 88 },
-                { name: "Ravenna", abbreviation: "RA", code: 39 },
-                { name: "Reggio-Calabria", abbreviation: "RC", code: 35 },
-                { name: "Reggio-Emilia", abbreviation: "RE", code: 35 },
-                { name: "Rieti", abbreviation: "RI", code: 57 },
-                { name: "Rimini", abbreviation: "RN", code: 99 },
-                { name: "Roma", abbreviation: "Roma", code: 58 },
-                { name: "Rovigo", abbreviation: "RO", code: 29 },
-                { name: "Salerno", abbreviation: "SA", code: 65 },
-                { name: "Sassari", abbreviation: "SS", code: 90 },
-                { name: "Savona", abbreviation: "SV", code: 9 },
-                { name: "Siena", abbreviation: "SI", code: 52 },
-                { name: "Siracusa", abbreviation: "SR", code: 89 },
-                { name: "Sondrio", abbreviation: "SO", code: 14 },
-                { name: "Taranto", abbreviation: "TA", code: 73 },
-                { name: "Teramo", abbreviation: "TE", code: 67 },
-                { name: "Terni", abbreviation: "TR", code: 55 },
-                { name: "Torino", abbreviation: "TO", code: 1 },
-                { name: "Trapani", abbreviation: "TP", code: 81 },
-                { name: "Trento", abbreviation: "TN", code: 22 },
-                { name: "Treviso", abbreviation: "TV", code: 26 },
-                { name: "Trieste", abbreviation: "TS", code: 32 },
-                { name: "Udine", abbreviation: "UD", code: 30 },
-                { name: "Varese", abbreviation: "VA", code: 12 },
-                { name: "Venezia", abbreviation: "VE", code: 27 },
-                { name: "Verbania", abbreviation: "VB", code: 27 },
-                { name: "Vercelli", abbreviation: "VC", code: 2 },
-                { name: "Verona", abbreviation: "VR", code: 23 },
-                { name: "Vibo-Valentia", abbreviation: "VV", code: 102 },
-                { name: "Vicenza", abbreviation: "VI", code: 24 },
-                { name: "Viterbo", abbreviation: "VT", code: 56 }
-            ]
+            it: [
+                {name: "Agrigento", abbreviation: "AG", code: 84},
+                {name: "Alessandria", abbreviation: "AL", code: 6},
+                {name: "Ancona", abbreviation: "AN", code: 42},
+                {name: "Aosta", abbreviation: "AO", code: 7},
+                {name: "L'Aquila", abbreviation: "AQ", code: 66},
+                {name: "Arezzo", abbreviation: "AR", code: 51},
+                {name: "Ascoli-Piceno", abbreviation: "AP", code: 44},
+                {name: "Asti", abbreviation: "AT", code: 5},
+                {name: "Avellino", abbreviation: "AV", code: 64},
+                {name: "Bari", abbreviation: "BA", code: 72},
+                {name: "Barletta-Andria-Trani", abbreviation: "BT", code: 72},
+                {name: "Belluno", abbreviation: "BL", code: 25},
+                {name: "Benevento", abbreviation: "BN", code: 62},
+                {name: "Bergamo", abbreviation: "BG", code: 16},
+                {name: "Biella", abbreviation: "BI", code: 96},
+                {name: "Bologna", abbreviation: "BO", code: 37},
+                {name: "Bolzano", abbreviation: "BZ", code: 21},
+                {name: "Brescia", abbreviation: "BS", code: 17},
+                {name: "Brindisi", abbreviation: "BR", code: 74},
+                {name: "Cagliari", abbreviation: "CA", code: 92},
+                {name: "Caltanissetta", abbreviation: "CL", code: 85},
+                {name: "Campobasso", abbreviation: "CB", code: 70},
+                {name: "Carbonia Iglesias", abbreviation: "CI", code: 70},
+                {name: "Caserta", abbreviation: "CE", code: 61},
+                {name: "Catania", abbreviation: "CT", code: 87},
+                {name: "Catanzaro", abbreviation: "CZ", code: 79},
+                {name: "Chieti", abbreviation: "CH", code: 69},
+                {name: "Como", abbreviation: "CO", code: 13},
+                {name: "Cosenza", abbreviation: "CS", code: 78},
+                {name: "Cremona", abbreviation: "CR", code: 19},
+                {name: "Crotone", abbreviation: "KR", code: 101},
+                {name: "Cuneo", abbreviation: "CN", code: 4},
+                {name: "Enna", abbreviation: "EN", code: 86},
+                {name: "Fermo", abbreviation: "FM", code: 86},
+                {name: "Ferrara", abbreviation: "FE", code: 38},
+                {name: "Firenze", abbreviation: "FI", code: 48},
+                {name: "Foggia", abbreviation: "FG", code: 71},
+                {name: "Forli-Cesena", abbreviation: "FC", code: 71},
+                {name: "Frosinone", abbreviation: "FR", code: 60},
+                {name: "Genova", abbreviation: "GE", code: 10},
+                {name: "Gorizia", abbreviation: "GO", code: 31},
+                {name: "Grosseto", abbreviation: "GR", code: 53},
+                {name: "Imperia", abbreviation: "IM", code: 8},
+                {name: "Isernia", abbreviation: "IS", code: 94},
+                {name: "La-Spezia", abbreviation: "SP", code: 66},
+                {name: "Latina", abbreviation: "LT", code: 59},
+                {name: "Lecce", abbreviation: "LE", code: 75},
+                {name: "Lecco", abbreviation: "LC", code: 97},
+                {name: "Livorno", abbreviation: "LI", code: 49},
+                {name: "Lodi", abbreviation: "LO", code: 98},
+                {name: "Lucca", abbreviation: "LU", code: 46},
+                {name: "Macerata", abbreviation: "MC", code: 43},
+                {name: "Mantova", abbreviation: "MN", code: 20},
+                {name: "Massa-Carrara", abbreviation: "MS", code: 45},
+                {name: "Matera", abbreviation: "MT", code: 77},
+                {name: "Medio Campidano", abbreviation: "VS", code: 77},
+                {name: "Messina", abbreviation: "ME", code: 83},
+                {name: "Milano", abbreviation: "MI", code: 15},
+                {name: "Modena", abbreviation: "MO", code: 36},
+                {name: "Monza-Brianza", abbreviation: "MB", code: 36},
+                {name: "Napoli", abbreviation: "NA", code: 63},
+                {name: "Novara", abbreviation: "NO", code: 3},
+                {name: "Nuoro", abbreviation: "NU", code: 91},
+                {name: "Ogliastra", abbreviation: "OG", code: 91},
+                {name: "Olbia Tempio", abbreviation: "OT", code: 91},
+                {name: "Oristano", abbreviation: "OR", code: 95},
+                {name: "Padova", abbreviation: "PD", code: 28},
+                {name: "Palermo", abbreviation: "PA", code: 82},
+                {name: "Parma", abbreviation: "PR", code: 34},
+                {name: "Pavia", abbreviation: "PV", code: 18},
+                {name: "Perugia", abbreviation: "PG", code: 54},
+                {name: "Pesaro-Urbino", abbreviation: "PU", code: 41},
+                {name: "Pescara", abbreviation: "PE", code: 68},
+                {name: "Piacenza", abbreviation: "PC", code: 33},
+                {name: "Pisa", abbreviation: "PI", code: 50},
+                {name: "Pistoia", abbreviation: "PT", code: 47},
+                {name: "Pordenone", abbreviation: "PN", code: 93},
+                {name: "Potenza", abbreviation: "PZ", code: 76},
+                {name: "Prato", abbreviation: "PO", code: 100},
+                {name: "Ragusa", abbreviation: "RG", code: 88},
+                {name: "Ravenna", abbreviation: "RA", code: 39},
+                {name: "Reggio-Calabria", abbreviation: "RC", code: 35},
+                {name: "Reggio-Emilia", abbreviation: "RE", code: 35},
+                {name: "Rieti", abbreviation: "RI", code: 57},
+                {name: "Rimini", abbreviation: "RN", code: 99},
+                {name: "Roma", abbreviation: "Roma", code: 58},
+                {name: "Rovigo", abbreviation: "RO", code: 29},
+                {name: "Salerno", abbreviation: "SA", code: 65},
+                {name: "Sassari", abbreviation: "SS", code: 90},
+                {name: "Savona", abbreviation: "SV", code: 9},
+                {name: "Siena", abbreviation: "SI", code: 52},
+                {name: "Siracusa", abbreviation: "SR", code: 89},
+                {name: "Sondrio", abbreviation: "SO", code: 14},
+                {name: "Taranto", abbreviation: "TA", code: 73},
+                {name: "Teramo", abbreviation: "TE", code: 67},
+                {name: "Terni", abbreviation: "TR", code: 55},
+                {name: "Torino", abbreviation: "TO", code: 1},
+                {name: "Trapani", abbreviation: "TP", code: 81},
+                {name: "Trento", abbreviation: "TN", code: 22},
+                {name: "Treviso", abbreviation: "TV", code: 26},
+                {name: "Trieste", abbreviation: "TS", code: 32},
+                {name: "Udine", abbreviation: "UD", code: 30},
+                {name: "Varese", abbreviation: "VA", code: 12},
+                {name: "Venezia", abbreviation: "VE", code: 27},
+                {name: "Verbania", abbreviation: "VB", code: 27},
+                {name: "Vercelli", abbreviation: "VC", code: 2},
+                {name: "Verona", abbreviation: "VR", code: 23},
+                {name: "Vibo-Valentia", abbreviation: "VV", code: 102},
+                {name: "Vicenza", abbreviation: "VI", code: 24},
+                {name: "Viterbo", abbreviation: "VT", code: 56},
+            ],
         },
 
-            // from: https://github.com/samsargent/Useful-Autocomplete-Data/blob/master/data/nationalities.json
+        // from: https://github.com/samsargent/Useful-Autocomplete-Data/blob/master/data/nationalities.json
         nationalities: [
-           {name: 'Afghan'},
-           {name: 'Albanian'},
-           {name: 'Algerian'},
-           {name: 'American'},
-           {name: 'Andorran'},
-           {name: 'Angolan'},
-           {name: 'Antiguans'},
-           {name: 'Argentinean'},
-           {name: 'Armenian'},
-           {name: 'Australian'},
-           {name: 'Austrian'},
-           {name: 'Azerbaijani'},
-           {name: 'Bahami'},
-           {name: 'Bahraini'},
-           {name: 'Bangladeshi'},
-           {name: 'Barbadian'},
-           {name: 'Barbudans'},
-           {name: 'Batswana'},
-           {name: 'Belarusian'},
-           {name: 'Belgian'},
-           {name: 'Belizean'},
-           {name: 'Beninese'},
-           {name: 'Bhutanese'},
-           {name: 'Bolivian'},
-           {name: 'Bosnian'},
-           {name: 'Brazilian'},
-           {name: 'British'},
-           {name: 'Bruneian'},
-           {name: 'Bulgarian'},
-           {name: 'Burkinabe'},
-           {name: 'Burmese'},
-           {name: 'Burundian'},
-           {name: 'Cambodian'},
-           {name: 'Cameroonian'},
-           {name: 'Canadian'},
-           {name: 'Cape Verdean'},
-           {name: 'Central African'},
-           {name: 'Chadian'},
-           {name: 'Chilean'},
-           {name: 'Chinese'},
-           {name: 'Colombian'},
-           {name: 'Comoran'},
-           {name: 'Congolese'},
-           {name: 'Costa Rican'},
-           {name: 'Croatian'},
-           {name: 'Cuban'},
-           {name: 'Cypriot'},
-           {name: 'Czech'},
-           {name: 'Danish'},
-           {name: 'Djibouti'},
-           {name: 'Dominican'},
-           {name: 'Dutch'},
-           {name: 'East Timorese'},
-           {name: 'Ecuadorean'},
-           {name: 'Egyptian'},
-           {name: 'Emirian'},
-           {name: 'Equatorial Guinean'},
-           {name: 'Eritrean'},
-           {name: 'Estonian'},
-           {name: 'Ethiopian'},
-           {name: 'Fijian'},
-           {name: 'Filipino'},
-           {name: 'Finnish'},
-           {name: 'French'},
-           {name: 'Gabonese'},
-           {name: 'Gambian'},
-           {name: 'Georgian'},
-           {name: 'German'},
-           {name: 'Ghanaian'},
-           {name: 'Greek'},
-           {name: 'Grenadian'},
-           {name: 'Guatemalan'},
-           {name: 'Guinea-Bissauan'},
-           {name: 'Guinean'},
-           {name: 'Guyanese'},
-           {name: 'Haitian'},
-           {name: 'Herzegovinian'},
-           {name: 'Honduran'},
-           {name: 'Hungarian'},
-           {name: 'I-Kiribati'},
-           {name: 'Icelander'},
-           {name: 'Indian'},
-           {name: 'Indonesian'},
-           {name: 'Iranian'},
-           {name: 'Iraqi'},
-           {name: 'Irish'},
-           {name: 'Israeli'},
-           {name: 'Italian'},
-           {name: 'Ivorian'},
-           {name: 'Jamaican'},
-           {name: 'Japanese'},
-           {name: 'Jordanian'},
-           {name: 'Kazakhstani'},
-           {name: 'Kenyan'},
-           {name: 'Kittian and Nevisian'},
-           {name: 'Kuwaiti'},
-           {name: 'Kyrgyz'},
-           {name: 'Laotian'},
-           {name: 'Latvian'},
-           {name: 'Lebanese'},
-           {name: 'Liberian'},
-           {name: 'Libyan'},
-           {name: 'Liechtensteiner'},
-           {name: 'Lithuanian'},
-           {name: 'Luxembourger'},
-           {name: 'Macedonian'},
-           {name: 'Malagasy'},
-           {name: 'Malawian'},
-           {name: 'Malaysian'},
-           {name: 'Maldivan'},
-           {name: 'Malian'},
-           {name: 'Maltese'},
-           {name: 'Marshallese'},
-           {name: 'Mauritanian'},
-           {name: 'Mauritian'},
-           {name: 'Mexican'},
-           {name: 'Micronesian'},
-           {name: 'Moldovan'},
-           {name: 'Monacan'},
-           {name: 'Mongolian'},
-           {name: 'Moroccan'},
-           {name: 'Mosotho'},
-           {name: 'Motswana'},
-           {name: 'Mozambican'},
-           {name: 'Namibian'},
-           {name: 'Nauruan'},
-           {name: 'Nepalese'},
-           {name: 'New Zealander'},
-           {name: 'Nicaraguan'},
-           {name: 'Nigerian'},
-           {name: 'Nigerien'},
-           {name: 'North Korean'},
-           {name: 'Northern Irish'},
-           {name: 'Norwegian'},
-           {name: 'Omani'},
-           {name: 'Pakistani'},
-           {name: 'Palauan'},
-           {name: 'Panamanian'},
-           {name: 'Papua New Guinean'},
-           {name: 'Paraguayan'},
-           {name: 'Peruvian'},
-           {name: 'Polish'},
-           {name: 'Portuguese'},
-           {name: 'Qatari'},
-           {name: 'Romani'},
-           {name: 'Russian'},
-           {name: 'Rwandan'},
-           {name: 'Saint Lucian'},
-           {name: 'Salvadoran'},
-           {name: 'Samoan'},
-           {name: 'San Marinese'},
-           {name: 'Sao Tomean'},
-           {name: 'Saudi'},
-           {name: 'Scottish'},
-           {name: 'Senegalese'},
-           {name: 'Serbian'},
-           {name: 'Seychellois'},
-           {name: 'Sierra Leonean'},
-           {name: 'Singaporean'},
-           {name: 'Slovakian'},
-           {name: 'Slovenian'},
-           {name: 'Solomon Islander'},
-           {name: 'Somali'},
-           {name: 'South African'},
-           {name: 'South Korean'},
-           {name: 'Spanish'},
-           {name: 'Sri Lankan'},
-           {name: 'Sudanese'},
-           {name: 'Surinamer'},
-           {name: 'Swazi'},
-           {name: 'Swedish'},
-           {name: 'Swiss'},
-           {name: 'Syrian'},
-           {name: 'Taiwanese'},
-           {name: 'Tajik'},
-           {name: 'Tanzanian'},
-           {name: 'Thai'},
-           {name: 'Togolese'},
-           {name: 'Tongan'},
-           {name: 'Trinidadian or Tobagonian'},
-           {name: 'Tunisian'},
-           {name: 'Turkish'},
-           {name: 'Tuvaluan'},
-           {name: 'Ugandan'},
-           {name: 'Ukrainian'},
-           {name: 'Uruguaya'},
-           {name: 'Uzbekistani'},
-           {name: 'Venezuela'},
-           {name: 'Vietnamese'},
-           {name: 'Wels'},
-           {name: 'Yemenit'},
-           {name: 'Zambia'},
-           {name: 'Zimbabwe'},
+        {name: 'Afghan'},
+        {name: 'Albanian'},
+        {name: 'Algerian'},
+        {name: 'American'},
+        {name: 'Andorran'},
+        {name: 'Angolan'},
+        {name: 'Antiguans'},
+        {name: 'Argentinean'},
+        {name: 'Armenian'},
+        {name: 'Australian'},
+        {name: 'Austrian'},
+        {name: 'Azerbaijani'},
+        {name: 'Bahami'},
+        {name: 'Bahraini'},
+        {name: 'Bangladeshi'},
+        {name: 'Barbadian'},
+        {name: 'Barbudans'},
+        {name: 'Batswana'},
+        {name: 'Belarusian'},
+        {name: 'Belgian'},
+        {name: 'Belizean'},
+        {name: 'Beninese'},
+        {name: 'Bhutanese'},
+        {name: 'Bolivian'},
+        {name: 'Bosnian'},
+        {name: 'Brazilian'},
+        {name: 'British'},
+        {name: 'Bruneian'},
+        {name: 'Bulgarian'},
+        {name: 'Burkinabe'},
+        {name: 'Burmese'},
+        {name: 'Burundian'},
+        {name: 'Cambodian'},
+        {name: 'Cameroonian'},
+        {name: 'Canadian'},
+        {name: 'Cape Verdean'},
+        {name: 'Central African'},
+        {name: 'Chadian'},
+        {name: 'Chilean'},
+        {name: 'Chinese'},
+        {name: 'Colombian'},
+        {name: 'Comoran'},
+        {name: 'Congolese'},
+        {name: 'Costa Rican'},
+        {name: 'Croatian'},
+        {name: 'Cuban'},
+        {name: 'Cypriot'},
+        {name: 'Czech'},
+        {name: 'Danish'},
+        {name: 'Djibouti'},
+        {name: 'Dominican'},
+        {name: 'Dutch'},
+        {name: 'East Timorese'},
+        {name: 'Ecuadorean'},
+        {name: 'Egyptian'},
+        {name: 'Emirian'},
+        {name: 'Equatorial Guinean'},
+        {name: 'Eritrean'},
+        {name: 'Estonian'},
+        {name: 'Ethiopian'},
+        {name: 'Fijian'},
+        {name: 'Filipino'},
+        {name: 'Finnish'},
+        {name: 'French'},
+        {name: 'Gabonese'},
+        {name: 'Gambian'},
+        {name: 'Georgian'},
+        {name: 'German'},
+        {name: 'Ghanaian'},
+        {name: 'Greek'},
+        {name: 'Grenadian'},
+        {name: 'Guatemalan'},
+        {name: 'Guinea-Bissauan'},
+        {name: 'Guinean'},
+        {name: 'Guyanese'},
+        {name: 'Haitian'},
+        {name: 'Herzegovinian'},
+        {name: 'Honduran'},
+        {name: 'Hungarian'},
+        {name: 'I-Kiribati'},
+        {name: 'Icelander'},
+        {name: 'Indian'},
+        {name: 'Indonesian'},
+        {name: 'Iranian'},
+        {name: 'Iraqi'},
+        {name: 'Irish'},
+        {name: 'Israeli'},
+        {name: 'Italian'},
+        {name: 'Ivorian'},
+        {name: 'Jamaican'},
+        {name: 'Japanese'},
+        {name: 'Jordanian'},
+        {name: 'Kazakhstani'},
+        {name: 'Kenyan'},
+        {name: 'Kittian and Nevisian'},
+        {name: 'Kuwaiti'},
+        {name: 'Kyrgyz'},
+        {name: 'Laotian'},
+        {name: 'Latvian'},
+        {name: 'Lebanese'},
+        {name: 'Liberian'},
+        {name: 'Libyan'},
+        {name: 'Liechtensteiner'},
+        {name: 'Lithuanian'},
+        {name: 'Luxembourger'},
+        {name: 'Macedonian'},
+        {name: 'Malagasy'},
+        {name: 'Malawian'},
+        {name: 'Malaysian'},
+        {name: 'Maldivan'},
+        {name: 'Malian'},
+        {name: 'Maltese'},
+        {name: 'Marshallese'},
+        {name: 'Mauritanian'},
+        {name: 'Mauritian'},
+        {name: 'Mexican'},
+        {name: 'Micronesian'},
+        {name: 'Moldovan'},
+        {name: 'Monacan'},
+        {name: 'Mongolian'},
+        {name: 'Moroccan'},
+        {name: 'Mosotho'},
+        {name: 'Motswana'},
+        {name: 'Mozambican'},
+        {name: 'Namibian'},
+        {name: 'Nauruan'},
+        {name: 'Nepalese'},
+        {name: 'New Zealander'},
+        {name: 'Nicaraguan'},
+        {name: 'Nigerian'},
+        {name: 'Nigerien'},
+        {name: 'North Korean'},
+        {name: 'Northern Irish'},
+        {name: 'Norwegian'},
+        {name: 'Omani'},
+        {name: 'Pakistani'},
+        {name: 'Palauan'},
+        {name: 'Panamanian'},
+        {name: 'Papua New Guinean'},
+        {name: 'Paraguayan'},
+        {name: 'Peruvian'},
+        {name: 'Polish'},
+        {name: 'Portuguese'},
+        {name: 'Qatari'},
+        {name: 'Romani'},
+        {name: 'Russian'},
+        {name: 'Rwandan'},
+        {name: 'Saint Lucian'},
+        {name: 'Salvadoran'},
+        {name: 'Samoan'},
+        {name: 'San Marinese'},
+        {name: 'Sao Tomean'},
+        {name: 'Saudi'},
+        {name: 'Scottish'},
+        {name: 'Senegalese'},
+        {name: 'Serbian'},
+        {name: 'Seychellois'},
+        {name: 'Sierra Leonean'},
+        {name: 'Singaporean'},
+        {name: 'Slovakian'},
+        {name: 'Slovenian'},
+        {name: 'Solomon Islander'},
+        {name: 'Somali'},
+        {name: 'South African'},
+        {name: 'South Korean'},
+        {name: 'Spanish'},
+        {name: 'Sri Lankan'},
+        {name: 'Sudanese'},
+        {name: 'Surinamer'},
+        {name: 'Swazi'},
+        {name: 'Swedish'},
+        {name: 'Swiss'},
+        {name: 'Syrian'},
+        {name: 'Taiwanese'},
+        {name: 'Tajik'},
+        {name: 'Tanzanian'},
+        {name: 'Thai'},
+        {name: 'Togolese'},
+        {name: 'Tongan'},
+        {name: 'Trinidadian or Tobagonian'},
+        {name: 'Tunisian'},
+        {name: 'Turkish'},
+        {name: 'Tuvaluan'},
+        {name: 'Ugandan'},
+        {name: 'Ukrainian'},
+        {name: 'Uruguaya'},
+        {name: 'Uzbekistani'},
+        {name: 'Venezuela'},
+        {name: 'Vietnamese'},
+        {name: 'Wels'},
+        {name: 'Yemenit'},
+        {name: 'Zambia'},
+        {name: 'Zimbabwe'},
         ],
-          // http://www.loc.gov/standards/iso639-2/php/code_list.php (ISO-639-1 codes)
+
+        // http://www.loc.gov/standards/iso639-2/php/code_list.php (ISO-639-1 codes)
         locale_languages: [
-          "aa",
-          "ab",
-          "ae",
-          "af",
-          "ak",
-          "am",
-          "an",
-          "ar",
-          "as",
-          "av",
-          "ay",
-          "az",
-          "ba",
-          "be",
-          "bg",
-          "bh",
-          "bi",
-          "bm",
-          "bn",
-          "bo",
-          "br",
-          "bs",
-          "ca",
-          "ce",
-          "ch",
-          "co",
-          "cr",
-          "cs",
-          "cu",
-          "cv",
-          "cy",
-          "da",
-          "de",
-          "dv",
-          "dz",
-          "ee",
-          "el",
-          "en",
-          "eo",
-          "es",
-          "et",
-          "eu",
-          "fa",
-          "ff",
-          "fi",
-          "fj",
-          "fo",
-          "fr",
-          "fy",
-          "ga",
-          "gd",
-          "gl",
-          "gn",
-          "gu",
-          "gv",
-          "ha",
-          "he",
-          "hi",
-          "ho",
-          "hr",
-          "ht",
-          "hu",
-          "hy",
-          "hz",
-          "ia",
-          "id",
-          "ie",
-          "ig",
-          "ii",
-          "ik",
-          "io",
-          "is",
-          "it",
-          "iu",
-          "ja",
-          "jv",
-          "ka",
-          "kg",
-          "ki",
-          "kj",
-          "kk",
-          "kl",
-          "km",
-          "kn",
-          "ko",
-          "kr",
-          "ks",
-          "ku",
-          "kv",
-          "kw",
-          "ky",
-          "la",
-          "lb",
-          "lg",
-          "li",
-          "ln",
-          "lo",
-          "lt",
-          "lu",
-          "lv",
-          "mg",
-          "mh",
-          "mi",
-          "mk",
-          "ml",
-          "mn",
-          "mr",
-          "ms",
-          "mt",
-          "my",
-          "na",
-          "nb",
-          "nd",
-          "ne",
-          "ng",
-          "nl",
-          "nn",
-          "no",
-          "nr",
-          "nv",
-          "ny",
-          "oc",
-          "oj",
-          "om",
-          "or",
-          "os",
-          "pa",
-          "pi",
-          "pl",
-          "ps",
-          "pt",
-          "qu",
-          "rm",
-          "rn",
-          "ro",
-          "ru",
-          "rw",
-          "sa",
-          "sc",
-          "sd",
-          "se",
-          "sg",
-          "si",
-          "sk",
-          "sl",
-          "sm",
-          "sn",
-          "so",
-          "sq",
-          "sr",
-          "ss",
-          "st",
-          "su",
-          "sv",
-          "sw",
-          "ta",
-          "te",
-          "tg",
-          "th",
-          "ti",
-          "tk",
-          "tl",
-          "tn",
-          "to",
-          "tr",
-          "ts",
-          "tt",
-          "tw",
-          "ty",
-          "ug",
-          "uk",
-          "ur",
-          "uz",
-          "ve",
-          "vi",
-          "vo",
-          "wa",
-          "wo",
-          "xh",
-          "yi",
-          "yo",
-          "za",
-          "zh",
-          "zu"
+            "aa","ab","ae","af","ak","am","an","ar","as","av","ay","az",
+            "ba","be","bg","bh","bi","bm","bn","bo","br","bs",
+            "ca","ce","ch","co","cr","cs","cu","cv","cy","da","de","dv","dz","ee","el","en","eo","es","et","eu",
+            "fa","ff","fi","fj","fo","fr","fy",
+            "ga","gd","gl","gn","gu","gv",
+            "ha","he","hi","ho","hr","ht","hu","hy","hz",
+            "ia","id","ie","ig","ii","ik","io","is","it","iu","ja","jv",
+            "ka","kg","ki","kj","kk","kl","km","kn","ko","kr","ks","ku","kv","kw","ky",
+            "la","lb","lg","li","ln","lo","lt","lu","lv",
+            "mg","mh","mi","mk","ml","mn","mr","ms","mt","my",
+            "na","nb","nd","ne","ng","nl","nn","no","nr","nv","ny",
+            "oc","oj","om","or","os","pa","pi","pl","ps","pt",
+            "qu","rm","rn","ro","ru","rw",
+            "sa","sc","sd","se","sg","si","sk","sl","sm","sn","so","sq","sr","ss","st","su","sv","sw",
+            "ta","te","tg","th","ti","tk","tl","tn","to","tr","ts","tt","tw","ty",
+            "ug","uk","ur","uz",
+            "ve","vi","vo","wa","wo",
+            "xh","yi","yo","za","zh","zu",
         ],
 
         // From http://data.okfn.org/data/core/language-codes#resource-language-codes-full (IETF language tags)
         locale_regions: [
-          "agq-CM",
-          "asa-TZ",
-          "ast-ES",
-          "bas-CM",
-          "bem-ZM",
-          "bez-TZ",
-          "brx-IN",
-          "cgg-UG",
-          "chr-US",
-          "dav-KE",
-          "dje-NE",
-          "dsb-DE",
-          "dua-CM",
-          "dyo-SN",
-          "ebu-KE",
-          "ewo-CM",
-          "fil-PH",
-          "fur-IT",
-          "gsw-CH",
-          "gsw-FR",
-          "gsw-LI",
-          "guz-KE",
-          "haw-US",
-          "hsb-DE",
-          "jgo-CM",
-          "jmc-TZ",
-          "kab-DZ",
-          "kam-KE",
-          "kde-TZ",
-          "kea-CV",
-          "khq-ML",
-          "kkj-CM",
-          "kln-KE",
-          "kok-IN",
-          "ksb-TZ",
-          "ksf-CM",
-          "ksh-DE",
-          "lag-TZ",
-          "lkt-US",
-          "luo-KE",
-          "luy-KE",
-          "mas-KE",
-          "mas-TZ",
-          "mer-KE",
-          "mfe-MU",
-          "mgh-MZ",
-          "mgo-CM",
-          "mua-CM",
-          "naq-NA",
-          "nmg-CM",
-          "nnh-CM",
-          "nus-SD",
-          "nyn-UG",
-          "rof-TZ",
-          "rwk-TZ",
-          "sah-RU",
-          "saq-KE",
-          "sbp-TZ",
-          "seh-MZ",
-          "ses-ML",
-          "shi-Latn",
-          "shi-Latn-MA",
-          "shi-Tfng",
-          "shi-Tfng-MA",
-          "smn-FI",
-          "teo-KE",
-          "teo-UG",
-          "twq-NE",
-          "tzm-Latn",
-          "tzm-Latn-MA",
-          "vai-Latn",
-          "vai-Latn-LR",
-          "vai-Vaii",
-          "vai-Vaii-LR",
-          "vun-TZ",
-          "wae-CH",
-          "xog-UG",
-          "yav-CM",
-          "zgh-MA",
-          "af-NA",
-          "af-ZA",
-          "ak-GH",
-          "am-ET",
-          "ar-001",
-          "ar-AE",
-          "ar-BH",
-          "ar-DJ",
-          "ar-DZ",
-          "ar-EG",
-          "ar-EH",
-          "ar-ER",
-          "ar-IL",
-          "ar-IQ",
-          "ar-JO",
-          "ar-KM",
-          "ar-KW",
-          "ar-LB",
-          "ar-LY",
-          "ar-MA",
-          "ar-MR",
-          "ar-OM",
-          "ar-PS",
-          "ar-QA",
-          "ar-SA",
-          "ar-SD",
-          "ar-SO",
-          "ar-SS",
-          "ar-SY",
-          "ar-TD",
-          "ar-TN",
-          "ar-YE",
-          "as-IN",
-          "az-Cyrl",
-          "az-Cyrl-AZ",
-          "az-Latn",
-          "az-Latn-AZ",
-          "be-BY",
-          "bg-BG",
-          "bm-Latn",
-          "bm-Latn-ML",
-          "bn-BD",
-          "bn-IN",
-          "bo-CN",
-          "bo-IN",
-          "br-FR",
-          "bs-Cyrl",
-          "bs-Cyrl-BA",
-          "bs-Latn",
-          "bs-Latn-BA",
-          "ca-AD",
-          "ca-ES",
-          "ca-ES-VALENCIA",
-          "ca-FR",
-          "ca-IT",
-          "cs-CZ",
-          "cy-GB",
-          "da-DK",
-          "da-GL",
-          "de-AT",
-          "de-BE",
-          "de-CH",
-          "de-DE",
-          "de-LI",
-          "de-LU",
-          "dz-BT",
-          "ee-GH",
-          "ee-TG",
-          "el-CY",
-          "el-GR",
-          "en-001",
-          "en-150",
-          "en-AG",
-          "en-AI",
-          "en-AS",
-          "en-AU",
-          "en-BB",
-          "en-BE",
-          "en-BM",
-          "en-BS",
-          "en-BW",
-          "en-BZ",
-          "en-CA",
-          "en-CC",
-          "en-CK",
-          "en-CM",
-          "en-CX",
-          "en-DG",
-          "en-DM",
-          "en-ER",
-          "en-FJ",
-          "en-FK",
-          "en-FM",
-          "en-GB",
-          "en-GD",
-          "en-GG",
-          "en-GH",
-          "en-GI",
-          "en-GM",
-          "en-GU",
-          "en-GY",
-          "en-HK",
-          "en-IE",
-          "en-IM",
-          "en-IN",
-          "en-IO",
-          "en-JE",
-          "en-JM",
-          "en-KE",
-          "en-KI",
-          "en-KN",
-          "en-KY",
-          "en-LC",
-          "en-LR",
-          "en-LS",
-          "en-MG",
-          "en-MH",
-          "en-MO",
-          "en-MP",
-          "en-MS",
-          "en-MT",
-          "en-MU",
-          "en-MW",
-          "en-MY",
-          "en-NA",
-          "en-NF",
-          "en-NG",
-          "en-NR",
-          "en-NU",
-          "en-NZ",
-          "en-PG",
-          "en-PH",
-          "en-PK",
-          "en-PN",
-          "en-PR",
-          "en-PW",
-          "en-RW",
-          "en-SB",
-          "en-SC",
-          "en-SD",
-          "en-SG",
-          "en-SH",
-          "en-SL",
-          "en-SS",
-          "en-SX",
-          "en-SZ",
-          "en-TC",
-          "en-TK",
-          "en-TO",
-          "en-TT",
-          "en-TV",
-          "en-TZ",
-          "en-UG",
-          "en-UM",
-          "en-US",
-          "en-US-POSIX",
-          "en-VC",
-          "en-VG",
-          "en-VI",
-          "en-VU",
-          "en-WS",
-          "en-ZA",
-          "en-ZM",
-          "en-ZW",
-          "eo-001",
-          "es-419",
-          "es-AR",
-          "es-BO",
-          "es-CL",
-          "es-CO",
-          "es-CR",
-          "es-CU",
-          "es-DO",
-          "es-EA",
-          "es-EC",
-          "es-ES",
-          "es-GQ",
-          "es-GT",
-          "es-HN",
-          "es-IC",
-          "es-MX",
-          "es-NI",
-          "es-PA",
-          "es-PE",
-          "es-PH",
-          "es-PR",
-          "es-PY",
-          "es-SV",
-          "es-US",
-          "es-UY",
-          "es-VE",
-          "et-EE",
-          "eu-ES",
-          "fa-AF",
-          "fa-IR",
-          "ff-CM",
-          "ff-GN",
-          "ff-MR",
-          "ff-SN",
-          "fi-FI",
-          "fo-FO",
-          "fr-BE",
-          "fr-BF",
-          "fr-BI",
-          "fr-BJ",
-          "fr-BL",
-          "fr-CA",
-          "fr-CD",
-          "fr-CF",
-          "fr-CG",
-          "fr-CH",
-          "fr-CI",
-          "fr-CM",
-          "fr-DJ",
-          "fr-DZ",
-          "fr-FR",
-          "fr-GA",
-          "fr-GF",
-          "fr-GN",
-          "fr-GP",
-          "fr-GQ",
-          "fr-HT",
-          "fr-KM",
-          "fr-LU",
-          "fr-MA",
-          "fr-MC",
-          "fr-MF",
-          "fr-MG",
-          "fr-ML",
-          "fr-MQ",
-          "fr-MR",
-          "fr-MU",
-          "fr-NC",
-          "fr-NE",
-          "fr-PF",
-          "fr-PM",
-          "fr-RE",
-          "fr-RW",
-          "fr-SC",
-          "fr-SN",
-          "fr-SY",
-          "fr-TD",
-          "fr-TG",
-          "fr-TN",
-          "fr-VU",
-          "fr-WF",
-          "fr-YT",
-          "fy-NL",
-          "ga-IE",
-          "gd-GB",
-          "gl-ES",
-          "gu-IN",
-          "gv-IM",
-          "ha-Latn",
-          "ha-Latn-GH",
-          "ha-Latn-NE",
-          "ha-Latn-NG",
-          "he-IL",
-          "hi-IN",
-          "hr-BA",
-          "hr-HR",
-          "hu-HU",
-          "hy-AM",
-          "id-ID",
-          "ig-NG",
-          "ii-CN",
-          "is-IS",
-          "it-CH",
-          "it-IT",
-          "it-SM",
-          "ja-JP",
-          "ka-GE",
-          "ki-KE",
-          "kk-Cyrl",
-          "kk-Cyrl-KZ",
-          "kl-GL",
-          "km-KH",
-          "kn-IN",
-          "ko-KP",
-          "ko-KR",
-          "ks-Arab",
-          "ks-Arab-IN",
-          "kw-GB",
-          "ky-Cyrl",
-          "ky-Cyrl-KG",
-          "lb-LU",
-          "lg-UG",
-          "ln-AO",
-          "ln-CD",
-          "ln-CF",
-          "ln-CG",
-          "lo-LA",
-          "lt-LT",
-          "lu-CD",
-          "lv-LV",
-          "mg-MG",
-          "mk-MK",
-          "ml-IN",
-          "mn-Cyrl",
-          "mn-Cyrl-MN",
-          "mr-IN",
-          "ms-Latn",
-          "ms-Latn-BN",
-          "ms-Latn-MY",
-          "ms-Latn-SG",
-          "mt-MT",
-          "my-MM",
-          "nb-NO",
-          "nb-SJ",
-          "nd-ZW",
-          "ne-IN",
-          "ne-NP",
-          "nl-AW",
-          "nl-BE",
-          "nl-BQ",
-          "nl-CW",
-          "nl-NL",
-          "nl-SR",
-          "nl-SX",
-          "nn-NO",
-          "om-ET",
-          "om-KE",
-          "or-IN",
-          "os-GE",
-          "os-RU",
-          "pa-Arab",
-          "pa-Arab-PK",
-          "pa-Guru",
-          "pa-Guru-IN",
-          "pl-PL",
-          "ps-AF",
-          "pt-AO",
-          "pt-BR",
-          "pt-CV",
-          "pt-GW",
-          "pt-MO",
-          "pt-MZ",
-          "pt-PT",
-          "pt-ST",
-          "pt-TL",
-          "qu-BO",
-          "qu-EC",
-          "qu-PE",
-          "rm-CH",
-          "rn-BI",
-          "ro-MD",
-          "ro-RO",
-          "ru-BY",
-          "ru-KG",
-          "ru-KZ",
-          "ru-MD",
-          "ru-RU",
-          "ru-UA",
-          "rw-RW",
-          "se-FI",
-          "se-NO",
-          "se-SE",
-          "sg-CF",
-          "si-LK",
-          "sk-SK",
-          "sl-SI",
-          "sn-ZW",
-          "so-DJ",
-          "so-ET",
-          "so-KE",
-          "so-SO",
-          "sq-AL",
-          "sq-MK",
-          "sq-XK",
-          "sr-Cyrl",
-          "sr-Cyrl-BA",
-          "sr-Cyrl-ME",
-          "sr-Cyrl-RS",
-          "sr-Cyrl-XK",
-          "sr-Latn",
-          "sr-Latn-BA",
-          "sr-Latn-ME",
-          "sr-Latn-RS",
-          "sr-Latn-XK",
-          "sv-AX",
-          "sv-FI",
-          "sv-SE",
-          "sw-CD",
-          "sw-KE",
-          "sw-TZ",
-          "sw-UG",
-          "ta-IN",
-          "ta-LK",
-          "ta-MY",
-          "ta-SG",
-          "te-IN",
-          "th-TH",
-          "ti-ER",
-          "ti-ET",
-          "to-TO",
-          "tr-CY",
-          "tr-TR",
-          "ug-Arab",
-          "ug-Arab-CN",
-          "uk-UA",
-          "ur-IN",
-          "ur-PK",
-          "uz-Arab",
-          "uz-Arab-AF",
-          "uz-Cyrl",
-          "uz-Cyrl-UZ",
-          "uz-Latn",
-          "uz-Latn-UZ",
-          "vi-VN",
-          "yi-001",
-          "yo-BJ",
-          "yo-NG",
-          "zh-Hans",
-          "zh-Hans-CN",
-          "zh-Hans-HK",
-          "zh-Hans-MO",
-          "zh-Hans-SG",
-          "zh-Hant",
-          "zh-Hant-HK",
-          "zh-Hant-MO",
-          "zh-Hant-TW",
-          "zu-ZA"
+        "agq-CM",
+        "asa-TZ",
+        "ast-ES",
+        "bas-CM",
+        "bem-ZM",
+        "bez-TZ",
+        "brx-IN",
+        "cgg-UG",
+        "chr-US",
+        "dav-KE",
+        "dje-NE",
+        "dsb-DE",
+        "dua-CM",
+        "dyo-SN",
+        "ebu-KE",
+        "ewo-CM",
+        "fil-PH",
+        "fur-IT",
+        "gsw-CH",
+        "gsw-FR",
+        "gsw-LI",
+        "guz-KE",
+        "haw-US",
+        "hsb-DE",
+        "jgo-CM",
+        "jmc-TZ",
+        "kab-DZ",
+        "kam-KE",
+        "kde-TZ",
+        "kea-CV",
+        "khq-ML",
+        "kkj-CM",
+        "kln-KE",
+        "kok-IN",
+        "ksb-TZ",
+        "ksf-CM",
+        "ksh-DE",
+        "lag-TZ",
+        "lkt-US",
+        "luo-KE",
+        "luy-KE",
+        "mas-KE",
+        "mas-TZ",
+        "mer-KE",
+        "mfe-MU",
+        "mgh-MZ",
+        "mgo-CM",
+        "mua-CM",
+        "naq-NA",
+        "nmg-CM",
+        "nnh-CM",
+        "nus-SD",
+        "nyn-UG",
+        "rof-TZ",
+        "rwk-TZ",
+        "sah-RU",
+        "saq-KE",
+        "sbp-TZ",
+        "seh-MZ",
+        "ses-ML",
+        "shi-Latn",
+        "shi-Latn-MA",
+        "shi-Tfng",
+        "shi-Tfng-MA",
+        "smn-FI",
+        "teo-KE",
+        "teo-UG",
+        "twq-NE",
+        "tzm-Latn",
+        "tzm-Latn-MA",
+        "vai-Latn",
+        "vai-Latn-LR",
+        "vai-Vaii",
+        "vai-Vaii-LR",
+        "vun-TZ",
+        "wae-CH",
+        "xog-UG",
+        "yav-CM",
+        "zgh-MA",
+        "af-NA",
+        "af-ZA",
+        "ak-GH",
+        "am-ET",
+        "ar-001",
+        "ar-AE",
+        "ar-BH",
+        "ar-DJ",
+        "ar-DZ",
+        "ar-EG",
+        "ar-EH",
+        "ar-ER",
+        "ar-IL",
+        "ar-IQ",
+        "ar-JO",
+        "ar-KM",
+        "ar-KW",
+        "ar-LB",
+        "ar-LY",
+        "ar-MA",
+        "ar-MR",
+        "ar-OM",
+        "ar-PS",
+        "ar-QA",
+        "ar-SA",
+        "ar-SD",
+        "ar-SO",
+        "ar-SS",
+        "ar-SY",
+        "ar-TD",
+        "ar-TN",
+        "ar-YE",
+        "as-IN",
+        "az-Cyrl",
+        "az-Cyrl-AZ",
+        "az-Latn",
+        "az-Latn-AZ",
+        "be-BY",
+        "bg-BG",
+        "bm-Latn",
+        "bm-Latn-ML",
+        "bn-BD",
+        "bn-IN",
+        "bo-CN",
+        "bo-IN",
+        "br-FR",
+        "bs-Cyrl",
+        "bs-Cyrl-BA",
+        "bs-Latn",
+        "bs-Latn-BA",
+        "ca-AD",
+        "ca-ES",
+        "ca-ES-VALENCIA",
+        "ca-FR",
+        "ca-IT",
+        "cs-CZ",
+        "cy-GB",
+        "da-DK",
+        "da-GL",
+        "de-AT",
+        "de-BE",
+        "de-CH",
+        "de-DE",
+        "de-LI",
+        "de-LU",
+        "dz-BT",
+        "ee-GH",
+        "ee-TG",
+        "el-CY",
+        "el-GR",
+        "en-001",
+        "en-150",
+        "en-AG",
+        "en-AI",
+        "en-AS",
+        "en-AU",
+        "en-BB",
+        "en-BE",
+        "en-BM",
+        "en-BS",
+        "en-BW",
+        "en-BZ",
+        "en-CA",
+        "en-CC",
+        "en-CK",
+        "en-CM",
+        "en-CX",
+        "en-DG",
+        "en-DM",
+        "en-ER",
+        "en-FJ",
+        "en-FK",
+        "en-FM",
+        "en-GB",
+        "en-GD",
+        "en-GG",
+        "en-GH",
+        "en-GI",
+        "en-GM",
+        "en-GU",
+        "en-GY",
+        "en-HK",
+        "en-IE",
+        "en-IM",
+        "en-IN",
+        "en-IO",
+        "en-JE",
+        "en-JM",
+        "en-KE",
+        "en-KI",
+        "en-KN",
+        "en-KY",
+        "en-LC",
+        "en-LR",
+        "en-LS",
+        "en-MG",
+        "en-MH",
+        "en-MO",
+        "en-MP",
+        "en-MS",
+        "en-MT",
+        "en-MU",
+        "en-MW",
+        "en-MY",
+        "en-NA",
+        "en-NF",
+        "en-NG",
+        "en-NR",
+        "en-NU",
+        "en-NZ",
+        "en-PG",
+        "en-PH",
+        "en-PK",
+        "en-PN",
+        "en-PR",
+        "en-PW",
+        "en-RW",
+        "en-SB",
+        "en-SC",
+        "en-SD",
+        "en-SG",
+        "en-SH",
+        "en-SL",
+        "en-SS",
+        "en-SX",
+        "en-SZ",
+        "en-TC",
+        "en-TK",
+        "en-TO",
+        "en-TT",
+        "en-TV",
+        "en-TZ",
+        "en-UG",
+        "en-UM",
+        "en-US",
+        "en-US-POSIX",
+        "en-VC",
+        "en-VG",
+        "en-VI",
+        "en-VU",
+        "en-WS",
+        "en-ZA",
+        "en-ZM",
+        "en-ZW",
+        "eo-001",
+        "es-419",
+        "es-AR",
+        "es-BO",
+        "es-CL",
+        "es-CO",
+        "es-CR",
+        "es-CU",
+        "es-DO",
+        "es-EA",
+        "es-EC",
+        "es-ES",
+        "es-GQ",
+        "es-GT",
+        "es-HN",
+        "es-IC",
+        "es-MX",
+        "es-NI",
+        "es-PA",
+        "es-PE",
+        "es-PH",
+        "es-PR",
+        "es-PY",
+        "es-SV",
+        "es-US",
+        "es-UY",
+        "es-VE",
+        "et-EE",
+        "eu-ES",
+        "fa-AF",
+        "fa-IR",
+        "ff-CM",
+        "ff-GN",
+        "ff-MR",
+        "ff-SN",
+        "fi-FI",
+        "fo-FO",
+        "fr-BE",
+        "fr-BF",
+        "fr-BI",
+        "fr-BJ",
+        "fr-BL",
+        "fr-CA",
+        "fr-CD",
+        "fr-CF",
+        "fr-CG",
+        "fr-CH",
+        "fr-CI",
+        "fr-CM",
+        "fr-DJ",
+        "fr-DZ",
+        "fr-FR",
+        "fr-GA",
+        "fr-GF",
+        "fr-GN",
+        "fr-GP",
+        "fr-GQ",
+        "fr-HT",
+        "fr-KM",
+        "fr-LU",
+        "fr-MA",
+        "fr-MC",
+        "fr-MF",
+        "fr-MG",
+        "fr-ML",
+        "fr-MQ",
+        "fr-MR",
+        "fr-MU",
+        "fr-NC",
+        "fr-NE",
+        "fr-PF",
+        "fr-PM",
+        "fr-RE",
+        "fr-RW",
+        "fr-SC",
+        "fr-SN",
+        "fr-SY",
+        "fr-TD",
+        "fr-TG",
+        "fr-TN",
+        "fr-VU",
+        "fr-WF",
+        "fr-YT",
+        "fy-NL",
+        "ga-IE",
+        "gd-GB",
+        "gl-ES",
+        "gu-IN",
+        "gv-IM",
+        "ha-Latn",
+        "ha-Latn-GH",
+        "ha-Latn-NE",
+        "ha-Latn-NG",
+        "he-IL",
+        "hi-IN",
+        "hr-BA",
+        "hr-HR",
+        "hu-HU",
+        "hy-AM",
+        "id-ID",
+        "ig-NG",
+        "ii-CN",
+        "is-IS",
+        "it-CH",
+        "it-IT",
+        "it-SM",
+        "ja-JP",
+        "ka-GE",
+        "ki-KE",
+        "kk-Cyrl",
+        "kk-Cyrl-KZ",
+        "kl-GL",
+        "km-KH",
+        "kn-IN",
+        "ko-KP",
+        "ko-KR",
+        "ks-Arab",
+        "ks-Arab-IN",
+        "kw-GB",
+        "ky-Cyrl",
+        "ky-Cyrl-KG",
+        "lb-LU",
+        "lg-UG",
+        "ln-AO",
+        "ln-CD",
+        "ln-CF",
+        "ln-CG",
+        "lo-LA",
+        "lt-LT",
+        "lu-CD",
+        "lv-LV",
+        "mg-MG",
+        "mk-MK",
+        "ml-IN",
+        "mn-Cyrl",
+        "mn-Cyrl-MN",
+        "mr-IN",
+        "ms-Latn",
+        "ms-Latn-BN",
+        "ms-Latn-MY",
+        "ms-Latn-SG",
+        "mt-MT",
+        "my-MM",
+        "nb-NO",
+        "nb-SJ",
+        "nd-ZW",
+        "ne-IN",
+        "ne-NP",
+        "nl-AW",
+        "nl-BE",
+        "nl-BQ",
+        "nl-CW",
+        "nl-NL",
+        "nl-SR",
+        "nl-SX",
+        "nn-NO",
+        "om-ET",
+        "om-KE",
+        "or-IN",
+        "os-GE",
+        "os-RU",
+        "pa-Arab",
+        "pa-Arab-PK",
+        "pa-Guru",
+        "pa-Guru-IN",
+        "pl-PL",
+        "ps-AF",
+        "pt-AO",
+        "pt-BR",
+        "pt-CV",
+        "pt-GW",
+        "pt-MO",
+        "pt-MZ",
+        "pt-PT",
+        "pt-ST",
+        "pt-TL",
+        "qu-BO",
+        "qu-EC",
+        "qu-PE",
+        "rm-CH",
+        "rn-BI",
+        "ro-MD",
+        "ro-RO",
+        "ru-BY",
+        "ru-KG",
+        "ru-KZ",
+        "ru-MD",
+        "ru-RU",
+        "ru-UA",
+        "rw-RW",
+        "se-FI",
+        "se-NO",
+        "se-SE",
+        "sg-CF",
+        "si-LK",
+        "sk-SK",
+        "sl-SI",
+        "sn-ZW",
+        "so-DJ",
+        "so-ET",
+        "so-KE",
+        "so-SO",
+        "sq-AL",
+        "sq-MK",
+        "sq-XK",
+        "sr-Cyrl",
+        "sr-Cyrl-BA",
+        "sr-Cyrl-ME",
+        "sr-Cyrl-RS",
+        "sr-Cyrl-XK",
+        "sr-Latn",
+        "sr-Latn-BA",
+        "sr-Latn-ME",
+        "sr-Latn-RS",
+        "sr-Latn-XK",
+        "sv-AX",
+        "sv-FI",
+        "sv-SE",
+        "sw-CD",
+        "sw-KE",
+        "sw-TZ",
+        "sw-UG",
+        "ta-IN",
+        "ta-LK",
+        "ta-MY",
+        "ta-SG",
+        "te-IN",
+        "th-TH",
+        "ti-ER",
+        "ti-ET",
+        "to-TO",
+        "tr-CY",
+        "tr-TR",
+        "ug-Arab",
+        "ug-Arab-CN",
+        "uk-UA",
+        "ur-IN",
+        "ur-PK",
+        "uz-Arab",
+        "uz-Arab-AF",
+        "uz-Cyrl",
+        "uz-Cyrl-UZ",
+        "uz-Latn",
+        "uz-Latn-UZ",
+        "vi-VN",
+        "yi-001",
+        "yo-BJ",
+        "yo-NG",
+        "zh-Hans",
+        "zh-Hans-CN",
+        "zh-Hans-HK",
+        "zh-Hans-MO",
+        "zh-Hans-SG",
+        "zh-Hant",
+        "zh-Hant-HK",
+        "zh-Hant-MO",
+        "zh-Hant-TW",
+        "zu-ZA",
         ],
 
         us_states_and_dc: [
@@ -4047,7 +3901,7 @@ options,
             {name: 'Washington', abbreviation: 'WA'},
             {name: 'West Virginia', abbreviation: 'WV'},
             {name: 'Wisconsin', abbreviation: 'WI'},
-            {name: 'Wyoming', abbreviation: 'WY'}
+            {name: 'Wyoming', abbreviation: 'WY'},
         ],
 
         territories: [
@@ -4057,76 +3911,76 @@ options,
             {name: 'Marshall Islands', abbreviation: 'MH'},
             {name: 'Northern Mariana Islands', abbreviation: 'MP'},
             {name: 'Puerto Rico', abbreviation: 'PR'},
-            {name: 'Virgin Islands, U.S.', abbreviation: 'VI'}
+            {name: 'Virgin Islands, U.S.', abbreviation: 'VI'},
         ],
 
         armed_forces: [
             {name: 'Armed Forces Europe', abbreviation: 'AE'},
             {name: 'Armed Forces Pacific', abbreviation: 'AP'},
-            {name: 'Armed Forces the Americas', abbreviation: 'AA'}
+            {name: 'Armed Forces the Americas', abbreviation: 'AA'},
         ],
 
         country_regions: {
             it: [
-                { name: "Valle d'Aosta", abbreviation: "VDA" },
-                { name: "Piemonte", abbreviation: "PIE" },
-                { name: "Lombardia", abbreviation: "LOM" },
-                { name: "Veneto", abbreviation: "VEN" },
-                { name: "Trentino Alto Adige", abbreviation: "TAA" },
-                { name: "Friuli Venezia Giulia", abbreviation: "FVG" },
-                { name: "Liguria", abbreviation: "LIG" },
-                { name: "Emilia Romagna", abbreviation: "EMR" },
-                { name: "Toscana", abbreviation: "TOS" },
-                { name: "Umbria", abbreviation: "UMB" },
-                { name: "Marche", abbreviation: "MAR" },
-                { name: "Abruzzo", abbreviation: "ABR" },
-                { name: "Lazio", abbreviation: "LAZ" },
-                { name: "Campania", abbreviation: "CAM" },
-                { name: "Puglia", abbreviation: "PUG" },
-                { name: "Basilicata", abbreviation: "BAS" },
-                { name: "Molise", abbreviation: "MOL" },
-                { name: "Calabria", abbreviation: "CAL" },
-                { name: "Sicilia", abbreviation: "SIC" },
-                { name: "Sardegna", abbreviation: "SAR" }
+                {name: "Valle d'Aosta", abbreviation: "VDA"},
+                {name: "Piemonte", abbreviation: "PIE"},
+                {name: "Lombardia", abbreviation: "LOM"},
+                {name: "Veneto", abbreviation: "VEN"},
+                {name: "Trentino Alto Adige", abbreviation: "TAA"},
+                {name: "Friuli Venezia Giulia", abbreviation: "FVG"},
+                {name: "Liguria", abbreviation: "LIG"},
+                {name: "Emilia Romagna", abbreviation: "EMR"},
+                {name: "Toscana", abbreviation: "TOS"},
+                {name: "Umbria", abbreviation: "UMB"},
+                {name: "Marche", abbreviation: "MAR"},
+                {name: "Abruzzo", abbreviation: "ABR"},
+                {name: "Lazio", abbreviation: "LAZ"},
+                {name: "Campania", abbreviation: "CAM"},
+                {name: "Puglia", abbreviation: "PUG"},
+                {name: "Basilicata", abbreviation: "BAS"},
+                {name: "Molise", abbreviation: "MOL"},
+                {name: "Calabria", abbreviation: "CAL"},
+                {name: "Sicilia", abbreviation: "SIC"},
+                {name: "Sardegna", abbreviation: "SAR"},
             ],
             mx: [
-                { name: 'Aguascalientes', abbreviation: 'AGU' },
-                { name: 'Baja California', abbreviation: 'BCN' },
-                { name: 'Baja California Sur', abbreviation: 'BCS' },
-                { name: 'Campeche', abbreviation: 'CAM' },
-                { name: 'Chiapas', abbreviation: 'CHP' },
-                { name: 'Chihuahua', abbreviation: 'CHH' },
-                { name: 'Ciudad de México', abbreviation: 'DIF' },
-                { name: 'Coahuila', abbreviation: 'COA' },
-                { name: 'Colima', abbreviation: 'COL' },
-                { name: 'Durango', abbreviation: 'DUR' },
-                { name: 'Guanajuato', abbreviation: 'GUA' },
-                { name: 'Guerrero', abbreviation: 'GRO' },
-                { name: 'Hidalgo', abbreviation: 'HID' },
-                { name: 'Jalisco', abbreviation: 'JAL' },
-                { name: 'México', abbreviation: 'MEX' },
-                { name: 'Michoacán', abbreviation: 'MIC' },
-                { name: 'Morelos', abbreviation: 'MOR' },
-                { name: 'Nayarit', abbreviation: 'NAY' },
-                { name: 'Nuevo León', abbreviation: 'NLE' },
-                { name: 'Oaxaca', abbreviation: 'OAX' },
-                { name: 'Puebla', abbreviation: 'PUE' },
-                { name: 'Querétaro', abbreviation: 'QUE' },
-                { name: 'Quintana Roo', abbreviation: 'ROO' },
-                { name: 'San Luis Potosí', abbreviation: 'SLP' },
-                { name: 'Sinaloa', abbreviation: 'SIN' },
-                { name: 'Sonora', abbreviation: 'SON' },
-                { name: 'Tabasco', abbreviation: 'TAB' },
-                { name: 'Tamaulipas', abbreviation: 'TAM' },
-                { name: 'Tlaxcala', abbreviation: 'TLA' },
-                { name: 'Veracruz', abbreviation: 'VER' },
-                { name: 'Yucatán', abbreviation: 'YUC' },
-                { name: 'Zacatecas', abbreviation: 'ZAC' }
+                {name: 'Aguascalientes', abbreviation: 'AGU'},
+                {name: 'Baja California', abbreviation: 'BCN'},
+                {name: 'Baja California Sur', abbreviation: 'BCS'},
+                {name: 'Campeche', abbreviation: 'CAM'},
+                {name: 'Chiapas', abbreviation: 'CHP'},
+                {name: 'Chihuahua', abbreviation: 'CHH'},
+                {name: 'Ciudad de México', abbreviation: 'DIF'},
+                {name: 'Coahuila', abbreviation: 'COA'},
+                {name: 'Colima', abbreviation: 'COL'},
+                {name: 'Durango', abbreviation: 'DUR'},
+                {name: 'Guanajuato', abbreviation: 'GUA'},
+                {name: 'Guerrero', abbreviation: 'GRO'},
+                {name: 'Hidalgo', abbreviation: 'HID'},
+                {name: 'Jalisco', abbreviation: 'JAL'},
+                {name: 'México', abbreviation: 'MEX'},
+                {name: 'Michoacán', abbreviation: 'MIC'},
+                {name: 'Morelos', abbreviation: 'MOR'},
+                {name: 'Nayarit', abbreviation: 'NAY'},
+                {name: 'Nuevo León', abbreviation: 'NLE'},
+                {name: 'Oaxaca', abbreviation: 'OAX'},
+                {name: 'Puebla', abbreviation: 'PUE'},
+                {name: 'Querétaro', abbreviation: 'QUE'},
+                {name: 'Quintana Roo', abbreviation: 'ROO'},
+                {name: 'San Luis Potosí', abbreviation: 'SLP'},
+                {name: 'Sinaloa', abbreviation: 'SIN'},
+                {name: 'Sonora', abbreviation: 'SON'},
+                {name: 'Tabasco', abbreviation: 'TAB'},
+                {name: 'Tamaulipas', abbreviation: 'TAM'},
+                {name: 'Tlaxcala', abbreviation: 'TLA'},
+                {name: 'Veracruz', abbreviation: 'VER'},
+                {name: 'Yucatán', abbreviation: 'YUC'},
+                {name: 'Zacatecas', abbreviation: 'ZAC'},
             ]
         },
 
         street_suffixes: {
-            'us': [
+            us: [
                 {name: 'Avenue', abbreviation: 'Ave'},
                 {name: 'Boulevard', abbreviation: 'Blvd'},
                 {name: 'Center', abbreviation: 'Ctr'},
@@ -4161,79 +4015,79 @@ options,
                 {name: 'Trail', abbreviation: 'Trl'},
                 {name: 'Turnpike', abbreviation: 'Tpke'},
                 {name: 'View', abbreviation: 'Vw'},
-                {name: 'Way', abbreviation: 'Way'}
+                {name: 'Way', abbreviation: 'Way'},
             ],
-            'it': [
-                { name: 'Accesso', abbreviation: 'Acc.' },
-                { name: 'Alzaia', abbreviation: 'Alz.' },
-                { name: 'Arco', abbreviation: 'Arco' },
-                { name: 'Archivolto', abbreviation: 'Acv.' },
-                { name: 'Arena', abbreviation: 'Arena' },
-                { name: 'Argine', abbreviation: 'Argine' },
-                { name: 'Bacino', abbreviation: 'Bacino' },
-                { name: 'Banchi', abbreviation: 'Banchi' },
-                { name: 'Banchina', abbreviation: 'Ban.' },
-                { name: 'Bastioni', abbreviation: 'Bas.' },
-                { name: 'Belvedere', abbreviation: 'Belv.' },
-                { name: 'Borgata', abbreviation: 'B.ta' },
-                { name: 'Borgo', abbreviation: 'B.go' },
-                { name: 'Calata', abbreviation: 'Cal.' },
-                { name: 'Calle', abbreviation: 'Calle' },
-                { name: 'Campiello', abbreviation: 'Cam.' },
-                { name: 'Campo', abbreviation: 'Cam.' },
-                { name: 'Canale', abbreviation: 'Can.' },
-                { name: 'Carraia', abbreviation: 'Carr.' },
-                { name: 'Cascina', abbreviation: 'Cascina' },
-                { name: 'Case sparse', abbreviation: 'c.s.' },
-                { name: 'Cavalcavia', abbreviation: 'Cv.' },
-                { name: 'Circonvallazione', abbreviation: 'Cv.' },
-                { name: 'Complanare', abbreviation: 'C.re' },
-                { name: 'Contrada', abbreviation: 'C.da' },
-                { name: 'Corso', abbreviation: 'C.so' },
-                { name: 'Corte', abbreviation: 'C.te' },
-                { name: 'Cortile', abbreviation: 'C.le' },
-                { name: 'Diramazione', abbreviation: 'Dir.' },
-                { name: 'Fondaco', abbreviation: 'F.co' },
-                { name: 'Fondamenta', abbreviation: 'F.ta' },
-                { name: 'Fondo', abbreviation: 'F.do' },
-                { name: 'Frazione', abbreviation: 'Fr.' },
-                { name: 'Isola', abbreviation: 'Is.' },
-                { name: 'Largo', abbreviation: 'L.go' },
-                { name: 'Litoranea', abbreviation: 'Lit.' },
-                { name: 'Lungolago', abbreviation: 'L.go lago' },
-                { name: 'Lungo Po', abbreviation: 'l.go Po' },
-                { name: 'Molo', abbreviation: 'Molo' },
-                { name: 'Mura', abbreviation: 'Mura' },
-                { name: 'Passaggio privato', abbreviation: 'pass. priv.' },
-                { name: 'Passeggiata', abbreviation: 'Pass.' },
-                { name: 'Piazza', abbreviation: 'P.zza' },
-                { name: 'Piazzale', abbreviation: 'P.le' },
-                { name: 'Ponte', abbreviation: 'P.te' },
-                { name: 'Portico', abbreviation: 'P.co' },
-                { name: 'Rampa', abbreviation: 'Rampa' },
-                { name: 'Regione', abbreviation: 'Reg.' },
-                { name: 'Rione', abbreviation: 'R.ne' },
-                { name: 'Rio', abbreviation: 'Rio' },
-                { name: 'Ripa', abbreviation: 'Ripa' },
-                { name: 'Riva', abbreviation: 'Riva' },
-                { name: 'Rondò', abbreviation: 'Rondò' },
-                { name: 'Rotonda', abbreviation: 'Rot.' },
-                { name: 'Sagrato', abbreviation: 'Sagr.' },
-                { name: 'Salita', abbreviation: 'Sal.' },
-                { name: 'Scalinata', abbreviation: 'Scal.' },
-                { name: 'Scalone', abbreviation: 'Scal.' },
-                { name: 'Slargo', abbreviation: 'Sl.' },
-                { name: 'Sottoportico', abbreviation: 'Sott.' },
-                { name: 'Strada', abbreviation: 'Str.' },
-                { name: 'Stradale', abbreviation: 'Str.le' },
-                { name: 'Strettoia', abbreviation: 'Strett.' },
-                { name: 'Traversa', abbreviation: 'Trav.' },
-                { name: 'Via', abbreviation: 'V.' },
-                { name: 'Viale', abbreviation: 'V.le' },
-                { name: 'Vicinale', abbreviation: 'Vic.le' },
-                { name: 'Vicolo', abbreviation: 'Vic.' }
+            it: [
+                {name: 'Accesso', abbreviation: 'Acc.'},
+                {name: 'Alzaia', abbreviation: 'Alz.'},
+                {name: 'Arco', abbreviation: 'Arco'},
+                {name: 'Archivolto', abbreviation: 'Acv.'},
+                {name: 'Arena', abbreviation: 'Arena'},
+                {name: 'Argine', abbreviation: 'Argine'},
+                {name: 'Bacino', abbreviation: 'Bacino'},
+                {name: 'Banchi', abbreviation: 'Banchi'},
+                {name: 'Banchina', abbreviation: 'Ban.'},
+                {name: 'Bastioni', abbreviation: 'Bas.'},
+                {name: 'Belvedere', abbreviation: 'Belv.'},
+                {name: 'Borgata', abbreviation: 'B.ta'},
+                {name: 'Borgo', abbreviation: 'B.go'},
+                {name: 'Calata', abbreviation: 'Cal.'},
+                {name: 'Calle', abbreviation: 'Calle'},
+                {name: 'Campiello', abbreviation: 'Cam.'},
+                {name: 'Campo', abbreviation: 'Cam.'},
+                {name: 'Canale', abbreviation: 'Can.'},
+                {name: 'Carraia', abbreviation: 'Carr.'},
+                {name: 'Cascina', abbreviation: 'Cascina'},
+                {name: 'Case sparse', abbreviation: 'c.s.'},
+                {name: 'Cavalcavia', abbreviation: 'Cv.'},
+                {name: 'Circonvallazione', abbreviation: 'Cv.'},
+                {name: 'Complanare', abbreviation: 'C.re'},
+                {name: 'Contrada', abbreviation: 'C.da'},
+                {name: 'Corso', abbreviation: 'C.so'},
+                {name: 'Corte', abbreviation: 'C.te'},
+                {name: 'Cortile', abbreviation: 'C.le'},
+                {name: 'Diramazione', abbreviation: 'Dir.'},
+                {name: 'Fondaco', abbreviation: 'F.co'},
+                {name: 'Fondamenta', abbreviation: 'F.ta'},
+                {name: 'Fondo', abbreviation: 'F.do'},
+                {name: 'Frazione', abbreviation: 'Fr.'},
+                {name: 'Isola', abbreviation: 'Is.'},
+                {name: 'Largo', abbreviation: 'L.go'},
+                {name: 'Litoranea', abbreviation: 'Lit.'},
+                {name: 'Lungolago', abbreviation: 'L.go lago'},
+                {name: 'Lungo Po', abbreviation: 'l.go Po'},
+                {name: 'Molo', abbreviation: 'Molo'},
+                {name: 'Mura', abbreviation: 'Mura'},
+                {name: 'Passaggio privato', abbreviation: 'pass. priv.'},
+                {name: 'Passeggiata', abbreviation: 'Pass.'},
+                {name: 'Piazza', abbreviation: 'P.zza'},
+                {name: 'Piazzale', abbreviation: 'P.le'},
+                {name: 'Ponte', abbreviation: 'P.te'},
+                {name: 'Portico', abbreviation: 'P.co'},
+                {name: 'Rampa', abbreviation: 'Rampa'},
+                {name: 'Regione', abbreviation: 'Reg.'},
+                {name: 'Rione', abbreviation: 'R.ne'},
+                {name: 'Rio', abbreviation: 'Rio'},
+                {name: 'Ripa', abbreviation: 'Ripa'},
+                {name: 'Riva', abbreviation: 'Riva'},
+                {name: 'Rondò', abbreviation: 'Rondò'},
+                {name: 'Rotonda', abbreviation: 'Rot.'},
+                {name: 'Sagrato', abbreviation: 'Sagr.'},
+                {name: 'Salita', abbreviation: 'Sal.'},
+                {name: 'Scalinata', abbreviation: 'Scal.'},
+                {name: 'Scalone', abbreviation: 'Scal.'},
+                {name: 'Slargo', abbreviation: 'Sl.'},
+                {name: 'Sottoportico', abbreviation: 'Sott.'},
+                {name: 'Strada', abbreviation: 'Str.'},
+                {name: 'Stradale', abbreviation: 'Str.le'},
+                {name: 'Strettoia', abbreviation: 'Strett.'},
+                {name: 'Traversa', abbreviation: 'Trav.'},
+                {name: 'Via', abbreviation: 'V.'},
+                {name: 'Viale', abbreviation: 'V.le'},
+                {name: 'Vicinale', abbreviation: 'Vic.le'},
+                {name: 'Vicolo', abbreviation: 'Vic.'},
             ],
-            'uk' : [
+            uk: [
                 {name: 'Avenue', abbreviation: 'Ave'},
                 {name: 'Close', abbreviation: 'Cl'},
                 {name: 'Court', abbreviation: 'Ct'},
@@ -4252,7 +4106,7 @@ options,
                 {name: 'Square', abbreviation: 'Sq'},
                 {name: 'Street', abbreviation: 'St'},
                 {name: 'Terrace', abbreviation: 'Ter'},
-                {name: 'Valley', abbreviation: 'Val'}
+                {name: 'Valley', abbreviation: 'Val'},
             ]
         },
 
@@ -4269,7 +4123,7 @@ options,
             {name: 'September', short_name: 'Sep', numeric: '09', days: 30},
             {name: 'October', short_name: 'Oct', numeric: '10', days: 31},
             {name: 'November', short_name: 'Nov', numeric: '11', days: 30},
-            {name: 'December', short_name: 'Dec', numeric: '12', days: 31}
+            {name: 'December', short_name: 'Dec', numeric: '12', days: 31},
         ],
 
         // http://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29
@@ -4290,178 +4144,179 @@ options,
             {name: "Solo", short_name: 'solo', prefix: '6334', length: 16},
             {name: "Switch", short_name: 'switch', prefix: '4903', length: 16},
             {name: "Visa", short_name: 'visa', prefix: '4', length: 16},
-            {name: "Visa Electron", short_name: 'electron', prefix: '4026', length: 16}
+            {name: "Visa Electron", short_name: 'electron', prefix: '4026', length: 16},
         ],
 
-        //return all world currency by ISO 4217
+        // All world currencies by ISO 4217
         currency_types: [
-            {'code' : 'AED', 'name' : 'United Arab Emirates Dirham'},
-            {'code' : 'AFN', 'name' : 'Afghanistan Afghani'},
-            {'code' : 'ALL', 'name' : 'Albania Lek'},
-            {'code' : 'AMD', 'name' : 'Armenia Dram'},
-            {'code' : 'ANG', 'name' : 'Netherlands Antilles Guilder'},
-            {'code' : 'AOA', 'name' : 'Angola Kwanza'},
-            {'code' : 'ARS', 'name' : 'Argentina Peso'},
-            {'code' : 'AUD', 'name' : 'Australia Dollar'},
-            {'code' : 'AWG', 'name' : 'Aruba Guilder'},
-            {'code' : 'AZN', 'name' : 'Azerbaijan New Manat'},
-            {'code' : 'BAM', 'name' : 'Bosnia and Herzegovina Convertible Marka'},
-            {'code' : 'BBD', 'name' : 'Barbados Dollar'},
-            {'code' : 'BDT', 'name' : 'Bangladesh Taka'},
-            {'code' : 'BGN', 'name' : 'Bulgaria Lev'},
-            {'code' : 'BHD', 'name' : 'Bahrain Dinar'},
-            {'code' : 'BIF', 'name' : 'Burundi Franc'},
-            {'code' : 'BMD', 'name' : 'Bermuda Dollar'},
-            {'code' : 'BND', 'name' : 'Brunei Darussalam Dollar'},
-            {'code' : 'BOB', 'name' : 'Bolivia Boliviano'},
-            {'code' : 'BRL', 'name' : 'Brazil Real'},
-            {'code' : 'BSD', 'name' : 'Bahamas Dollar'},
-            {'code' : 'BTN', 'name' : 'Bhutan Ngultrum'},
-            {'code' : 'BWP', 'name' : 'Botswana Pula'},
-            {'code' : 'BYR', 'name' : 'Belarus Ruble'},
-            {'code' : 'BZD', 'name' : 'Belize Dollar'},
-            {'code' : 'CAD', 'name' : 'Canada Dollar'},
-            {'code' : 'CDF', 'name' : 'Congo/Kinshasa Franc'},
-            {'code' : 'CHF', 'name' : 'Switzerland Franc'},
-            {'code' : 'CLP', 'name' : 'Chile Peso'},
-            {'code' : 'CNY', 'name' : 'China Yuan Renminbi'},
-            {'code' : 'COP', 'name' : 'Colombia Peso'},
-            {'code' : 'CRC', 'name' : 'Costa Rica Colon'},
-            {'code' : 'CUC', 'name' : 'Cuba Convertible Peso'},
-            {'code' : 'CUP', 'name' : 'Cuba Peso'},
-            {'code' : 'CVE', 'name' : 'Cape Verde Escudo'},
-            {'code' : 'CZK', 'name' : 'Czech Republic Koruna'},
-            {'code' : 'DJF', 'name' : 'Djibouti Franc'},
-            {'code' : 'DKK', 'name' : 'Denmark Krone'},
-            {'code' : 'DOP', 'name' : 'Dominican Republic Peso'},
-            {'code' : 'DZD', 'name' : 'Algeria Dinar'},
-            {'code' : 'EGP', 'name' : 'Egypt Pound'},
-            {'code' : 'ERN', 'name' : 'Eritrea Nakfa'},
-            {'code' : 'ETB', 'name' : 'Ethiopia Birr'},
-            {'code' : 'EUR', 'name' : 'Euro Member Countries'},
-            {'code' : 'FJD', 'name' : 'Fiji Dollar'},
-            {'code' : 'FKP', 'name' : 'Falkland Islands (Malvinas) Pound'},
-            {'code' : 'GBP', 'name' : 'United Kingdom Pound'},
-            {'code' : 'GEL', 'name' : 'Georgia Lari'},
-            {'code' : 'GGP', 'name' : 'Guernsey Pound'},
-            {'code' : 'GHS', 'name' : 'Ghana Cedi'},
-            {'code' : 'GIP', 'name' : 'Gibraltar Pound'},
-            {'code' : 'GMD', 'name' : 'Gambia Dalasi'},
-            {'code' : 'GNF', 'name' : 'Guinea Franc'},
-            {'code' : 'GTQ', 'name' : 'Guatemala Quetzal'},
-            {'code' : 'GYD', 'name' : 'Guyana Dollar'},
-            {'code' : 'HKD', 'name' : 'Hong Kong Dollar'},
-            {'code' : 'HNL', 'name' : 'Honduras Lempira'},
-            {'code' : 'HRK', 'name' : 'Croatia Kuna'},
-            {'code' : 'HTG', 'name' : 'Haiti Gourde'},
-            {'code' : 'HUF', 'name' : 'Hungary Forint'},
-            {'code' : 'IDR', 'name' : 'Indonesia Rupiah'},
-            {'code' : 'ILS', 'name' : 'Israel Shekel'},
-            {'code' : 'IMP', 'name' : 'Isle of Man Pound'},
-            {'code' : 'INR', 'name' : 'India Rupee'},
-            {'code' : 'IQD', 'name' : 'Iraq Dinar'},
-            {'code' : 'IRR', 'name' : 'Iran Rial'},
-            {'code' : 'ISK', 'name' : 'Iceland Krona'},
-            {'code' : 'JEP', 'name' : 'Jersey Pound'},
-            {'code' : 'JMD', 'name' : 'Jamaica Dollar'},
-            {'code' : 'JOD', 'name' : 'Jordan Dinar'},
-            {'code' : 'JPY', 'name' : 'Japan Yen'},
-            {'code' : 'KES', 'name' : 'Kenya Shilling'},
-            {'code' : 'KGS', 'name' : 'Kyrgyzstan Som'},
-            {'code' : 'KHR', 'name' : 'Cambodia Riel'},
-            {'code' : 'KMF', 'name' : 'Comoros Franc'},
-            {'code' : 'KPW', 'name' : 'Korea (North) Won'},
-            {'code' : 'KRW', 'name' : 'Korea (South) Won'},
-            {'code' : 'KWD', 'name' : 'Kuwait Dinar'},
-            {'code' : 'KYD', 'name' : 'Cayman Islands Dollar'},
-            {'code' : 'KZT', 'name' : 'Kazakhstan Tenge'},
-            {'code' : 'LAK', 'name' : 'Laos Kip'},
-            {'code' : 'LBP', 'name' : 'Lebanon Pound'},
-            {'code' : 'LKR', 'name' : 'Sri Lanka Rupee'},
-            {'code' : 'LRD', 'name' : 'Liberia Dollar'},
-            {'code' : 'LSL', 'name' : 'Lesotho Loti'},
-            {'code' : 'LTL', 'name' : 'Lithuania Litas'},
-            {'code' : 'LYD', 'name' : 'Libya Dinar'},
-            {'code' : 'MAD', 'name' : 'Morocco Dirham'},
-            {'code' : 'MDL', 'name' : 'Moldova Leu'},
-            {'code' : 'MGA', 'name' : 'Madagascar Ariary'},
-            {'code' : 'MKD', 'name' : 'Macedonia Denar'},
-            {'code' : 'MMK', 'name' : 'Myanmar (Burma) Kyat'},
-            {'code' : 'MNT', 'name' : 'Mongolia Tughrik'},
-            {'code' : 'MOP', 'name' : 'Macau Pataca'},
-            {'code' : 'MRO', 'name' : 'Mauritania Ouguiya'},
-            {'code' : 'MUR', 'name' : 'Mauritius Rupee'},
-            {'code' : 'MVR', 'name' : 'Maldives (Maldive Islands) Rufiyaa'},
-            {'code' : 'MWK', 'name' : 'Malawi Kwacha'},
-            {'code' : 'MXN', 'name' : 'Mexico Peso'},
-            {'code' : 'MYR', 'name' : 'Malaysia Ringgit'},
-            {'code' : 'MZN', 'name' : 'Mozambique Metical'},
-            {'code' : 'NAD', 'name' : 'Namibia Dollar'},
-            {'code' : 'NGN', 'name' : 'Nigeria Naira'},
-            {'code' : 'NIO', 'name' : 'Nicaragua Cordoba'},
-            {'code' : 'NOK', 'name' : 'Norway Krone'},
-            {'code' : 'NPR', 'name' : 'Nepal Rupee'},
-            {'code' : 'NZD', 'name' : 'New Zealand Dollar'},
-            {'code' : 'OMR', 'name' : 'Oman Rial'},
-            {'code' : 'PAB', 'name' : 'Panama Balboa'},
-            {'code' : 'PEN', 'name' : 'Peru Nuevo Sol'},
-            {'code' : 'PGK', 'name' : 'Papua New Guinea Kina'},
-            {'code' : 'PHP', 'name' : 'Philippines Peso'},
-            {'code' : 'PKR', 'name' : 'Pakistan Rupee'},
-            {'code' : 'PLN', 'name' : 'Poland Zloty'},
-            {'code' : 'PYG', 'name' : 'Paraguay Guarani'},
-            {'code' : 'QAR', 'name' : 'Qatar Riyal'},
-            {'code' : 'RON', 'name' : 'Romania New Leu'},
-            {'code' : 'RSD', 'name' : 'Serbia Dinar'},
-            {'code' : 'RUB', 'name' : 'Russia Ruble'},
-            {'code' : 'RWF', 'name' : 'Rwanda Franc'},
-            {'code' : 'SAR', 'name' : 'Saudi Arabia Riyal'},
-            {'code' : 'SBD', 'name' : 'Solomon Islands Dollar'},
-            {'code' : 'SCR', 'name' : 'Seychelles Rupee'},
-            {'code' : 'SDG', 'name' : 'Sudan Pound'},
-            {'code' : 'SEK', 'name' : 'Sweden Krona'},
-            {'code' : 'SGD', 'name' : 'Singapore Dollar'},
-            {'code' : 'SHP', 'name' : 'Saint Helena Pound'},
-            {'code' : 'SLL', 'name' : 'Sierra Leone Leone'},
-            {'code' : 'SOS', 'name' : 'Somalia Shilling'},
-            {'code' : 'SPL', 'name' : 'Seborga Luigino'},
-            {'code' : 'SRD', 'name' : 'Suriname Dollar'},
-            {'code' : 'STD', 'name' : 'São Tomé and Príncipe Dobra'},
-            {'code' : 'SVC', 'name' : 'El Salvador Colon'},
-            {'code' : 'SYP', 'name' : 'Syria Pound'},
-            {'code' : 'SZL', 'name' : 'Swaziland Lilangeni'},
-            {'code' : 'THB', 'name' : 'Thailand Baht'},
-            {'code' : 'TJS', 'name' : 'Tajikistan Somoni'},
-            {'code' : 'TMT', 'name' : 'Turkmenistan Manat'},
-            {'code' : 'TND', 'name' : 'Tunisia Dinar'},
-            {'code' : 'TOP', 'name' : 'Tonga Pa\'anga'},
-            {'code' : 'TRY', 'name' : 'Turkey Lira'},
-            {'code' : 'TTD', 'name' : 'Trinidad and Tobago Dollar'},
-            {'code' : 'TVD', 'name' : 'Tuvalu Dollar'},
-            {'code' : 'TWD', 'name' : 'Taiwan New Dollar'},
-            {'code' : 'TZS', 'name' : 'Tanzania Shilling'},
-            {'code' : 'UAH', 'name' : 'Ukraine Hryvnia'},
-            {'code' : 'UGX', 'name' : 'Uganda Shilling'},
-            {'code' : 'USD', 'name' : 'United States Dollar'},
-            {'code' : 'UYU', 'name' : 'Uruguay Peso'},
-            {'code' : 'UZS', 'name' : 'Uzbekistan Som'},
-            {'code' : 'VEF', 'name' : 'Venezuela Bolivar'},
-            {'code' : 'VND', 'name' : 'Viet Nam Dong'},
-            {'code' : 'VUV', 'name' : 'Vanuatu Vatu'},
-            {'code' : 'WST', 'name' : 'Samoa Tala'},
-            {'code' : 'XAF', 'name' : 'Communauté Financière Africaine (BEAC) CFA Franc BEAC'},
-            {'code' : 'XCD', 'name' : 'East Caribbean Dollar'},
-            {'code' : 'XDR', 'name' : 'International Monetary Fund (IMF) Special Drawing Rights'},
-            {'code' : 'XOF', 'name' : 'Communauté Financière Africaine (BCEAO) Franc'},
-            {'code' : 'XPF', 'name' : 'Comptoirs Français du Pacifique (CFP) Franc'},
-            {'code' : 'YER', 'name' : 'Yemen Rial'},
-            {'code' : 'ZAR', 'name' : 'South Africa Rand'},
-            {'code' : 'ZMW', 'name' : 'Zambia Kwacha'},
-            {'code' : 'ZWD', 'name' : 'Zimbabwe Dollar'}
+        {code: 'AED', name: 'United Arab Emirates Dirham'},
+        {code: 'AFN', name: 'Afghanistan Afghani'},
+        {code: 'ALL', name: 'Albania Lek'},
+        {code: 'AMD', name: 'Armenia Dram'},
+        {code: 'ANG', name: 'Netherlands Antilles Guilder'},
+        {code: 'AOA', name: 'Angola Kwanza'},
+        {code: 'ARS', name: 'Argentina Peso'},
+        {code: 'AUD', name: 'Australia Dollar'},
+        {code: 'AWG', name: 'Aruba Guilder'},
+        {code: 'AZN', name: 'Azerbaijan New Manat'},
+        {code: 'BAM', name: 'Bosnia and Herzegovina Convertible Marka'},
+        {code: 'BBD', name: 'Barbados Dollar'},
+        {code: 'BDT', name: 'Bangladesh Taka'},
+        {code: 'BGN', name: 'Bulgaria Lev'},
+        {code: 'BHD', name: 'Bahrain Dinar'},
+        {code: 'BIF', name: 'Burundi Franc'},
+        {code: 'BMD', name: 'Bermuda Dollar'},
+        {code: 'BND', name: 'Brunei Darussalam Dollar'},
+        {code: 'BOB', name: 'Bolivia Boliviano'},
+        {code: 'BRL', name: 'Brazil Real'},
+        {code: 'BSD', name: 'Bahamas Dollar'},
+        {code: 'BTN', name: 'Bhutan Ngultrum'},
+        {code: 'BWP', name: 'Botswana Pula'},
+        {code: 'BYR', name: 'Belarus Ruble'},
+        {code: 'BZD', name: 'Belize Dollar'},
+        {code: 'CAD', name: 'Canada Dollar'},
+        {code: 'CDF', name: 'Congo/Kinshasa Franc'},
+        {code: 'CHF', name: 'Switzerland Franc'},
+        {code: 'CLP', name: 'Chile Peso'},
+        {code: 'CNY', name: 'China Yuan Renminbi'},
+        {code: 'COP', name: 'Colombia Peso'},
+        {code: 'CRC', name: 'Costa Rica Colon'},
+        {code: 'CUC', name: 'Cuba Convertible Peso'},
+        {code: 'CUP', name: 'Cuba Peso'},
+        {code: 'CVE', name: 'Cape Verde Escudo'},
+        {code: 'CZK', name: 'Czech Republic Koruna'},
+        {code: 'DJF', name: 'Djibouti Franc'},
+        {code: 'DKK', name: 'Denmark Krone'},
+        {code: 'DOP', name: 'Dominican Republic Peso'},
+        {code: 'DZD', name: 'Algeria Dinar'},
+        {code: 'EGP', name: 'Egypt Pound'},
+        {code: 'ERN', name: 'Eritrea Nakfa'},
+        {code: 'ETB', name: 'Ethiopia Birr'},
+        {code: 'EUR', name: 'Euro Member Countries'},
+        {code: 'FJD', name: 'Fiji Dollar'},
+        {code: 'FKP', name: 'Falkland Islands (Malvinas) Pound'},
+        {code: 'GBP', name: 'United Kingdom Pound'},
+        {code: 'GEL', name: 'Georgia Lari'},
+        {code: 'GGP', name: 'Guernsey Pound'},
+        {code: 'GHS', name: 'Ghana Cedi'},
+        {code: 'GIP', name: 'Gibraltar Pound'},
+        {code: 'GMD', name: 'Gambia Dalasi'},
+        {code: 'GNF', name: 'Guinea Franc'},
+        {code: 'GTQ', name: 'Guatemala Quetzal'},
+        {code: 'GYD', name: 'Guyana Dollar'},
+        {code: 'HKD', name: 'Hong Kong Dollar'},
+        {code: 'HNL', name: 'Honduras Lempira'},
+        {code: 'HRK', name: 'Croatia Kuna'},
+        {code: 'HTG', name: 'Haiti Gourde'},
+        {code: 'HUF', name: 'Hungary Forint'},
+        {code: 'IDR', name: 'Indonesia Rupiah'},
+        {code: 'ILS', name: 'Israel Shekel'},
+        {code: 'IMP', name: 'Isle of Man Pound'},
+        {code: 'INR', name: 'India Rupee'},
+        {code: 'IQD', name: 'Iraq Dinar'},
+        {code: 'IRR', name: 'Iran Rial'},
+        {code: 'ISK', name: 'Iceland Krona'},
+        {code: 'JEP', name: 'Jersey Pound'},
+        {code: 'JMD', name: 'Jamaica Dollar'},
+        {code: 'JOD', name: 'Jordan Dinar'},
+        {code: 'JPY', name: 'Japan Yen'},
+        {code: 'KES', name: 'Kenya Shilling'},
+        {code: 'KGS', name: 'Kyrgyzstan Som'},
+        {code: 'KHR', name: 'Cambodia Riel'},
+        {code: 'KMF', name: 'Comoros Franc'},
+        {code: 'KPW', name: 'Korea (North) Won'},
+        {code: 'KRW', name: 'Korea (South) Won'},
+        {code: 'KWD', name: 'Kuwait Dinar'},
+        {code: 'KYD', name: 'Cayman Islands Dollar'},
+        {code: 'KZT', name: 'Kazakhstan Tenge'},
+        {code: 'LAK', name: 'Laos Kip'},
+        {code: 'LBP', name: 'Lebanon Pound'},
+        {code: 'LKR', name: 'Sri Lanka Rupee'},
+        {code: 'LRD', name: 'Liberia Dollar'},
+        {code: 'LSL', name: 'Lesotho Loti'},
+        {code: 'LTL', name: 'Lithuania Litas'},
+        {code: 'LYD', name: 'Libya Dinar'},
+        {code: 'MAD', name: 'Morocco Dirham'},
+        {code: 'MDL', name: 'Moldova Leu'},
+        {code: 'MGA', name: 'Madagascar Ariary'},
+        {code: 'MKD', name: 'Macedonia Denar'},
+        {code: 'MMK', name: 'Myanmar (Burma) Kyat'},
+        {code: 'MNT', name: 'Mongolia Tughrik'},
+        {code: 'MOP', name: 'Macau Pataca'},
+        {code: 'MRO', name: 'Mauritania Ouguiya'},
+        {code: 'MUR', name: 'Mauritius Rupee'},
+        {code: 'MVR', name: 'Maldives (Maldive Islands) Rufiyaa'},
+        {code: 'MWK', name: 'Malawi Kwacha'},
+        {code: 'MXN', name: 'Mexico Peso'},
+        {code: 'MYR', name: 'Malaysia Ringgit'},
+        {code: 'MZN', name: 'Mozambique Metical'},
+        {code: 'NAD', name: 'Namibia Dollar'},
+        {code: 'NGN', name: 'Nigeria Naira'},
+        {code: 'NIO', name: 'Nicaragua Cordoba'},
+        {code: 'NOK', name: 'Norway Krone'},
+        {code: 'NPR', name: 'Nepal Rupee'},
+        {code: 'NZD', name: 'New Zealand Dollar'},
+        {code: 'OMR', name: 'Oman Rial'},
+        {code: 'PAB', name: 'Panama Balboa'},
+        {code: 'PEN', name: 'Peru Nuevo Sol'},
+        {code: 'PGK', name: 'Papua New Guinea Kina'},
+        {code: 'PHP', name: 'Philippines Peso'},
+        {code: 'PKR', name: 'Pakistan Rupee'},
+        {code: 'PLN', name: 'Poland Zloty'},
+        {code: 'PYG', name: 'Paraguay Guarani'},
+        {code: 'QAR', name: 'Qatar Riyal'},
+        {code: 'RON', name: 'Romania New Leu'},
+        {code: 'RSD', name: 'Serbia Dinar'},
+        {code: 'RUB', name: 'Russia Ruble'},
+        {code: 'RWF', name: 'Rwanda Franc'},
+        {code: 'SAR', name: 'Saudi Arabia Riyal'},
+        {code: 'SBD', name: 'Solomon Islands Dollar'},
+        {code: 'SCR', name: 'Seychelles Rupee'},
+        {code: 'SDG', name: 'Sudan Pound'},
+        {code: 'SEK', name: 'Sweden Krona'},
+        {code: 'SGD', name: 'Singapore Dollar'},
+        {code: 'SHP', name: 'Saint Helena Pound'},
+        {code: 'SLL', name: 'Sierra Leone Leone'},
+        {code: 'SOS', name: 'Somalia Shilling'},
+        {code: 'SPL', name: 'Seborga Luigino'},
+        {code: 'SRD', name: 'Suriname Dollar'},
+        {code: 'STD', name: 'São Tomé and Príncipe Dobra'},
+        {code: 'SVC', name: 'El Salvador Colon'},
+        {code: 'SYP', name: 'Syria Pound'},
+        {code: 'SZL', name: 'Swaziland Lilangeni'},
+        {code: 'THB', name: 'Thailand Baht'},
+        {code: 'TJS', name: 'Tajikistan Somoni'},
+        {code: 'TMT', name: 'Turkmenistan Manat'},
+        {code: 'TND', name: 'Tunisia Dinar'},
+        {code: 'TOP', name: 'Tonga Pa\'anga'},
+        {code: 'TRY', name: 'Turkey Lira'},
+        {code: 'TTD', name: 'Trinidad and Tobago Dollar'},
+        {code: 'TVD', name: 'Tuvalu Dollar'},
+        {code: 'TWD', name: 'Taiwan New Dollar'},
+        {code: 'TZS', name: 'Tanzania Shilling'},
+        {code: 'UAH', name: 'Ukraine Hryvnia'},
+        {code: 'UGX', name: 'Uganda Shilling'},
+        {code: 'USD', name: 'United States Dollar'},
+        {code: 'UYU', name: 'Uruguay Peso'},
+        {code: 'UZS', name: 'Uzbekistan Som'},
+        {code: 'VEF', name: 'Venezuela Bolivar'},
+        {code: 'VND', name: 'Viet Nam Dong'},
+        {code: 'VUV', name: 'Vanuatu Vatu'},
+        {code: 'WST', name: 'Samoa Tala'},
+        {code: 'XAF', name: 'Communauté Financière Africaine (BEAC) CFA Franc BEAC'},
+        {code: 'XCD', name: 'East Caribbean Dollar'},
+        {code: 'XDR', name: 'International Monetary Fund (IMF) Special Drawing Rights'},
+        {code: 'XOF', name: 'Communauté Financière Africaine (BCEAO) Franc'},
+        {code: 'XPF', name: 'Comptoirs Français du Pacifique (CFP) Franc'},
+        {code: 'YER', name: 'Yemen Rial'},
+        {code: 'ZAR', name: 'South Africa Rand'},
+        {code: 'ZMW', name: 'Zambia Kwacha'},
+        {code: 'ZWD', name: 'Zimbabwe Dollar'},
         ],
 
-        // return the names of all valide colors
-        colorNames : [  "AliceBlue", "Black", "Navy", "DarkBlue", "MediumBlue", "Blue", "DarkGreen", "Green", "Teal", "DarkCyan", "DeepSkyBlue", "DarkTurquoise", "MediumSpringGreen", "Lime", "SpringGreen",
+        // All standard named colors.
+        colorNames : [
+            "AliceBlue", "Black", "Navy", "DarkBlue", "MediumBlue", "Blue", "DarkGreen", "Green", "Teal", "DarkCyan", "DeepSkyBlue", "DarkTurquoise", "MediumSpringGreen", "Lime", "SpringGreen",
             "Aqua", "Cyan", "MidnightBlue", "DodgerBlue", "LightSeaGreen", "ForestGreen", "SeaGreen", "DarkSlateGray", "LimeGreen", "MediumSeaGreen", "Turquoise", "RoyalBlue", "SteelBlue", "DarkSlateBlue", "MediumTurquoise",
             "Indigo", "DarkOliveGreen", "CadetBlue", "CornflowerBlue", "RebeccaPurple", "MediumAquaMarine", "DimGray", "SlateBlue", "OliveDrab", "SlateGray", "LightSlateGray", "MediumSlateBlue", "LawnGreen", "Chartreuse",
             "Aquamarine", "Maroon", "Purple", "Olive", "Gray", "SkyBlue", "LightSkyBlue", "BlueViolet", "DarkRed", "DarkMagenta", "SaddleBrown", "Ivory", "White",
@@ -4469,11 +4324,12 @@ options,
             "FireBrick", "DarkGoldenRod", "MediumOrchid", "RosyBrown", "DarkKhaki", "Silver", "MediumVioletRed", "IndianRed", "Peru", "Chocolate", "Tan", "LightGray", "Thistle", "Orchid", "GoldenRod", "PaleVioletRed",
             "Crimson", "Gainsboro", "Plum", "BurlyWood", "LightCyan", "Lavender", "DarkSalmon", "Violet", "PaleGoldenRod", "LightCoral", "Khaki", "AliceBlue", "HoneyDew", "Azure", "SandyBrown", "Wheat", "Beige", "WhiteSmoke",
             "MintCream", "GhostWhite", "Salmon", "AntiqueWhite", "Linen", "LightGoldenRodYellow", "OldLace", "Red", "Fuchsia", "Magenta", "DeepPink", "OrangeRed", "Tomato", "HotPink", "Coral", "DarkOrange", "LightSalmon", "Orange",
-            "LightPink", "Pink", "Gold", "PeachPuff", "NavajoWhite", "Moccasin", "Bisque", "MistyRose", "BlanchedAlmond", "PapayaWhip", "LavenderBlush", "SeaShell", "Cornsilk", "LemonChiffon", "FloralWhite", "Snow", "Yellow", "LightYellow"
+            "LightPink", "Pink", "Gold", "PeachPuff", "NavajoWhite", "Moccasin", "Bisque", "MistyRose", "BlanchedAlmond", "PapayaWhip", "LavenderBlush", "SeaShell", "Cornsilk", "LemonChiffon", "FloralWhite", "Snow", "Yellow", "LightYellow",
         ],
 
         // Data taken from https://www.sec.gov/rules/other/4-460list.htm
-        company: [ "3Com Corp",
+        company: [
+        "3Com Corp",
         "3M Company",
         "A.G. Edwards Inc.",
         "Abbott Laboratories",
@@ -5419,1428 +5275,1429 @@ options,
         "York International Corp",
         "Yum Brands Inc.",
         "Zale Corporation",
-        "Zions Bancorporation"
-      ],
+        "Zions Bancorporation",
+        ],
 
         fileExtension : {
-            "raster"    : ["bmp", "gif", "gpl", "ico", "jpeg", "psd", "png", "psp", "raw", "tiff"],
-            "vector"    : ["3dv", "amf", "awg", "ai", "cgm", "cdr", "cmx", "dxf", "e2d", "egt", "eps", "fs", "odg", "svg", "xar"],
-            "3d"        : ["3dmf", "3dm", "3mf", "3ds", "an8", "aoi", "blend", "cal3d", "cob", "ctm", "iob", "jas", "max", "mb", "mdx", "obj", "x", "x3d"],
-            "document"  : ["doc", "docx", "dot", "html", "xml", "odt", "odm", "ott", "csv", "rtf", "tex", "xhtml", "xps"]
+            "raster"  : ["bmp", "gif", "gpl", "ico", "jpeg", "psd", "png", "psp", "raw", "tiff"],
+            "vector"  : ["3dv", "amf", "awg", "ai", "cgm", "cdr", "cmx", "dxf", "e2d", "egt", "eps", "fs", "odg", "svg", "xar"],
+            "3d"      : ["3dmf", "3dm", "3mf", "3ds", "an8", "aoi", "blend", "cal3d", "cob", "ctm", "iob", "jas", "max", "mb", "mdx", "obj", "x", "x3d"],
+            "document": ["doc", "docx", "dot", "html", "xml", "odt", "odm", "ott", "csv", "rtf", "tex", "xhtml", "xps"],
         },
 
         // Data taken from https://github.com/dmfilipenko/timezones.json/blob/master/timezones.json
         timezones: [
-                  {
-                    "name": "Dateline Standard Time",
-                    "abbr": "DST",
-                    "offset": -12,
-                    "isdst": false,
-                    "text": "(UTC-12:00) International Date Line West",
-                    "utc": [
-                      "Etc/GMT+12"
-                    ]
-                  },
-                  {
-                    "name": "UTC-11",
-                    "abbr": "U",
-                    "offset": -11,
-                    "isdst": false,
-                    "text": "(UTC-11:00) Coordinated Universal Time-11",
-                    "utc": [
-                      "Etc/GMT+11",
-                      "Pacific/Midway",
-                      "Pacific/Niue",
-                      "Pacific/Pago_Pago"
-                    ]
-                  },
-                  {
-                    "name": "Hawaiian Standard Time",
-                    "abbr": "HST",
-                    "offset": -10,
-                    "isdst": false,
-                    "text": "(UTC-10:00) Hawaii",
-                    "utc": [
-                      "Etc/GMT+10",
-                      "Pacific/Honolulu",
-                      "Pacific/Johnston",
-                      "Pacific/Rarotonga",
-                      "Pacific/Tahiti"
-                    ]
-                  },
-                  {
-                    "name": "Alaskan Standard Time",
-                    "abbr": "AKDT",
-                    "offset": -8,
-                    "isdst": true,
-                    "text": "(UTC-09:00) Alaska",
-                    "utc": [
-                      "America/Anchorage",
-                      "America/Juneau",
-                      "America/Nome",
-                      "America/Sitka",
-                      "America/Yakutat"
-                    ]
-                  },
-                  {
-                    "name": "Pacific Standard Time (Mexico)",
-                    "abbr": "PDT",
-                    "offset": -7,
-                    "isdst": true,
-                    "text": "(UTC-08:00) Baja California",
-                    "utc": [
-                      "America/Santa_Isabel"
-                    ]
-                  },
-                  {
-                    "name": "Pacific Daylight Time",
-                    "abbr": "PDT",
-                    "offset": -7,
-                    "isdst": true,
-                    "text": "(UTC-07:00) Pacific Time (US & Canada)",
-                    "utc": [
-                      "America/Dawson",
-                      "America/Los_Angeles",
-                      "America/Tijuana",
-                      "America/Vancouver",
-                      "America/Whitehorse"
-                    ]
-                  },
-                  {
-                    "name": "Pacific Standard Time",
-                    "abbr": "PST",
-                    "offset": -8,
-                    "isdst": false,
-                    "text": "(UTC-08:00) Pacific Time (US & Canada)",
-                    "utc": [
-                      "America/Dawson",
-                      "America/Los_Angeles",
-                      "America/Tijuana",
-                      "America/Vancouver",
-                      "America/Whitehorse",
-                      "PST8PDT"
-                    ]
-                  },
-                  {
-                    "name": "US Mountain Standard Time",
-                    "abbr": "UMST",
-                    "offset": -7,
-                    "isdst": false,
-                    "text": "(UTC-07:00) Arizona",
-                    "utc": [
-                      "America/Creston",
-                      "America/Dawson_Creek",
-                      "America/Hermosillo",
-                      "America/Phoenix",
-                      "Etc/GMT+7"
-                    ]
-                  },
-                  {
-                    "name": "Mountain Standard Time (Mexico)",
-                    "abbr": "MDT",
-                    "offset": -6,
-                    "isdst": true,
-                    "text": "(UTC-07:00) Chihuahua, La Paz, Mazatlan",
-                    "utc": [
-                      "America/Chihuahua",
-                      "America/Mazatlan"
-                    ]
-                  },
-                  {
-                    "name": "Mountain Standard Time",
-                    "abbr": "MDT",
-                    "offset": -6,
-                    "isdst": true,
-                    "text": "(UTC-07:00) Mountain Time (US & Canada)",
-                    "utc": [
-                      "America/Boise",
-                      "America/Cambridge_Bay",
-                      "America/Denver",
-                      "America/Edmonton",
-                      "America/Inuvik",
-                      "America/Ojinaga",
-                      "America/Yellowknife",
-                      "MST7MDT"
-                    ]
-                  },
-                  {
-                    "name": "Central America Standard Time",
-                    "abbr": "CAST",
-                    "offset": -6,
-                    "isdst": false,
-                    "text": "(UTC-06:00) Central America",
-                    "utc": [
-                      "America/Belize",
-                      "America/Costa_Rica",
-                      "America/El_Salvador",
-                      "America/Guatemala",
-                      "America/Managua",
-                      "America/Tegucigalpa",
-                      "Etc/GMT+6",
-                      "Pacific/Galapagos"
-                    ]
-                  },
-                  {
-                    "name": "Central Standard Time",
-                    "abbr": "CDT",
-                    "offset": -5,
-                    "isdst": true,
-                    "text": "(UTC-06:00) Central Time (US & Canada)",
-                    "utc": [
-                      "America/Chicago",
-                      "America/Indiana/Knox",
-                      "America/Indiana/Tell_City",
-                      "America/Matamoros",
-                      "America/Menominee",
-                      "America/North_Dakota/Beulah",
-                      "America/North_Dakota/Center",
-                      "America/North_Dakota/New_Salem",
-                      "America/Rainy_River",
-                      "America/Rankin_Inlet",
-                      "America/Resolute",
-                      "America/Winnipeg",
-                      "CST6CDT"
-                    ]
-                  },
-                  {
-                    "name": "Central Standard Time (Mexico)",
-                    "abbr": "CDT",
-                    "offset": -5,
-                    "isdst": true,
-                    "text": "(UTC-06:00) Guadalajara, Mexico City, Monterrey",
-                    "utc": [
-                      "America/Bahia_Banderas",
-                      "America/Cancun",
-                      "America/Merida",
-                      "America/Mexico_City",
-                      "America/Monterrey"
-                    ]
-                  },
-                  {
-                    "name": "Canada Central Standard Time",
-                    "abbr": "CCST",
-                    "offset": -6,
-                    "isdst": false,
-                    "text": "(UTC-06:00) Saskatchewan",
-                    "utc": [
-                      "America/Regina",
-                      "America/Swift_Current"
-                    ]
-                  },
-                  {
-                    "name": "SA Pacific Standard Time",
-                    "abbr": "SPST",
-                    "offset": -5,
-                    "isdst": false,
-                    "text": "(UTC-05:00) Bogota, Lima, Quito",
-                    "utc": [
-                      "America/Bogota",
-                      "America/Cayman",
-                      "America/Coral_Harbour",
-                      "America/Eirunepe",
-                      "America/Guayaquil",
-                      "America/Jamaica",
-                      "America/Lima",
-                      "America/Panama",
-                      "America/Rio_Branco",
-                      "Etc/GMT+5"
-                    ]
-                  },
-                  {
-                    "name": "Eastern Standard Time",
-                    "abbr": "EDT",
-                    "offset": -4,
-                    "isdst": true,
-                    "text": "(UTC-05:00) Eastern Time (US & Canada)",
-                    "utc": [
-                      "America/Detroit",
-                      "America/Havana",
-                      "America/Indiana/Petersburg",
-                      "America/Indiana/Vincennes",
-                      "America/Indiana/Winamac",
-                      "America/Iqaluit",
-                      "America/Kentucky/Monticello",
-                      "America/Louisville",
-                      "America/Montreal",
-                      "America/Nassau",
-                      "America/New_York",
-                      "America/Nipigon",
-                      "America/Pangnirtung",
-                      "America/Port-au-Prince",
-                      "America/Thunder_Bay",
-                      "America/Toronto",
-                      "EST5EDT"
-                    ]
-                  },
-                  {
-                    "name": "US Eastern Standard Time",
-                    "abbr": "UEDT",
-                    "offset": -4,
-                    "isdst": true,
-                    "text": "(UTC-05:00) Indiana (East)",
-                    "utc": [
-                      "America/Indiana/Marengo",
-                      "America/Indiana/Vevay",
-                      "America/Indianapolis"
-                    ]
-                  },
-                  {
-                    "name": "Venezuela Standard Time",
-                    "abbr": "VST",
-                    "offset": -4.5,
-                    "isdst": false,
-                    "text": "(UTC-04:30) Caracas",
-                    "utc": [
-                      "America/Caracas"
-                    ]
-                  },
-                  {
-                    "name": "Paraguay Standard Time",
-                    "abbr": "PYT",
-                    "offset": -4,
-                    "isdst": false,
-                    "text": "(UTC-04:00) Asuncion",
-                    "utc": [
-                      "America/Asuncion"
-                    ]
-                  },
-                  {
-                    "name": "Atlantic Standard Time",
-                    "abbr": "ADT",
-                    "offset": -3,
-                    "isdst": true,
-                    "text": "(UTC-04:00) Atlantic Time (Canada)",
-                    "utc": [
-                      "America/Glace_Bay",
-                      "America/Goose_Bay",
-                      "America/Halifax",
-                      "America/Moncton",
-                      "America/Thule",
-                      "Atlantic/Bermuda"
-                    ]
-                  },
-                  {
-                    "name": "Central Brazilian Standard Time",
-                    "abbr": "CBST",
-                    "offset": -4,
-                    "isdst": false,
-                    "text": "(UTC-04:00) Cuiaba",
-                    "utc": [
-                      "America/Campo_Grande",
-                      "America/Cuiaba"
-                    ]
-                  },
-                  {
-                    "name": "SA Western Standard Time",
-                    "abbr": "SWST",
-                    "offset": -4,
-                    "isdst": false,
-                    "text": "(UTC-04:00) Georgetown, La Paz, Manaus, San Juan",
-                    "utc": [
-                      "America/Anguilla",
-                      "America/Antigua",
-                      "America/Aruba",
-                      "America/Barbados",
-                      "America/Blanc-Sablon",
-                      "America/Boa_Vista",
-                      "America/Curacao",
-                      "America/Dominica",
-                      "America/Grand_Turk",
-                      "America/Grenada",
-                      "America/Guadeloupe",
-                      "America/Guyana",
-                      "America/Kralendijk",
-                      "America/La_Paz",
-                      "America/Lower_Princes",
-                      "America/Manaus",
-                      "America/Marigot",
-                      "America/Martinique",
-                      "America/Montserrat",
-                      "America/Port_of_Spain",
-                      "America/Porto_Velho",
-                      "America/Puerto_Rico",
-                      "America/Santo_Domingo",
-                      "America/St_Barthelemy",
-                      "America/St_Kitts",
-                      "America/St_Lucia",
-                      "America/St_Thomas",
-                      "America/St_Vincent",
-                      "America/Tortola",
-                      "Etc/GMT+4"
-                    ]
-                  },
-                  {
-                    "name": "Pacific SA Standard Time",
-                    "abbr": "PSST",
-                    "offset": -4,
-                    "isdst": false,
-                    "text": "(UTC-04:00) Santiago",
-                    "utc": [
-                      "America/Santiago",
-                      "Antarctica/Palmer"
-                    ]
-                  },
-                  {
-                    "name": "Newfoundland Standard Time",
-                    "abbr": "NDT",
-                    "offset": -2.5,
-                    "isdst": true,
-                    "text": "(UTC-03:30) Newfoundland",
-                    "utc": [
-                      "America/St_Johns"
-                    ]
-                  },
-                  {
-                    "name": "E. South America Standard Time",
-                    "abbr": "ESAST",
-                    "offset": -3,
-                    "isdst": false,
-                    "text": "(UTC-03:00) Brasilia",
-                    "utc": [
-                      "America/Sao_Paulo"
-                    ]
-                  },
-                  {
-                    "name": "Argentina Standard Time",
-                    "abbr": "AST",
-                    "offset": -3,
-                    "isdst": false,
-                    "text": "(UTC-03:00) Buenos Aires",
-                    "utc": [
-                      "America/Argentina/La_Rioja",
-                      "America/Argentina/Rio_Gallegos",
-                      "America/Argentina/Salta",
-                      "America/Argentina/San_Juan",
-                      "America/Argentina/San_Luis",
-                      "America/Argentina/Tucuman",
-                      "America/Argentina/Ushuaia",
-                      "America/Buenos_Aires",
-                      "America/Catamarca",
-                      "America/Cordoba",
-                      "America/Jujuy",
-                      "America/Mendoza"
-                    ]
-                  },
-                  {
-                    "name": "SA Eastern Standard Time",
-                    "abbr": "SEST",
-                    "offset": -3,
-                    "isdst": false,
-                    "text": "(UTC-03:00) Cayenne, Fortaleza",
-                    "utc": [
-                      "America/Araguaina",
-                      "America/Belem",
-                      "America/Cayenne",
-                      "America/Fortaleza",
-                      "America/Maceio",
-                      "America/Paramaribo",
-                      "America/Recife",
-                      "America/Santarem",
-                      "Antarctica/Rothera",
-                      "Atlantic/Stanley",
-                      "Etc/GMT+3"
-                    ]
-                  },
-                  {
-                    "name": "Greenland Standard Time",
-                    "abbr": "GDT",
-                    "offset": -3,
-                    "isdst": true,
-                    "text": "(UTC-03:00) Greenland",
-                    "utc": [
-                      "America/Godthab"
-                    ]
-                  },
-                  {
-                    "name": "Montevideo Standard Time",
-                    "abbr": "MST",
-                    "offset": -3,
-                    "isdst": false,
-                    "text": "(UTC-03:00) Montevideo",
-                    "utc": [
-                      "America/Montevideo"
-                    ]
-                  },
-                  {
-                    "name": "Bahia Standard Time",
-                    "abbr": "BST",
-                    "offset": -3,
-                    "isdst": false,
-                    "text": "(UTC-03:00) Salvador",
-                    "utc": [
-                      "America/Bahia"
-                    ]
-                  },
-                  {
-                    "name": "UTC-02",
-                    "abbr": "U",
-                    "offset": -2,
-                    "isdst": false,
-                    "text": "(UTC-02:00) Coordinated Universal Time-02",
-                    "utc": [
-                      "America/Noronha",
-                      "Atlantic/South_Georgia",
-                      "Etc/GMT+2"
-                    ]
-                  },
-                  {
-                    "name": "Mid-Atlantic Standard Time",
-                    "abbr": "MDT",
-                    "offset": -1,
-                    "isdst": true,
-                    "text": "(UTC-02:00) Mid-Atlantic - Old",
-                    "utc": []
-                  },
-                  {
-                    "name": "Azores Standard Time",
-                    "abbr": "ADT",
-                    "offset": 0,
-                    "isdst": true,
-                    "text": "(UTC-01:00) Azores",
-                    "utc": [
-                      "America/Scoresbysund",
-                      "Atlantic/Azores"
-                    ]
-                  },
-                  {
-                    "name": "Cape Verde Standard Time",
-                    "abbr": "CVST",
-                    "offset": -1,
-                    "isdst": false,
-                    "text": "(UTC-01:00) Cape Verde Is.",
-                    "utc": [
-                      "Atlantic/Cape_Verde",
-                      "Etc/GMT+1"
-                    ]
-                  },
-                  {
-                    "name": "Morocco Standard Time",
-                    "abbr": "MDT",
-                    "offset": 1,
-                    "isdst": true,
-                    "text": "(UTC) Casablanca",
-                    "utc": [
-                      "Africa/Casablanca",
-                      "Africa/El_Aaiun"
-                    ]
-                  },
-                  {
-                    "name": "UTC",
-                    "abbr": "UTC",
-                    "offset": 0,
-                    "isdst": false,
-                    "text": "(UTC) Coordinated Universal Time",
-                    "utc": [
-                      "America/Danmarkshavn",
-                      "Etc/GMT"
-                    ]
-                  },
-                  {
-                    "name": "GMT Standard Time",
-                    "abbr": "GMT",
-                    "offset": 0,
-                    "isdst": false,
-                    "text": "(UTC) Edinburgh, London",
-                    "utc": [
-                      "Europe/Isle_of_Man",
-                      "Europe/Guernsey",
-                      "Europe/Jersey",
-                      "Europe/London"
-                    ]
-                  },
-                  {
-                    "name": "British Summer Time",
-                    "abbr": "BST",
-                    "offset": 1,
-                    "isdst": true,
-                    "text": "(UTC+01:00) Edinburgh, London",
-                    "utc": [
-                      "Europe/Isle_of_Man",
-                      "Europe/Guernsey",
-                      "Europe/Jersey",
-                      "Europe/London"
-                    ]
-                  },
-                  {
-                    "name": "GMT Standard Time",
-                    "abbr": "GDT",
-                    "offset": 1,
-                    "isdst": true,
-                    "text": "(UTC) Dublin, Lisbon",
-                    "utc": [
-                      "Atlantic/Canary",
-                      "Atlantic/Faeroe",
-                      "Atlantic/Madeira",
-                      "Europe/Dublin",
-                      "Europe/Lisbon"
-                    ]
-                  },
-                  {
-                    "name": "Greenwich Standard Time",
-                    "abbr": "GST",
-                    "offset": 0,
-                    "isdst": false,
-                    "text": "(UTC) Monrovia, Reykjavik",
-                    "utc": [
-                      "Africa/Abidjan",
-                      "Africa/Accra",
-                      "Africa/Bamako",
-                      "Africa/Banjul",
-                      "Africa/Bissau",
-                      "Africa/Conakry",
-                      "Africa/Dakar",
-                      "Africa/Freetown",
-                      "Africa/Lome",
-                      "Africa/Monrovia",
-                      "Africa/Nouakchott",
-                      "Africa/Ouagadougou",
-                      "Africa/Sao_Tome",
-                      "Atlantic/Reykjavik",
-                      "Atlantic/St_Helena"
-                    ]
-                  },
-                  {
-                    "name": "W. Europe Standard Time",
-                    "abbr": "WEDT",
-                    "offset": 2,
-                    "isdst": true,
-                    "text": "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna",
-                    "utc": [
-                      "Arctic/Longyearbyen",
-                      "Europe/Amsterdam",
-                      "Europe/Andorra",
-                      "Europe/Berlin",
-                      "Europe/Busingen",
-                      "Europe/Gibraltar",
-                      "Europe/Luxembourg",
-                      "Europe/Malta",
-                      "Europe/Monaco",
-                      "Europe/Oslo",
-                      "Europe/Rome",
-                      "Europe/San_Marino",
-                      "Europe/Stockholm",
-                      "Europe/Vaduz",
-                      "Europe/Vatican",
-                      "Europe/Vienna",
-                      "Europe/Zurich"
-                    ]
-                  },
-                  {
-                    "name": "Central Europe Standard Time",
-                    "abbr": "CEDT",
-                    "offset": 2,
-                    "isdst": true,
-                    "text": "(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague",
-                    "utc": [
-                      "Europe/Belgrade",
-                      "Europe/Bratislava",
-                      "Europe/Budapest",
-                      "Europe/Ljubljana",
-                      "Europe/Podgorica",
-                      "Europe/Prague",
-                      "Europe/Tirane"
-                    ]
-                  },
-                  {
-                    "name": "Romance Standard Time",
-                    "abbr": "RDT",
-                    "offset": 2,
-                    "isdst": true,
-                    "text": "(UTC+01:00) Brussels, Copenhagen, Madrid, Paris",
-                    "utc": [
-                      "Africa/Ceuta",
-                      "Europe/Brussels",
-                      "Europe/Copenhagen",
-                      "Europe/Madrid",
-                      "Europe/Paris"
-                    ]
-                  },
-                  {
-                    "name": "Central European Standard Time",
-                    "abbr": "CEDT",
-                    "offset": 2,
-                    "isdst": true,
-                    "text": "(UTC+01:00) Sarajevo, Skopje, Warsaw, Zagreb",
-                    "utc": [
-                      "Europe/Sarajevo",
-                      "Europe/Skopje",
-                      "Europe/Warsaw",
-                      "Europe/Zagreb"
-                    ]
-                  },
-                  {
-                    "name": "W. Central Africa Standard Time",
-                    "abbr": "WCAST",
-                    "offset": 1,
-                    "isdst": false,
-                    "text": "(UTC+01:00) West Central Africa",
-                    "utc": [
-                      "Africa/Algiers",
-                      "Africa/Bangui",
-                      "Africa/Brazzaville",
-                      "Africa/Douala",
-                      "Africa/Kinshasa",
-                      "Africa/Lagos",
-                      "Africa/Libreville",
-                      "Africa/Luanda",
-                      "Africa/Malabo",
-                      "Africa/Ndjamena",
-                      "Africa/Niamey",
-                      "Africa/Porto-Novo",
-                      "Africa/Tunis",
-                      "Etc/GMT-1"
-                    ]
-                  },
-                  {
-                    "name": "Namibia Standard Time",
-                    "abbr": "NST",
-                    "offset": 1,
-                    "isdst": false,
-                    "text": "(UTC+01:00) Windhoek",
-                    "utc": [
-                      "Africa/Windhoek"
-                    ]
-                  },
-                  {
-                    "name": "GTB Standard Time",
-                    "abbr": "GDT",
-                    "offset": 3,
-                    "isdst": true,
-                    "text": "(UTC+02:00) Athens, Bucharest",
-                    "utc": [
-                      "Asia/Nicosia",
-                      "Europe/Athens",
-                      "Europe/Bucharest",
-                      "Europe/Chisinau"
-                    ]
-                  },
-                  {
-                    "name": "Middle East Standard Time",
-                    "abbr": "MEDT",
-                    "offset": 3,
-                    "isdst": true,
-                    "text": "(UTC+02:00) Beirut",
-                    "utc": [
-                      "Asia/Beirut"
-                    ]
-                  },
-                  {
-                    "name": "Egypt Standard Time",
-                    "abbr": "EST",
-                    "offset": 2,
-                    "isdst": false,
-                    "text": "(UTC+02:00) Cairo",
-                    "utc": [
-                      "Africa/Cairo"
-                    ]
-                  },
-                  {
-                    "name": "Syria Standard Time",
-                    "abbr": "SDT",
-                    "offset": 3,
-                    "isdst": true,
-                    "text": "(UTC+02:00) Damascus",
-                    "utc": [
-                      "Asia/Damascus"
-                    ]
-                  },
-                  {
-                    "name": "E. Europe Standard Time",
-                    "abbr": "EEDT",
-                    "offset": 3,
-                    "isdst": true,
-                    "text": "(UTC+02:00) E. Europe",
-                    "utc": [
-                      "Asia/Nicosia",
-                      "Europe/Athens",
-                      "Europe/Bucharest",
-                      "Europe/Chisinau",
-                      "Europe/Helsinki",
-                      "Europe/Kiev",
-                      "Europe/Mariehamn",
-                      "Europe/Nicosia",
-                      "Europe/Riga",
-                      "Europe/Sofia",
-                      "Europe/Tallinn",
-                      "Europe/Uzhgorod",
-                      "Europe/Vilnius",
-                      "Europe/Zaporozhye"
-                    ]
-                  },
-                  {
-                    "name": "South Africa Standard Time",
-                    "abbr": "SAST",
-                    "offset": 2,
-                    "isdst": false,
-                    "text": "(UTC+02:00) Harare, Pretoria",
-                    "utc": [
-                      "Africa/Blantyre",
-                      "Africa/Bujumbura",
-                      "Africa/Gaborone",
-                      "Africa/Harare",
-                      "Africa/Johannesburg",
-                      "Africa/Kigali",
-                      "Africa/Lubumbashi",
-                      "Africa/Lusaka",
-                      "Africa/Maputo",
-                      "Africa/Maseru",
-                      "Africa/Mbabane",
-                      "Etc/GMT-2"
-                    ]
-                  },
-                  {
-                    "name": "FLE Standard Time",
-                    "abbr": "FDT",
-                    "offset": 3,
-                    "isdst": true,
-                    "text": "(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius",
-                    "utc": [
-                      "Europe/Helsinki",
-                      "Europe/Kiev",
-                      "Europe/Mariehamn",
-                      "Europe/Riga",
-                      "Europe/Sofia",
-                      "Europe/Tallinn",
-                      "Europe/Uzhgorod",
-                      "Europe/Vilnius",
-                      "Europe/Zaporozhye"
-                    ]
-                  },
-                  {
-                    "name": "Turkey Standard Time",
-                    "abbr": "TDT",
-                    "offset": 3,
-                    "isdst": false,
-                    "text": "(UTC+03:00) Istanbul",
-                    "utc": [
-                      "Europe/Istanbul"
-                    ]
-                  },
-                  {
-                    "name": "Israel Standard Time",
-                    "abbr": "JDT",
-                    "offset": 3,
-                    "isdst": true,
-                    "text": "(UTC+02:00) Jerusalem",
-                    "utc": [
-                      "Asia/Jerusalem"
-                    ]
-                  },
-                  {
-                    "name": "Libya Standard Time",
-                    "abbr": "LST",
-                    "offset": 2,
-                    "isdst": false,
-                    "text": "(UTC+02:00) Tripoli",
-                    "utc": [
-                      "Africa/Tripoli"
-                    ]
-                  },
-                  {
-                    "name": "Jordan Standard Time",
-                    "abbr": "JST",
-                    "offset": 3,
-                    "isdst": false,
-                    "text": "(UTC+03:00) Amman",
-                    "utc": [
-                      "Asia/Amman"
-                    ]
-                  },
-                  {
-                    "name": "Arabic Standard Time",
-                    "abbr": "AST",
-                    "offset": 3,
-                    "isdst": false,
-                    "text": "(UTC+03:00) Baghdad",
-                    "utc": [
-                      "Asia/Baghdad"
-                    ]
-                  },
-                  {
-                    "name": "Kaliningrad Standard Time",
-                    "abbr": "KST",
-                    "offset": 3,
-                    "isdst": false,
-                    "text": "(UTC+02:00) Kaliningrad",
-                    "utc": [
-                      "Europe/Kaliningrad"
-                    ]
-                  },
-                  {
-                    "name": "Arab Standard Time",
-                    "abbr": "AST",
-                    "offset": 3,
-                    "isdst": false,
-                    "text": "(UTC+03:00) Kuwait, Riyadh",
-                    "utc": [
-                      "Asia/Aden",
-                      "Asia/Bahrain",
-                      "Asia/Kuwait",
-                      "Asia/Qatar",
-                      "Asia/Riyadh"
-                    ]
-                  },
-                  {
-                    "name": "E. Africa Standard Time",
-                    "abbr": "EAST",
-                    "offset": 3,
-                    "isdst": false,
-                    "text": "(UTC+03:00) Nairobi",
-                    "utc": [
-                      "Africa/Addis_Ababa",
-                      "Africa/Asmera",
-                      "Africa/Dar_es_Salaam",
-                      "Africa/Djibouti",
-                      "Africa/Juba",
-                      "Africa/Kampala",
-                      "Africa/Khartoum",
-                      "Africa/Mogadishu",
-                      "Africa/Nairobi",
-                      "Antarctica/Syowa",
-                      "Etc/GMT-3",
-                      "Indian/Antananarivo",
-                      "Indian/Comoro",
-                      "Indian/Mayotte"
-                    ]
-                  },
-                  {
-                    "name": "Moscow Standard Time",
-                    "abbr": "MSK",
-                    "offset": 3,
-                    "isdst": false,
-                    "text": "(UTC+03:00) Moscow, St. Petersburg, Volgograd, Minsk",
-                    "utc": [
-                        "Europe/Kirov",
-                      "Europe/Moscow",
-                      "Europe/Simferopol",
-                      "Europe/Volgograd",
-                      "Europe/Minsk"
-                    ]
-                  },
-                  {
-                    "name": "Samara Time",
-                    "abbr": "SAMT",
-                    "offset": 4,
-                    "isdst": false,
-                    "text": "(UTC+04:00) Samara, Ulyanovsk, Saratov",
-                    "utc": [
-                        "Europe/Astrakhan",
-                      "Europe/Samara",
-                        "Europe/Ulyanovsk"
-                    ]
-                  },
-                  {
-                    "name": "Iran Standard Time",
-                    "abbr": "IDT",
-                    "offset": 4.5,
-                    "isdst": true,
-                    "text": "(UTC+03:30) Tehran",
-                    "utc": [
-                      "Asia/Tehran"
-                    ]
-                  },
-                  {
-                    "name": "Arabian Standard Time",
-                    "abbr": "AST",
-                    "offset": 4,
-                    "isdst": false,
-                    "text": "(UTC+04:00) Abu Dhabi, Muscat",
-                    "utc": [
-                      "Asia/Dubai",
-                      "Asia/Muscat",
-                      "Etc/GMT-4"
-                    ]
-                  },
-                  {
-                    "name": "Azerbaijan Standard Time",
-                    "abbr": "ADT",
-                    "offset": 5,
-                    "isdst": true,
-                    "text": "(UTC+04:00) Baku",
-                    "utc": [
-                      "Asia/Baku"
-                    ]
-                  },
-                  {
-                    "name": "Mauritius Standard Time",
-                    "abbr": "MST",
-                    "offset": 4,
-                    "isdst": false,
-                    "text": "(UTC+04:00) Port Louis",
-                    "utc": [
-                      "Indian/Mahe",
-                      "Indian/Mauritius",
-                      "Indian/Reunion"
-                    ]
-                  },
-                  {
-                    "name": "Georgian Standard Time",
-                    "abbr": "GET",
-                    "offset": 4,
-                    "isdst": false,
-                    "text": "(UTC+04:00) Tbilisi",
-                    "utc": [
-                      "Asia/Tbilisi"
-                    ]
-                  },
-                  {
-                    "name": "Caucasus Standard Time",
-                    "abbr": "CST",
-                    "offset": 4,
-                    "isdst": false,
-                    "text": "(UTC+04:00) Yerevan",
-                    "utc": [
-                      "Asia/Yerevan"
-                    ]
-                  },
-                  {
-                    "name": "Afghanistan Standard Time",
-                    "abbr": "AST",
-                    "offset": 4.5,
-                    "isdst": false,
-                    "text": "(UTC+04:30) Kabul",
-                    "utc": [
-                      "Asia/Kabul"
-                    ]
-                  },
-                  {
-                    "name": "West Asia Standard Time",
-                    "abbr": "WAST",
-                    "offset": 5,
-                    "isdst": false,
-                    "text": "(UTC+05:00) Ashgabat, Tashkent",
-                    "utc": [
-                      "Antarctica/Mawson",
-                      "Asia/Aqtau",
-                      "Asia/Aqtobe",
-                      "Asia/Ashgabat",
-                      "Asia/Dushanbe",
-                      "Asia/Oral",
-                      "Asia/Samarkand",
-                      "Asia/Tashkent",
-                      "Etc/GMT-5",
-                      "Indian/Kerguelen",
-                      "Indian/Maldives"
-                    ]
-                  },
-                  {
-                    "name": "Yekaterinburg Time",
-                    "abbr": "YEKT",
-                    "offset": 5,
-                    "isdst": false,
-                    "text": "(UTC+05:00) Yekaterinburg",
-                    "utc": [
-                      "Asia/Yekaterinburg"
-                    ]
-                  },
-                  {
-                    "name": "Pakistan Standard Time",
-                    "abbr": "PKT",
-                    "offset": 5,
-                    "isdst": false,
-                    "text": "(UTC+05:00) Islamabad, Karachi",
-                    "utc": [
-                      "Asia/Karachi"
-                    ]
-                  },
-                  {
-                    "name": "India Standard Time",
-                    "abbr": "IST",
-                    "offset": 5.5,
-                    "isdst": false,
-                    "text": "(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi",
-                    "utc": [
-                      "Asia/Kolkata"
-                    ]
-                  },
-                  {
-                    "name": "Sri Lanka Standard Time",
-                    "abbr": "SLST",
-                    "offset": 5.5,
-                    "isdst": false,
-                    "text": "(UTC+05:30) Sri Jayawardenepura",
-                    "utc": [
-                      "Asia/Colombo"
-                    ]
-                  },
-                  {
-                    "name": "Nepal Standard Time",
-                    "abbr": "NST",
-                    "offset": 5.75,
-                    "isdst": false,
-                    "text": "(UTC+05:45) Kathmandu",
-                    "utc": [
-                      "Asia/Kathmandu"
-                    ]
-                  },
-                  {
-                    "name": "Central Asia Standard Time",
-                    "abbr": "CAST",
-                    "offset": 6,
-                    "isdst": false,
-                    "text": "(UTC+06:00) Nur-Sultan (Astana)",
-                    "utc": [
-                      "Antarctica/Vostok",
-                      "Asia/Almaty",
-                      "Asia/Bishkek",
-                      "Asia/Qyzylorda",
-                      "Asia/Urumqi",
-                      "Etc/GMT-6",
-                      "Indian/Chagos"
-                    ]
-                  },
-                  {
-                    "name": "Bangladesh Standard Time",
-                    "abbr": "BST",
-                    "offset": 6,
-                    "isdst": false,
-                    "text": "(UTC+06:00) Dhaka",
-                    "utc": [
-                      "Asia/Dhaka",
-                      "Asia/Thimphu"
-                    ]
-                  },
-                  {
-                    "name": "Myanmar Standard Time",
-                    "abbr": "MST",
-                    "offset": 6.5,
-                    "isdst": false,
-                    "text": "(UTC+06:30) Yangon (Rangoon)",
-                    "utc": [
-                      "Asia/Rangoon",
-                      "Indian/Cocos"
-                    ]
-                  },
-                  {
-                    "name": "SE Asia Standard Time",
-                    "abbr": "SAST",
-                    "offset": 7,
-                    "isdst": false,
-                    "text": "(UTC+07:00) Bangkok, Hanoi, Jakarta",
-                    "utc": [
-                      "Antarctica/Davis",
-                      "Asia/Bangkok",
-                      "Asia/Hovd",
-                      "Asia/Jakarta",
-                      "Asia/Phnom_Penh",
-                      "Asia/Pontianak",
-                      "Asia/Saigon",
-                      "Asia/Vientiane",
-                      "Etc/GMT-7",
-                      "Indian/Christmas"
-                    ]
-                  },
-                  {
-                    "name": "N. Central Asia Standard Time",
-                    "abbr": "NCAST",
-                    "offset": 7,
-                    "isdst": false,
-                    "text": "(UTC+07:00) Novosibirsk",
-                    "utc": [
-                      "Asia/Novokuznetsk",
-                      "Asia/Novosibirsk",
-                      "Asia/Omsk"
-                    ]
-                  },
-                  {
-                    "name": "China Standard Time",
-                    "abbr": "CST",
-                    "offset": 8,
-                    "isdst": false,
-                    "text": "(UTC+08:00) Beijing, Chongqing, Hong Kong, Urumqi",
-                    "utc": [
-                      "Asia/Hong_Kong",
-                      "Asia/Macau",
-                      "Asia/Shanghai"
-                    ]
-                  },
-                  {
-                    "name": "North Asia Standard Time",
-                    "abbr": "NAST",
-                    "offset": 8,
-                    "isdst": false,
-                    "text": "(UTC+08:00) Krasnoyarsk",
-                    "utc": [
-                      "Asia/Krasnoyarsk"
-                    ]
-                  },
-                  {
-                    "name": "Singapore Standard Time",
-                    "abbr": "MPST",
-                    "offset": 8,
-                    "isdst": false,
-                    "text": "(UTC+08:00) Kuala Lumpur, Singapore",
-                    "utc": [
-                      "Asia/Brunei",
-                      "Asia/Kuala_Lumpur",
-                      "Asia/Kuching",
-                      "Asia/Makassar",
-                      "Asia/Manila",
-                      "Asia/Singapore",
-                      "Etc/GMT-8"
-                    ]
-                  },
-                  {
-                    "name": "W. Australia Standard Time",
-                    "abbr": "WAST",
-                    "offset": 8,
-                    "isdst": false,
-                    "text": "(UTC+08:00) Perth",
-                    "utc": [
-                      "Antarctica/Casey",
-                      "Australia/Perth"
-                    ]
-                  },
-                  {
-                    "name": "Taipei Standard Time",
-                    "abbr": "TST",
-                    "offset": 8,
-                    "isdst": false,
-                    "text": "(UTC+08:00) Taipei",
-                    "utc": [
-                      "Asia/Taipei"
-                    ]
-                  },
-                  {
-                    "name": "Ulaanbaatar Standard Time",
-                    "abbr": "UST",
-                    "offset": 8,
-                    "isdst": false,
-                    "text": "(UTC+08:00) Ulaanbaatar",
-                    "utc": [
-                      "Asia/Choibalsan",
-                      "Asia/Ulaanbaatar"
-                    ]
-                  },
-                  {
-                    "name": "North Asia East Standard Time",
-                    "abbr": "NAEST",
-                    "offset": 8,
-                    "isdst": false,
-                    "text": "(UTC+08:00) Irkutsk",
-                    "utc": [
-                      "Asia/Irkutsk"
-                    ]
-                  },
-                  {
-                    "name": "Japan Standard Time",
-                    "abbr": "JST",
-                    "offset": 9,
-                    "isdst": false,
-                    "text": "(UTC+09:00) Osaka, Sapporo, Tokyo",
-                    "utc": [
-                      "Asia/Dili",
-                      "Asia/Jayapura",
-                      "Asia/Tokyo",
-                      "Etc/GMT-9",
-                      "Pacific/Palau"
-                    ]
-                  },
-                  {
-                    "name": "Korea Standard Time",
-                    "abbr": "KST",
-                    "offset": 9,
-                    "isdst": false,
-                    "text": "(UTC+09:00) Seoul",
-                    "utc": [
-                      "Asia/Pyongyang",
-                      "Asia/Seoul"
-                    ]
-                  },
-                  {
-                    "name": "Cen. Australia Standard Time",
-                    "abbr": "CAST",
-                    "offset": 9.5,
-                    "isdst": false,
-                    "text": "(UTC+09:30) Adelaide",
-                    "utc": [
-                      "Australia/Adelaide",
-                      "Australia/Broken_Hill"
-                    ]
-                  },
-                  {
-                    "name": "AUS Central Standard Time",
-                    "abbr": "ACST",
-                    "offset": 9.5,
-                    "isdst": false,
-                    "text": "(UTC+09:30) Darwin",
-                    "utc": [
-                      "Australia/Darwin"
-                    ]
-                  },
-                  {
-                    "name": "E. Australia Standard Time",
-                    "abbr": "EAST",
-                    "offset": 10,
-                    "isdst": false,
-                    "text": "(UTC+10:00) Brisbane",
-                    "utc": [
-                      "Australia/Brisbane",
-                      "Australia/Lindeman"
-                    ]
-                  },
-                  {
-                    "name": "AUS Eastern Standard Time",
-                    "abbr": "AEST",
-                    "offset": 10,
-                    "isdst": false,
-                    "text": "(UTC+10:00) Canberra, Melbourne, Sydney",
-                    "utc": [
-                      "Australia/Melbourne",
-                      "Australia/Sydney"
-                    ]
-                  },
-                  {
-                    "name": "West Pacific Standard Time",
-                    "abbr": "WPST",
-                    "offset": 10,
-                    "isdst": false,
-                    "text": "(UTC+10:00) Guam, Port Moresby",
-                    "utc": [
-                      "Antarctica/DumontDUrville",
-                      "Etc/GMT-10",
-                      "Pacific/Guam",
-                      "Pacific/Port_Moresby",
-                      "Pacific/Saipan",
-                      "Pacific/Truk"
-                    ]
-                  },
-                  {
-                    "name": "Tasmania Standard Time",
-                    "abbr": "TST",
-                    "offset": 10,
-                    "isdst": false,
-                    "text": "(UTC+10:00) Hobart",
-                    "utc": [
-                      "Australia/Currie",
-                      "Australia/Hobart"
-                    ]
-                  },
-                  {
-                    "name": "Yakutsk Standard Time",
-                    "abbr": "YST",
-                    "offset": 9,
-                    "isdst": false,
-                    "text": "(UTC+09:00) Yakutsk",
-                    "utc": [
-                      "Asia/Chita",
-                      "Asia/Khandyga",
-                      "Asia/Yakutsk"
-                    ]
-                  },
-                  {
-                    "name": "Central Pacific Standard Time",
-                    "abbr": "CPST",
-                    "offset": 11,
-                    "isdst": false,
-                    "text": "(UTC+11:00) Solomon Is., New Caledonia",
-                    "utc": [
-                      "Antarctica/Macquarie",
-                      "Etc/GMT-11",
-                      "Pacific/Efate",
-                      "Pacific/Guadalcanal",
-                      "Pacific/Kosrae",
-                      "Pacific/Noumea",
-                      "Pacific/Ponape"
-                    ]
-                  },
-                  {
-                    "name": "Vladivostok Standard Time",
-                    "abbr": "VST",
-                    "offset": 11,
-                    "isdst": false,
-                    "text": "(UTC+11:00) Vladivostok",
-                    "utc": [
-                      "Asia/Sakhalin",
-                      "Asia/Ust-Nera",
-                      "Asia/Vladivostok"
-                    ]
-                  },
-                  {
-                    "name": "New Zealand Standard Time",
-                    "abbr": "NZST",
-                    "offset": 12,
-                    "isdst": false,
-                    "text": "(UTC+12:00) Auckland, Wellington",
-                    "utc": [
-                      "Antarctica/McMurdo",
-                      "Pacific/Auckland"
-                    ]
-                  },
-                  {
-                    "name": "UTC+12",
-                    "abbr": "U",
-                    "offset": 12,
-                    "isdst": false,
-                    "text": "(UTC+12:00) Coordinated Universal Time+12",
-                    "utc": [
-                      "Etc/GMT-12",
-                      "Pacific/Funafuti",
-                      "Pacific/Kwajalein",
-                      "Pacific/Majuro",
-                      "Pacific/Nauru",
-                      "Pacific/Tarawa",
-                      "Pacific/Wake",
-                      "Pacific/Wallis"
-                    ]
-                  },
-                  {
-                    "name": "Fiji Standard Time",
-                    "abbr": "FST",
-                    "offset": 12,
-                    "isdst": false,
-                    "text": "(UTC+12:00) Fiji",
-                    "utc": [
-                      "Pacific/Fiji"
-                    ]
-                  },
-                  {
-                    "name": "Magadan Standard Time",
-                    "abbr": "MST",
-                    "offset": 12,
-                    "isdst": false,
-                    "text": "(UTC+12:00) Magadan",
-                    "utc": [
-                      "Asia/Anadyr",
-                      "Asia/Kamchatka",
-                      "Asia/Magadan",
-                      "Asia/Srednekolymsk"
-                    ]
-                  },
-                  {
-                    "name": "Kamchatka Standard Time",
-                    "abbr": "KDT",
-                    "offset": 13,
-                    "isdst": true,
-                    "text": "(UTC+12:00) Petropavlovsk-Kamchatsky - Old",
-                    "utc": [
-                      "Asia/Kamchatka"
-                    ]
-                  },
-                  {
-                    "name": "Tonga Standard Time",
-                    "abbr": "TST",
-                    "offset": 13,
-                    "isdst": false,
-                    "text": "(UTC+13:00) Nuku'alofa",
-                    "utc": [
-                      "Etc/GMT-13",
-                      "Pacific/Enderbury",
-                      "Pacific/Fakaofo",
-                      "Pacific/Tongatapu"
-                    ]
-                  },
-                  {
-                    "name": "Samoa Standard Time",
-                    "abbr": "SST",
-                    "offset": 13,
-                    "isdst": false,
-                    "text": "(UTC+13:00) Samoa",
-                    "utc": [
-                      "Pacific/Apia"
-                    ]
-                  }
-                ],
+        {
+            "name": "Dateline Standard Time",
+            "abbr": "DST",
+            "offset": -12,
+            "isdst": false,
+            "text": "(UTC-12:00) International Date Line West",
+            "utc": [
+                "Etc/GMT+12"
+            ]
+        },
+        {
+            "name": "UTC-11",
+            "abbr": "U",
+            "offset": -11,
+            "isdst": false,
+            "text": "(UTC-11:00) Coordinated Universal Time-11",
+            "utc": [
+                "Etc/GMT+11",
+                "Pacific/Midway",
+                "Pacific/Niue",
+                "Pacific/Pago_Pago"
+            ]
+        },
+        {
+            "name": "Hawaiian Standard Time",
+            "abbr": "HST",
+            "offset": -10,
+            "isdst": false,
+            "text": "(UTC-10:00) Hawaii",
+            "utc": [
+                "Etc/GMT+10",
+                "Pacific/Honolulu",
+                "Pacific/Johnston",
+                "Pacific/Rarotonga",
+                "Pacific/Tahiti"
+            ]
+        },
+        {
+            "name": "Alaskan Standard Time",
+            "abbr": "AKDT",
+            "offset": -8,
+            "isdst": true,
+            "text": "(UTC-09:00) Alaska",
+            "utc": [
+                "America/Anchorage",
+                "America/Juneau",
+                "America/Nome",
+                "America/Sitka",
+                "America/Yakutat"
+            ]
+        },
+        {
+            "name": "Pacific Standard Time (Mexico)",
+            "abbr": "PDT",
+            "offset": -7,
+            "isdst": true,
+            "text": "(UTC-08:00) Baja California",
+            "utc": [
+                "America/Santa_Isabel"
+            ]
+        },
+        {
+            "name": "Pacific Daylight Time",
+            "abbr": "PDT",
+            "offset": -7,
+            "isdst": true,
+            "text": "(UTC-07:00) Pacific Time (US & Canada)",
+            "utc": [
+                "America/Dawson",
+                "America/Los_Angeles",
+                "America/Tijuana",
+                "America/Vancouver",
+                "America/Whitehorse"
+            ]
+        },
+        {
+            "name": "Pacific Standard Time",
+            "abbr": "PST",
+            "offset": -8,
+            "isdst": false,
+            "text": "(UTC-08:00) Pacific Time (US & Canada)",
+            "utc": [
+                "America/Dawson",
+                "America/Los_Angeles",
+                "America/Tijuana",
+                "America/Vancouver",
+                "America/Whitehorse",
+                "PST8PDT"
+            ]
+        },
+        {
+            "name": "US Mountain Standard Time",
+            "abbr": "UMST",
+            "offset": -7,
+            "isdst": false,
+            "text": "(UTC-07:00) Arizona",
+            "utc": [
+                "America/Creston",
+                "America/Dawson_Creek",
+                "America/Hermosillo",
+                "America/Phoenix",
+                "Etc/GMT+7"
+            ]
+        },
+        {
+            "name": "Mountain Standard Time (Mexico)",
+            "abbr": "MDT",
+            "offset": -6,
+            "isdst": true,
+            "text": "(UTC-07:00) Chihuahua, La Paz, Mazatlan",
+            "utc": [
+                "America/Chihuahua",
+                "America/Mazatlan"
+            ]
+        },
+        {
+            "name": "Mountain Standard Time",
+            "abbr": "MDT",
+            "offset": -6,
+            "isdst": true,
+            "text": "(UTC-07:00) Mountain Time (US & Canada)",
+            "utc": [
+                "America/Boise",
+                "America/Cambridge_Bay",
+                "America/Denver",
+                "America/Edmonton",
+                "America/Inuvik",
+                "America/Ojinaga",
+                "America/Yellowknife",
+                "MST7MDT"
+            ]
+        },
+        {
+            "name": "Central America Standard Time",
+            "abbr": "CAST",
+            "offset": -6,
+            "isdst": false,
+            "text": "(UTC-06:00) Central America",
+            "utc": [
+                "America/Belize",
+                "America/Costa_Rica",
+                "America/El_Salvador",
+                "America/Guatemala",
+                "America/Managua",
+                "America/Tegucigalpa",
+                "Etc/GMT+6",
+                "Pacific/Galapagos"
+            ]
+        },
+        {
+            "name": "Central Standard Time",
+            "abbr": "CDT",
+            "offset": -5,
+            "isdst": true,
+            "text": "(UTC-06:00) Central Time (US & Canada)",
+            "utc": [
+                "America/Chicago",
+                "America/Indiana/Knox",
+                "America/Indiana/Tell_City",
+                "America/Matamoros",
+                "America/Menominee",
+                "America/North_Dakota/Beulah",
+                "America/North_Dakota/Center",
+                "America/North_Dakota/New_Salem",
+                "America/Rainy_River",
+                "America/Rankin_Inlet",
+                "America/Resolute",
+                "America/Winnipeg",
+                "CST6CDT"
+            ]
+        },
+        {
+            "name": "Central Standard Time (Mexico)",
+            "abbr": "CDT",
+            "offset": -5,
+            "isdst": true,
+            "text": "(UTC-06:00) Guadalajara, Mexico City, Monterrey",
+            "utc": [
+                "America/Bahia_Banderas",
+                "America/Cancun",
+                "America/Merida",
+                "America/Mexico_City",
+                "America/Monterrey"
+            ]
+        },
+        {
+            "name": "Canada Central Standard Time",
+            "abbr": "CCST",
+            "offset": -6,
+            "isdst": false,
+            "text": "(UTC-06:00) Saskatchewan",
+            "utc": [
+                "America/Regina",
+                "America/Swift_Current"
+            ]
+        },
+        {
+            "name": "SA Pacific Standard Time",
+            "abbr": "SPST",
+            "offset": -5,
+            "isdst": false,
+            "text": "(UTC-05:00) Bogota, Lima, Quito",
+            "utc": [
+                "America/Bogota",
+                "America/Cayman",
+                "America/Coral_Harbour",
+                "America/Eirunepe",
+                "America/Guayaquil",
+                "America/Jamaica",
+                "America/Lima",
+                "America/Panama",
+                "America/Rio_Branco",
+                "Etc/GMT+5"
+            ]
+        },
+        {
+            "name": "Eastern Standard Time",
+            "abbr": "EDT",
+            "offset": -4,
+            "isdst": true,
+            "text": "(UTC-05:00) Eastern Time (US & Canada)",
+            "utc": [
+                "America/Detroit",
+                "America/Havana",
+                "America/Indiana/Petersburg",
+                "America/Indiana/Vincennes",
+                "America/Indiana/Winamac",
+                "America/Iqaluit",
+                "America/Kentucky/Monticello",
+                "America/Louisville",
+                "America/Montreal",
+                "America/Nassau",
+                "America/New_York",
+                "America/Nipigon",
+                "America/Pangnirtung",
+                "America/Port-au-Prince",
+                "America/Thunder_Bay",
+                "America/Toronto",
+                "EST5EDT"
+            ]
+        },
+        {
+            "name": "US Eastern Standard Time",
+            "abbr": "UEDT",
+            "offset": -4,
+            "isdst": true,
+            "text": "(UTC-05:00) Indiana (East)",
+            "utc": [
+                "America/Indiana/Marengo",
+                "America/Indiana/Vevay",
+                "America/Indianapolis"
+            ]
+        },
+        {
+            "name": "Venezuela Standard Time",
+            "abbr": "VST",
+            "offset": -4.5,
+            "isdst": false,
+            "text": "(UTC-04:30) Caracas",
+            "utc": [
+                "America/Caracas"
+            ]
+        },
+        {
+            "name": "Paraguay Standard Time",
+            "abbr": "PYT",
+            "offset": -4,
+            "isdst": false,
+            "text": "(UTC-04:00) Asuncion",
+            "utc": [
+                "America/Asuncion"
+            ]
+        },
+        {
+            "name": "Atlantic Standard Time",
+            "abbr": "ADT",
+            "offset": -3,
+            "isdst": true,
+            "text": "(UTC-04:00) Atlantic Time (Canada)",
+            "utc": [
+                "America/Glace_Bay",
+                "America/Goose_Bay",
+                "America/Halifax",
+                "America/Moncton",
+                "America/Thule",
+                "Atlantic/Bermuda"
+            ]
+        },
+        {
+            "name": "Central Brazilian Standard Time",
+            "abbr": "CBST",
+            "offset": -4,
+            "isdst": false,
+            "text": "(UTC-04:00) Cuiaba",
+            "utc": [
+                "America/Campo_Grande",
+                "America/Cuiaba"
+            ]
+        },
+        {
+            "name": "SA Western Standard Time",
+            "abbr": "SWST",
+            "offset": -4,
+            "isdst": false,
+            "text": "(UTC-04:00) Georgetown, La Paz, Manaus, San Juan",
+            "utc": [
+                "America/Anguilla",
+                "America/Antigua",
+                "America/Aruba",
+                "America/Barbados",
+                "America/Blanc-Sablon",
+                "America/Boa_Vista",
+                "America/Curacao",
+                "America/Dominica",
+                "America/Grand_Turk",
+                "America/Grenada",
+                "America/Guadeloupe",
+                "America/Guyana",
+                "America/Kralendijk",
+                "America/La_Paz",
+                "America/Lower_Princes",
+                "America/Manaus",
+                "America/Marigot",
+                "America/Martinique",
+                "America/Montserrat",
+                "America/Port_of_Spain",
+                "America/Porto_Velho",
+                "America/Puerto_Rico",
+                "America/Santo_Domingo",
+                "America/St_Barthelemy",
+                "America/St_Kitts",
+                "America/St_Lucia",
+                "America/St_Thomas",
+                "America/St_Vincent",
+                "America/Tortola",
+                "Etc/GMT+4"
+            ]
+        },
+        {
+            "name": "Pacific SA Standard Time",
+            "abbr": "PSST",
+            "offset": -4,
+            "isdst": false,
+            "text": "(UTC-04:00) Santiago",
+            "utc": [
+                "America/Santiago",
+                "Antarctica/Palmer"
+            ]
+        },
+        {
+            "name": "Newfoundland Standard Time",
+            "abbr": "NDT",
+            "offset": -2.5,
+            "isdst": true,
+            "text": "(UTC-03:30) Newfoundland",
+            "utc": [
+                "America/St_Johns"
+            ]
+        },
+        {
+            "name": "E. South America Standard Time",
+            "abbr": "ESAST",
+            "offset": -3,
+            "isdst": false,
+            "text": "(UTC-03:00) Brasilia",
+            "utc": [
+                "America/Sao_Paulo"
+            ]
+        },
+        {
+            "name": "Argentina Standard Time",
+            "abbr": "AST",
+            "offset": -3,
+            "isdst": false,
+            "text": "(UTC-03:00) Buenos Aires",
+            "utc": [
+                "America/Argentina/La_Rioja",
+                "America/Argentina/Rio_Gallegos",
+                "America/Argentina/Salta",
+                "America/Argentina/San_Juan",
+                "America/Argentina/San_Luis",
+                "America/Argentina/Tucuman",
+                "America/Argentina/Ushuaia",
+                "America/Buenos_Aires",
+                "America/Catamarca",
+                "America/Cordoba",
+                "America/Jujuy",
+                "America/Mendoza"
+            ]
+        },
+        {
+            "name": "SA Eastern Standard Time",
+            "abbr": "SEST",
+            "offset": -3,
+            "isdst": false,
+            "text": "(UTC-03:00) Cayenne, Fortaleza",
+            "utc": [
+                "America/Araguaina",
+                "America/Belem",
+                "America/Cayenne",
+                "America/Fortaleza",
+                "America/Maceio",
+                "America/Paramaribo",
+                "America/Recife",
+                "America/Santarem",
+                "Antarctica/Rothera",
+                "Atlantic/Stanley",
+                "Etc/GMT+3"
+            ]
+        },
+        {
+            "name": "Greenland Standard Time",
+            "abbr": "GDT",
+            "offset": -3,
+            "isdst": true,
+            "text": "(UTC-03:00) Greenland",
+            "utc": [
+                "America/Godthab"
+            ]
+        },
+        {
+            "name": "Montevideo Standard Time",
+            "abbr": "MST",
+            "offset": -3,
+            "isdst": false,
+            "text": "(UTC-03:00) Montevideo",
+            "utc": [
+                "America/Montevideo"
+            ]
+        },
+        {
+            "name": "Bahia Standard Time",
+            "abbr": "BST",
+            "offset": -3,
+            "isdst": false,
+            "text": "(UTC-03:00) Salvador",
+            "utc": [
+                "America/Bahia"
+            ]
+        },
+        {
+            "name": "UTC-02",
+            "abbr": "U",
+            "offset": -2,
+            "isdst": false,
+            "text": "(UTC-02:00) Coordinated Universal Time-02",
+            "utc": [
+                "America/Noronha",
+                "Atlantic/South_Georgia",
+                "Etc/GMT+2"
+            ]
+        },
+        {
+            "name": "Mid-Atlantic Standard Time",
+            "abbr": "MDT",
+            "offset": -1,
+            "isdst": true,
+            "text": "(UTC-02:00) Mid-Atlantic - Old",
+            "utc": []
+        },
+        {
+            "name": "Azores Standard Time",
+            "abbr": "ADT",
+            "offset": 0,
+            "isdst": true,
+            "text": "(UTC-01:00) Azores",
+            "utc": [
+                "America/Scoresbysund",
+                "Atlantic/Azores"
+            ]
+        },
+        {
+            "name": "Cape Verde Standard Time",
+            "abbr": "CVST",
+            "offset": -1,
+            "isdst": false,
+            "text": "(UTC-01:00) Cape Verde Is.",
+            "utc": [
+                "Atlantic/Cape_Verde",
+                "Etc/GMT+1"
+            ]
+        },
+        {
+            "name": "Morocco Standard Time",
+            "abbr": "MDT",
+            "offset": 1,
+            "isdst": true,
+            "text": "(UTC) Casablanca",
+            "utc": [
+                "Africa/Casablanca",
+                "Africa/El_Aaiun"
+            ]
+        },
+        {
+            "name": "UTC",
+            "abbr": "UTC",
+            "offset": 0,
+            "isdst": false,
+            "text": "(UTC) Coordinated Universal Time",
+            "utc": [
+                "America/Danmarkshavn",
+                "Etc/GMT"
+            ]
+        },
+        {
+            "name": "GMT Standard Time",
+            "abbr": "GMT",
+            "offset": 0,
+            "isdst": false,
+            "text": "(UTC) Edinburgh, London",
+            "utc": [
+                "Europe/Isle_of_Man",
+                "Europe/Guernsey",
+                "Europe/Jersey",
+                "Europe/London"
+            ]
+        },
+        {
+            "name": "British Summer Time",
+            "abbr": "BST",
+            "offset": 1,
+            "isdst": true,
+            "text": "(UTC+01:00) Edinburgh, London",
+            "utc": [
+                "Europe/Isle_of_Man",
+                "Europe/Guernsey",
+                "Europe/Jersey",
+                "Europe/London"
+            ]
+        },
+        {
+            "name": "GMT Standard Time",
+            "abbr": "GDT",
+            "offset": 1,
+            "isdst": true,
+            "text": "(UTC) Dublin, Lisbon",
+            "utc": [
+                "Atlantic/Canary",
+                "Atlantic/Faeroe",
+                "Atlantic/Madeira",
+                "Europe/Dublin",
+                "Europe/Lisbon"
+            ]
+        },
+        {
+            "name": "Greenwich Standard Time",
+            "abbr": "GST",
+            "offset": 0,
+            "isdst": false,
+            "text": "(UTC) Monrovia, Reykjavik",
+            "utc": [
+                "Africa/Abidjan",
+                "Africa/Accra",
+                "Africa/Bamako",
+                "Africa/Banjul",
+                "Africa/Bissau",
+                "Africa/Conakry",
+                "Africa/Dakar",
+                "Africa/Freetown",
+                "Africa/Lome",
+                "Africa/Monrovia",
+                "Africa/Nouakchott",
+                "Africa/Ouagadougou",
+                "Africa/Sao_Tome",
+                "Atlantic/Reykjavik",
+                "Atlantic/St_Helena"
+            ]
+        },
+        {
+            "name": "W. Europe Standard Time",
+            "abbr": "WEDT",
+            "offset": 2,
+            "isdst": true,
+            "text": "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna",
+            "utc": [
+                "Arctic/Longyearbyen",
+                "Europe/Amsterdam",
+                "Europe/Andorra",
+                "Europe/Berlin",
+                "Europe/Busingen",
+                "Europe/Gibraltar",
+                "Europe/Luxembourg",
+                "Europe/Malta",
+                "Europe/Monaco",
+                "Europe/Oslo",
+                "Europe/Rome",
+                "Europe/San_Marino",
+                "Europe/Stockholm",
+                "Europe/Vaduz",
+                "Europe/Vatican",
+                "Europe/Vienna",
+                "Europe/Zurich"
+            ]
+        },
+        {
+            "name": "Central Europe Standard Time",
+            "abbr": "CEDT",
+            "offset": 2,
+            "isdst": true,
+            "text": "(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague",
+            "utc": [
+                "Europe/Belgrade",
+                "Europe/Bratislava",
+                "Europe/Budapest",
+                "Europe/Ljubljana",
+                "Europe/Podgorica",
+                "Europe/Prague",
+                "Europe/Tirane"
+            ]
+        },
+        {
+            "name": "Romance Standard Time",
+            "abbr": "RDT",
+            "offset": 2,
+            "isdst": true,
+            "text": "(UTC+01:00) Brussels, Copenhagen, Madrid, Paris",
+            "utc": [
+                "Africa/Ceuta",
+                "Europe/Brussels",
+                "Europe/Copenhagen",
+                "Europe/Madrid",
+                "Europe/Paris"
+            ]
+        },
+        {
+            "name": "Central European Standard Time",
+            "abbr": "CEDT",
+            "offset": 2,
+            "isdst": true,
+            "text": "(UTC+01:00) Sarajevo, Skopje, Warsaw, Zagreb",
+            "utc": [
+                "Europe/Sarajevo",
+                "Europe/Skopje",
+                "Europe/Warsaw",
+                "Europe/Zagreb"
+            ]
+        },
+        {
+            "name": "W. Central Africa Standard Time",
+            "abbr": "WCAST",
+            "offset": 1,
+            "isdst": false,
+            "text": "(UTC+01:00) West Central Africa",
+            "utc": [
+                "Africa/Algiers",
+                "Africa/Bangui",
+                "Africa/Brazzaville",
+                "Africa/Douala",
+                "Africa/Kinshasa",
+                "Africa/Lagos",
+                "Africa/Libreville",
+                "Africa/Luanda",
+                "Africa/Malabo",
+                "Africa/Ndjamena",
+                "Africa/Niamey",
+                "Africa/Porto-Novo",
+                "Africa/Tunis",
+                "Etc/GMT-1"
+            ]
+        },
+        {
+            "name": "Namibia Standard Time",
+            "abbr": "NST",
+            "offset": 1,
+            "isdst": false,
+            "text": "(UTC+01:00) Windhoek",
+            "utc": [
+                "Africa/Windhoek"
+            ]
+        },
+        {
+            "name": "GTB Standard Time",
+            "abbr": "GDT",
+            "offset": 3,
+            "isdst": true,
+            "text": "(UTC+02:00) Athens, Bucharest",
+            "utc": [
+                "Asia/Nicosia",
+                "Europe/Athens",
+                "Europe/Bucharest",
+                "Europe/Chisinau"
+            ]
+        },
+        {
+            "name": "Middle East Standard Time",
+            "abbr": "MEDT",
+            "offset": 3,
+            "isdst": true,
+            "text": "(UTC+02:00) Beirut",
+            "utc": [
+                "Asia/Beirut"
+            ]
+        },
+        {
+            "name": "Egypt Standard Time",
+            "abbr": "EST",
+            "offset": 2,
+            "isdst": false,
+            "text": "(UTC+02:00) Cairo",
+            "utc": [
+                "Africa/Cairo"
+            ]
+        },
+        {
+            "name": "Syria Standard Time",
+            "abbr": "SDT",
+            "offset": 3,
+            "isdst": true,
+            "text": "(UTC+02:00) Damascus",
+            "utc": [
+                "Asia/Damascus"
+            ]
+        },
+        {
+            "name": "E. Europe Standard Time",
+            "abbr": "EEDT",
+            "offset": 3,
+            "isdst": true,
+            "text": "(UTC+02:00) E. Europe",
+            "utc": [
+                "Asia/Nicosia",
+                "Europe/Athens",
+                "Europe/Bucharest",
+                "Europe/Chisinau",
+                "Europe/Helsinki",
+                "Europe/Kiev",
+                "Europe/Mariehamn",
+                "Europe/Nicosia",
+                "Europe/Riga",
+                "Europe/Sofia",
+                "Europe/Tallinn",
+                "Europe/Uzhgorod",
+                "Europe/Vilnius",
+                "Europe/Zaporozhye"
+            ]
+        },
+        {
+            "name": "South Africa Standard Time",
+            "abbr": "SAST",
+            "offset": 2,
+            "isdst": false,
+            "text": "(UTC+02:00) Harare, Pretoria",
+            "utc": [
+                "Africa/Blantyre",
+                "Africa/Bujumbura",
+                "Africa/Gaborone",
+                "Africa/Harare",
+                "Africa/Johannesburg",
+                "Africa/Kigali",
+                "Africa/Lubumbashi",
+                "Africa/Lusaka",
+                "Africa/Maputo",
+                "Africa/Maseru",
+                "Africa/Mbabane",
+                "Etc/GMT-2"
+            ]
+        },
+        {
+            "name": "FLE Standard Time",
+            "abbr": "FDT",
+            "offset": 3,
+            "isdst": true,
+            "text": "(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius",
+            "utc": [
+                "Europe/Helsinki",
+                "Europe/Kiev",
+                "Europe/Mariehamn",
+                "Europe/Riga",
+                "Europe/Sofia",
+                "Europe/Tallinn",
+                "Europe/Uzhgorod",
+                "Europe/Vilnius",
+                "Europe/Zaporozhye"
+            ]
+        },
+        {
+            "name": "Turkey Standard Time",
+            "abbr": "TDT",
+            "offset": 3,
+            "isdst": false,
+            "text": "(UTC+03:00) Istanbul",
+            "utc": [
+                "Europe/Istanbul"
+            ]
+        },
+        {
+            "name": "Israel Standard Time",
+            "abbr": "JDT",
+            "offset": 3,
+            "isdst": true,
+            "text": "(UTC+02:00) Jerusalem",
+            "utc": [
+                "Asia/Jerusalem"
+            ]
+        },
+        {
+            "name": "Libya Standard Time",
+            "abbr": "LST",
+            "offset": 2,
+            "isdst": false,
+            "text": "(UTC+02:00) Tripoli",
+            "utc": [
+                "Africa/Tripoli"
+            ]
+        },
+        {
+            "name": "Jordan Standard Time",
+            "abbr": "JST",
+            "offset": 3,
+            "isdst": false,
+            "text": "(UTC+03:00) Amman",
+            "utc": [
+                "Asia/Amman"
+            ]
+        },
+        {
+            "name": "Arabic Standard Time",
+            "abbr": "AST",
+            "offset": 3,
+            "isdst": false,
+            "text": "(UTC+03:00) Baghdad",
+            "utc": [
+                "Asia/Baghdad"
+            ]
+        },
+        {
+            "name": "Kaliningrad Standard Time",
+            "abbr": "KST",
+            "offset": 3,
+            "isdst": false,
+            "text": "(UTC+02:00) Kaliningrad",
+            "utc": [
+                "Europe/Kaliningrad"
+            ]
+        },
+        {
+            "name": "Arab Standard Time",
+            "abbr": "AST",
+            "offset": 3,
+            "isdst": false,
+            "text": "(UTC+03:00) Kuwait, Riyadh",
+            "utc": [
+                "Asia/Aden",
+                "Asia/Bahrain",
+                "Asia/Kuwait",
+                "Asia/Qatar",
+                "Asia/Riyadh"
+            ]
+        },
+        {
+            "name": "E. Africa Standard Time",
+            "abbr": "EAST",
+            "offset": 3,
+            "isdst": false,
+            "text": "(UTC+03:00) Nairobi",
+            "utc": [
+                "Africa/Addis_Ababa",
+                "Africa/Asmera",
+                "Africa/Dar_es_Salaam",
+                "Africa/Djibouti",
+                "Africa/Juba",
+                "Africa/Kampala",
+                "Africa/Khartoum",
+                "Africa/Mogadishu",
+                "Africa/Nairobi",
+                "Antarctica/Syowa",
+                "Etc/GMT-3",
+                "Indian/Antananarivo",
+                "Indian/Comoro",
+                "Indian/Mayotte"
+            ]
+        },
+        {
+            "name": "Moscow Standard Time",
+            "abbr": "MSK",
+            "offset": 3,
+            "isdst": false,
+            "text": "(UTC+03:00) Moscow, St. Petersburg, Volgograd, Minsk",
+            "utc": [
+                "Europe/Kirov",
+                "Europe/Moscow",
+                "Europe/Simferopol",
+                "Europe/Volgograd",
+                "Europe/Minsk"
+            ]
+        },
+        {
+            "name": "Samara Time",
+            "abbr": "SAMT",
+            "offset": 4,
+            "isdst": false,
+            "text": "(UTC+04:00) Samara, Ulyanovsk, Saratov",
+            "utc": [
+                "Europe/Astrakhan",
+                "Europe/Samara",
+                "Europe/Ulyanovsk"
+            ]
+        },
+        {
+            "name": "Iran Standard Time",
+            "abbr": "IDT",
+            "offset": 4.5,
+            "isdst": true,
+            "text": "(UTC+03:30) Tehran",
+            "utc": [
+                "Asia/Tehran"
+            ]
+        },
+        {
+            "name": "Arabian Standard Time",
+            "abbr": "AST",
+            "offset": 4,
+            "isdst": false,
+            "text": "(UTC+04:00) Abu Dhabi, Muscat",
+            "utc": [
+                "Asia/Dubai",
+                "Asia/Muscat",
+                "Etc/GMT-4"
+            ]
+        },
+        {
+            "name": "Azerbaijan Standard Time",
+            "abbr": "ADT",
+            "offset": 5,
+            "isdst": true,
+            "text": "(UTC+04:00) Baku",
+            "utc": [
+                "Asia/Baku"
+            ]
+        },
+        {
+            "name": "Mauritius Standard Time",
+            "abbr": "MST",
+            "offset": 4,
+            "isdst": false,
+            "text": "(UTC+04:00) Port Louis",
+            "utc": [
+                "Indian/Mahe",
+                "Indian/Mauritius",
+                "Indian/Reunion"
+            ]
+        },
+        {
+            "name": "Georgian Standard Time",
+            "abbr": "GET",
+            "offset": 4,
+            "isdst": false,
+            "text": "(UTC+04:00) Tbilisi",
+            "utc": [
+                "Asia/Tbilisi"
+            ]
+        },
+        {
+            "name": "Caucasus Standard Time",
+            "abbr": "CST",
+            "offset": 4,
+            "isdst": false,
+            "text": "(UTC+04:00) Yerevan",
+            "utc": [
+                "Asia/Yerevan"
+            ]
+        },
+        {
+            "name": "Afghanistan Standard Time",
+            "abbr": "AST",
+            "offset": 4.5,
+            "isdst": false,
+            "text": "(UTC+04:30) Kabul",
+            "utc": [
+                "Asia/Kabul"
+            ]
+        },
+        {
+            "name": "West Asia Standard Time",
+            "abbr": "WAST",
+            "offset": 5,
+            "isdst": false,
+            "text": "(UTC+05:00) Ashgabat, Tashkent",
+            "utc": [
+                "Antarctica/Mawson",
+                "Asia/Aqtau",
+                "Asia/Aqtobe",
+                "Asia/Ashgabat",
+                "Asia/Dushanbe",
+                "Asia/Oral",
+                "Asia/Samarkand",
+                "Asia/Tashkent",
+                "Etc/GMT-5",
+                "Indian/Kerguelen",
+                "Indian/Maldives"
+            ]
+        },
+        {
+            "name": "Yekaterinburg Time",
+            "abbr": "YEKT",
+            "offset": 5,
+            "isdst": false,
+            "text": "(UTC+05:00) Yekaterinburg",
+            "utc": [
+                "Asia/Yekaterinburg"
+            ]
+        },
+        {
+            "name": "Pakistan Standard Time",
+            "abbr": "PKT",
+            "offset": 5,
+            "isdst": false,
+            "text": "(UTC+05:00) Islamabad, Karachi",
+            "utc": [
+                "Asia/Karachi"
+            ]
+        },
+        {
+            "name": "India Standard Time",
+            "abbr": "IST",
+            "offset": 5.5,
+            "isdst": false,
+            "text": "(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi",
+            "utc": [
+                "Asia/Kolkata"
+            ]
+        },
+        {
+            "name": "Sri Lanka Standard Time",
+            "abbr": "SLST",
+            "offset": 5.5,
+            "isdst": false,
+            "text": "(UTC+05:30) Sri Jayawardenepura",
+            "utc": [
+                "Asia/Colombo"
+            ]
+        },
+        {
+            "name": "Nepal Standard Time",
+            "abbr": "NST",
+            "offset": 5.75,
+            "isdst": false,
+            "text": "(UTC+05:45) Kathmandu",
+            "utc": [
+                "Asia/Kathmandu"
+            ]
+        },
+        {
+            "name": "Central Asia Standard Time",
+            "abbr": "CAST",
+            "offset": 6,
+            "isdst": false,
+            "text": "(UTC+06:00) Nur-Sultan (Astana)",
+            "utc": [
+                "Antarctica/Vostok",
+                "Asia/Almaty",
+                "Asia/Bishkek",
+                "Asia/Qyzylorda",
+                "Asia/Urumqi",
+                "Etc/GMT-6",
+                "Indian/Chagos"
+            ]
+        },
+        {
+            "name": "Bangladesh Standard Time",
+            "abbr": "BST",
+            "offset": 6,
+            "isdst": false,
+            "text": "(UTC+06:00) Dhaka",
+            "utc": [
+                "Asia/Dhaka",
+                "Asia/Thimphu"
+            ]
+        },
+        {
+            "name": "Myanmar Standard Time",
+            "abbr": "MST",
+            "offset": 6.5,
+            "isdst": false,
+            "text": "(UTC+06:30) Yangon (Rangoon)",
+            "utc": [
+                "Asia/Rangoon",
+                "Indian/Cocos"
+            ]
+        },
+        {
+            "name": "SE Asia Standard Time",
+            "abbr": "SAST",
+            "offset": 7,
+            "isdst": false,
+            "text": "(UTC+07:00) Bangkok, Hanoi, Jakarta",
+            "utc": [
+                "Antarctica/Davis",
+                "Asia/Bangkok",
+                "Asia/Hovd",
+                "Asia/Jakarta",
+                "Asia/Phnom_Penh",
+                "Asia/Pontianak",
+                "Asia/Saigon",
+                "Asia/Vientiane",
+                "Etc/GMT-7",
+                "Indian/Christmas"
+            ]
+        },
+        {
+            "name": "N. Central Asia Standard Time",
+            "abbr": "NCAST",
+            "offset": 7,
+            "isdst": false,
+            "text": "(UTC+07:00) Novosibirsk",
+            "utc": [
+                "Asia/Novokuznetsk",
+                "Asia/Novosibirsk",
+                "Asia/Omsk"
+            ]
+        },
+        {
+            "name": "China Standard Time",
+            "abbr": "CST",
+            "offset": 8,
+            "isdst": false,
+            "text": "(UTC+08:00) Beijing, Chongqing, Hong Kong, Urumqi",
+            "utc": [
+                "Asia/Hong_Kong",
+                "Asia/Macau",
+                "Asia/Shanghai"
+            ]
+        },
+        {
+            "name": "North Asia Standard Time",
+            "abbr": "NAST",
+            "offset": 8,
+            "isdst": false,
+            "text": "(UTC+08:00) Krasnoyarsk",
+            "utc": [
+                "Asia/Krasnoyarsk"
+            ]
+        },
+        {
+            "name": "Singapore Standard Time",
+            "abbr": "MPST",
+            "offset": 8,
+            "isdst": false,
+            "text": "(UTC+08:00) Kuala Lumpur, Singapore",
+            "utc": [
+                "Asia/Brunei",
+                "Asia/Kuala_Lumpur",
+                "Asia/Kuching",
+                "Asia/Makassar",
+                "Asia/Manila",
+                "Asia/Singapore",
+                "Etc/GMT-8"
+            ]
+        },
+        {
+            "name": "W. Australia Standard Time",
+            "abbr": "WAST",
+            "offset": 8,
+            "isdst": false,
+            "text": "(UTC+08:00) Perth",
+            "utc": [
+                "Antarctica/Casey",
+                "Australia/Perth"
+            ]
+        },
+        {
+            "name": "Taipei Standard Time",
+            "abbr": "TST",
+            "offset": 8,
+            "isdst": false,
+            "text": "(UTC+08:00) Taipei",
+            "utc": [
+                "Asia/Taipei"
+            ]
+        },
+        {
+            "name": "Ulaanbaatar Standard Time",
+            "abbr": "UST",
+            "offset": 8,
+            "isdst": false,
+            "text": "(UTC+08:00) Ulaanbaatar",
+            "utc": [
+                "Asia/Choibalsan",
+                "Asia/Ulaanbaatar"
+            ]
+        },
+        {
+            "name": "North Asia East Standard Time",
+            "abbr": "NAEST",
+            "offset": 8,
+            "isdst": false,
+            "text": "(UTC+08:00) Irkutsk",
+            "utc": [
+                "Asia/Irkutsk"
+            ]
+        },
+        {
+            "name": "Japan Standard Time",
+            "abbr": "JST",
+            "offset": 9,
+            "isdst": false,
+            "text": "(UTC+09:00) Osaka, Sapporo, Tokyo",
+            "utc": [
+                "Asia/Dili",
+                "Asia/Jayapura",
+                "Asia/Tokyo",
+                "Etc/GMT-9",
+                "Pacific/Palau"
+            ]
+        },
+        {
+            "name": "Korea Standard Time",
+            "abbr": "KST",
+            "offset": 9,
+            "isdst": false,
+            "text": "(UTC+09:00) Seoul",
+            "utc": [
+                "Asia/Pyongyang",
+                "Asia/Seoul"
+            ]
+        },
+        {
+            "name": "Cen. Australia Standard Time",
+            "abbr": "CAST",
+            "offset": 9.5,
+            "isdst": false,
+            "text": "(UTC+09:30) Adelaide",
+            "utc": [
+                "Australia/Adelaide",
+                "Australia/Broken_Hill"
+            ]
+        },
+        {
+            "name": "AUS Central Standard Time",
+            "abbr": "ACST",
+            "offset": 9.5,
+            "isdst": false,
+            "text": "(UTC+09:30) Darwin",
+            "utc": [
+                "Australia/Darwin"
+            ]
+        },
+        {
+            "name": "E. Australia Standard Time",
+            "abbr": "EAST",
+            "offset": 10,
+            "isdst": false,
+            "text": "(UTC+10:00) Brisbane",
+            "utc": [
+                "Australia/Brisbane",
+                "Australia/Lindeman"
+            ]
+        },
+        {
+            "name": "AUS Eastern Standard Time",
+            "abbr": "AEST",
+            "offset": 10,
+            "isdst": false,
+            "text": "(UTC+10:00) Canberra, Melbourne, Sydney",
+            "utc": [
+                "Australia/Melbourne",
+                "Australia/Sydney"
+            ]
+        },
+        {
+            "name": "West Pacific Standard Time",
+            "abbr": "WPST",
+            "offset": 10,
+            "isdst": false,
+            "text": "(UTC+10:00) Guam, Port Moresby",
+            "utc": [
+                "Antarctica/DumontDUrville",
+                "Etc/GMT-10",
+                "Pacific/Guam",
+                "Pacific/Port_Moresby",
+                "Pacific/Saipan",
+                "Pacific/Truk"
+            ]
+        },
+        {
+            "name": "Tasmania Standard Time",
+            "abbr": "TST",
+            "offset": 10,
+            "isdst": false,
+            "text": "(UTC+10:00) Hobart",
+            "utc": [
+                "Australia/Currie",
+                "Australia/Hobart"
+            ]
+        },
+        {
+            "name": "Yakutsk Standard Time",
+            "abbr": "YST",
+            "offset": 9,
+            "isdst": false,
+            "text": "(UTC+09:00) Yakutsk",
+            "utc": [
+                "Asia/Chita",
+                "Asia/Khandyga",
+                "Asia/Yakutsk"
+            ]
+        },
+        {
+            "name": "Central Pacific Standard Time",
+            "abbr": "CPST",
+            "offset": 11,
+            "isdst": false,
+            "text": "(UTC+11:00) Solomon Is., New Caledonia",
+            "utc": [
+                "Antarctica/Macquarie",
+                "Etc/GMT-11",
+                "Pacific/Efate",
+                "Pacific/Guadalcanal",
+                "Pacific/Kosrae",
+                "Pacific/Noumea",
+                "Pacific/Ponape"
+            ]
+        },
+        {
+            "name": "Vladivostok Standard Time",
+            "abbr": "VST",
+            "offset": 11,
+            "isdst": false,
+            "text": "(UTC+11:00) Vladivostok",
+            "utc": [
+                "Asia/Sakhalin",
+                "Asia/Ust-Nera",
+                "Asia/Vladivostok"
+            ]
+        },
+        {
+            "name": "New Zealand Standard Time",
+            "abbr": "NZST",
+            "offset": 12,
+            "isdst": false,
+            "text": "(UTC+12:00) Auckland, Wellington",
+            "utc": [
+                "Antarctica/McMurdo",
+                "Pacific/Auckland"
+            ]
+        },
+        {
+            "name": "UTC+12",
+            "abbr": "U",
+            "offset": 12,
+            "isdst": false,
+            "text": "(UTC+12:00) Coordinated Universal Time+12",
+            "utc": [
+                "Etc/GMT-12",
+                "Pacific/Funafuti",
+                "Pacific/Kwajalein",
+                "Pacific/Majuro",
+                "Pacific/Nauru",
+                "Pacific/Tarawa",
+                "Pacific/Wake",
+                "Pacific/Wallis"
+            ]
+        },
+        {
+            "name": "Fiji Standard Time",
+            "abbr": "FST",
+            "offset": 12,
+            "isdst": false,
+            "text": "(UTC+12:00) Fiji",
+            "utc": [
+                "Pacific/Fiji"
+            ]
+        },
+        {
+            "name": "Magadan Standard Time",
+            "abbr": "MST",
+            "offset": 12,
+            "isdst": false,
+            "text": "(UTC+12:00) Magadan",
+            "utc": [
+                "Asia/Anadyr",
+                "Asia/Kamchatka",
+                "Asia/Magadan",
+                "Asia/Srednekolymsk"
+            ]
+        },
+        {
+            "name": "Kamchatka Standard Time",
+            "abbr": "KDT",
+            "offset": 13,
+            "isdst": true,
+            "text": "(UTC+12:00) Petropavlovsk-Kamchatsky - Old",
+            "utc": [
+                "Asia/Kamchatka"
+            ]
+        },
+        {
+            "name": "Tonga Standard Time",
+            "abbr": "TST",
+            "offset": 13,
+            "isdst": false,
+            "text": "(UTC+13:00) Nuku'alofa",
+            "utc": [
+                "Etc/GMT-13",
+                "Pacific/Enderbury",
+                "Pacific/Fakaofo",
+                "Pacific/Tongatapu"
+            ]
+        },
+        {
+            "name": "Samoa Standard Time",
+            "abbr": "SST",
+            "offset": 13,
+            "isdst": false,
+            "text": "(UTC+13:00) Samoa",
+            "utc": [
+                "Pacific/Apia"
+            ]
+        },
+        ],
+
         //List source: http://answers.google.com/answers/threadview/id/589312.html
         profession: [
             "Airline Pilot",
@@ -7231,25 +7088,25 @@ options,
             "Veterinarian",
             "Vendor Relations Director",
             "Viticulturist",
-            "Warehouse Manager"
+            "Warehouse Manager",
         ],
-        animals : {
-          //list of ocean animals comes from https://owlcation.com/stem/list-of-ocean-animals
-          "ocean" : ["Acantharea","Anemone","Angelfish King","Ahi Tuna","Albacore","American Oyster","Anchovy","Armored Snail","Arctic Char","Atlantic Bluefin Tuna","Atlantic Cod","Atlantic Goliath Grouper","Atlantic Trumpetfish","Atlantic Wolffish","Baleen Whale","Banded Butterflyfish","Banded Coral Shrimp","Banded Sea Krait","Barnacle","Barndoor Skate","Barracuda","Basking Shark","Bass","Beluga Whale","Bluebanded Goby","Bluehead Wrasse","Bluefish","Bluestreak Cleaner-Wrasse","Blue Marlin","Blue Shark","Blue Spiny Lobster","Blue Tang","Blue Whale","Broadclub Cuttlefish","Bull Shark","Chambered Nautilus","Chilean Basket Star","Chilean Jack Mackerel","Chinook Salmon","Christmas Tree Worm","Clam","Clown Anemonefish","Clown Triggerfish","Cod","Coelacanth","Cockscomb Cup Coral","Common Fangtooth","Conch","Cookiecutter Shark","Copepod","Coral","Corydoras","Cownose Ray","Crab","Crown-of-Thorns Starfish","Cushion Star","Cuttlefish","California Sea Otters","Dolphin","Dolphinfish","Dory","Devil Fish","Dugong","Dumbo Octopus","Dungeness Crab","Eccentric Sand Dollar","Edible Sea Cucumber","Eel","Elephant Seal","Elkhorn Coral","Emperor Shrimp","Estuarine Crocodile","Fathead Sculpin","Fiddler Crab","Fin Whale","Flameback","Flamingo Tongue Snail","Flashlight Fish","Flatback Turtle","Flatfish","Flying Fish","Flounder","Fluke","French Angelfish","Frilled Shark","Fugu (also called Pufferfish)","Gar","Geoduck","Giant Barrel Sponge","Giant Caribbean Sea Anemone","Giant Clam","Giant Isopod","Giant Kingfish","Giant Oarfish","Giant Pacific Octopus","Giant Pyrosome","Giant Sea Star","Giant Squid","Glowing Sucker Octopus","Giant Tube Worm","Goblin Shark","Goosefish","Great White Shark","Greenland Shark","Grey Atlantic Seal","Grouper","Grunion","Guineafowl Puffer","Haddock","Hake","Halibut","Hammerhead Shark","Hapuka","Harbor Porpoise","Harbor Seal","Hatchetfish","Hawaiian Monk Seal","Hawksbill Turtle","Hector's Dolphin","Hermit Crab","Herring","Hoki","Horn Shark","Horseshoe Crab","Humpback Anglerfish","Humpback Whale","Icefish","Imperator Angelfish","Irukandji Jellyfish","Isopod","Ivory Bush Coral","Japanese Spider Crab","Jellyfish","John Dory","Juan Fernandez Fur Seal","Killer Whale","Kiwa Hirsuta","Krill","Lagoon Triggerfish","Lamprey","Leafy Seadragon","Leopard Seal","Limpet","Ling","Lionfish","Lions Mane Jellyfish","Lobe Coral","Lobster","Loggerhead Turtle","Longnose Sawshark","Longsnout Seahorse","Lophelia Coral","Marrus Orthocanna","Manatee","Manta Ray","Marlin","Megamouth Shark","Mexican Lookdown","Mimic Octopus","Moon Jelly","Mollusk","Monkfish","Moray Eel","Mullet","Mussel","Megaladon","Napoleon Wrasse","Nassau Grouper","Narwhal","Nautilus","Needlefish","Northern Seahorse","North Atlantic Right Whale","Northern Red Snapper","Norway Lobster","Nudibranch","Nurse Shark","Oarfish","Ocean Sunfish","Oceanic Whitetip Shark","Octopus","Olive Sea Snake","Orange Roughy","Ostracod","Otter","Oyster","Pacific Angelshark","Pacific Blackdragon","Pacific Halibut","Pacific Sardine","Pacific Sea Nettle Jellyfish","Pacific White Sided Dolphin","Pantropical Spotted Dolphin","Patagonian Toothfish","Peacock Mantis Shrimp","Pelagic Thresher Shark","Penguin","Peruvian Anchoveta","Pilchard","Pink Salmon","Pinniped","Plankton","Porpoise","Polar Bear","Portuguese Man o' War","Pycnogonid Sea Spider","Quahog","Queen Angelfish","Queen Conch","Queen Parrotfish","Queensland Grouper","Ragfish","Ratfish","Rattail Fish","Ray","Red Drum","Red King Crab","Ringed Seal","Risso's Dolphin","Ross Seals","Sablefish","Salmon","Sand Dollar","Sandbar Shark","Sawfish","Sarcastic Fringehead","Scalloped Hammerhead Shark","Seahorse","Sea Cucumber","Sea Lion","Sea Urchin","Seal","Shark","Shortfin Mako Shark","Shovelnose Guitarfish","Shrimp","Silverside Fish","Skipjack Tuna","Slender Snipe Eel","Smalltooth Sawfish","Smelts","Sockeye Salmon","Southern Stingray","Sponge","Spotted Porcupinefish","Spotted Dolphin","Spotted Eagle Ray","Spotted Moray","Squid","Squidworm","Starfish","Stickleback","Stonefish","Stoplight Loosejaw","Sturgeon","Swordfish","Tan Bristlemouth","Tasseled Wobbegong","Terrible Claw Lobster","Threespot Damselfish","Tiger Prawn","Tiger Shark","Tilefish","Toadfish","Tropical Two-Wing Flyfish","Tuna","Umbrella Squid","Velvet Crab","Venus Flytrap Sea Anemone","Vigtorniella Worm","Viperfish","Vampire Squid","Vaquita","Wahoo","Walrus","West Indian Manatee","Whale","Whale Shark","Whiptail Gulper","White-Beaked Dolphin","White-Ring Garden Eel","White Shrimp","Wobbegong","Wrasse","Wreckfish","Xiphosura","Yellowtail Damselfish","Yelloweye Rockfish","Yellow Cup Black Coral","Yellow Tube Sponge","Yellowfin Tuna","Zebrashark","Zooplankton"],
-          //list of desert, grassland, and forest animals comes from http://www.skyenimals.com/
-          "desert" : ["Aardwolf","Addax","African Wild Ass","Ant","Antelope","Armadillo","Baboon","Badger","Bat","Bearded Dragon","Beetle","Bird","Black-footed Cat","Boa","Brown Bear","Bustard","Butterfly","Camel","Caracal","Caracara","Caterpillar","Centipede","Cheetah","Chipmunk","Chuckwalla","Climbing Mouse","Coati","Cobra","Cotton Rat","Cougar","Courser","Crane Fly","Crow","Dassie Rat","Dove","Dunnart","Eagle","Echidna","Elephant","Emu","Falcon","Fly","Fox","Frogmouth","Gecko","Geoffroy's Cat","Gerbil","Grasshopper","Guanaco","Gundi","Hamster","Hawk","Hedgehog","Hyena","Hyrax","Jackal","Kangaroo","Kangaroo Rat","Kestrel","Kowari","Kultarr","Leopard","Lion","Macaw","Meerkat","Mouse","Oryx","Ostrich","Owl","Pronghorn","Python","Rabbit","Raccoon","Rattlesnake","Rhinoceros","Sand Cat","Spectacled Bear","Spiny Mouse","Starling","Stick Bug","Tarantula","Tit","Toad","Tortoise","Tyrant Flycatcher","Viper","Vulture","Waxwing","Xerus","Zebra"],
-          "grassland" : ["Aardvark","Aardwolf","Accentor","African Buffalo","African Wild Dog","Alpaca","Anaconda","Ant","Anteater","Antelope","Armadillo","Baboon","Badger","Bandicoot","Barbet","Bat","Bee","Bee-eater","Beetle","Bird","Bison","Black-footed Cat","Black-footed Ferret","Bluebird","Boa","Bowerbird","Brown Bear","Bush Dog","Bushshrike","Bustard","Butterfly","Buzzard","Caracal","Caracara","Cardinal","Caterpillar","Cheetah","Chipmunk","Civet","Climbing Mouse","Clouded Leopard","Coati","Cobra","Cockatoo","Cockroach","Common Genet","Cotton Rat","Cougar","Courser","Coyote","Crane","Crane Fly","Cricket","Crow","Culpeo","Death Adder","Deer","Deer Mouse","Dingo","Dinosaur","Dove","Drongo","Duck","Duiker","Dunnart","Eagle","Echidna","Elephant","Elk","Emu","Falcon","Finch","Flea","Fly","Flying Frog","Fox","Frog","Frogmouth","Garter Snake","Gazelle","Gecko","Geoffroy's Cat","Gerbil","Giant Tortoise","Giraffe","Grasshopper","Grison","Groundhog","Grouse","Guanaco","Guinea Pig","Hamster","Harrier","Hartebeest","Hawk","Hedgehog","Helmetshrike","Hippopotamus","Hornbill","Hyena","Hyrax","Impala","Jackal","Jaguar","Jaguarundi","Kangaroo","Kangaroo Rat","Kestrel","Kultarr","Ladybug","Leopard","Lion","Macaw","Meerkat","Mouse","Newt","Oryx","Ostrich","Owl","Pangolin","Pheasant","Prairie Dog","Pronghorn","Przewalski's Horse","Python","Quoll","Rabbit","Raven","Rhinoceros","Shelduck","Sloth Bear","Spectacled Bear","Squirrel","Starling","Stick Bug","Tamandua","Tasmanian Devil","Thornbill","Thrush","Toad","Tortoise"],
-          "forest" : ["Agouti","Anaconda","Anoa","Ant","Anteater","Antelope","Armadillo","Asian Black Bear","Aye-aye","Babirusa","Baboon","Badger","Bandicoot","Banteng","Barbet","Basilisk","Bat","Bearded Dragon","Bee","Bee-eater","Beetle","Bettong","Binturong","Bird-of-paradise","Bongo","Bowerbird","Bulbul","Bush Dog","Bushbaby","Bushshrike","Butterfly","Buzzard","Caecilian","Cardinal","Cassowary","Caterpillar","Centipede","Chameleon","Chimpanzee","Cicada","Civet","Clouded Leopard","Coati","Cobra","Cockatoo","Cockroach","Colugo","Cotinga","Cotton Rat","Cougar","Crane Fly","Cricket","Crocodile","Crow","Cuckoo","Cuscus","Death Adder","Deer","Dhole","Dingo","Dinosaur","Drongo","Duck","Duiker","Eagle","Echidna","Elephant","Finch","Flat-headed Cat","Flea","Flowerpecker","Fly","Flying Frog","Fossa","Frog","Frogmouth","Gaur","Gecko","Gorilla","Grison","Hawaiian Honeycreeper","Hawk","Hedgehog","Helmetshrike","Hornbill","Hyrax","Iguana","Jackal","Jaguar","Jaguarundi","Kestrel","Ladybug","Lemur","Leopard","Lion","Macaw","Mandrill","Margay","Monkey","Mouse","Mouse Deer","Newt","Okapi","Old World Flycatcher","Orangutan","Owl","Pangolin","Peafowl","Pheasant","Possum","Python","Quokka","Rabbit","Raccoon","Red Panda","Red River Hog","Rhinoceros","Sloth Bear","Spectacled Bear","Squirrel","Starling","Stick Bug","Sun Bear","Tamandua","Tamarin","Tapir","Tarantula","Thrush","Tiger","Tit","Toad","Tortoise","Toucan","Trogon","Trumpeter","Turaco","Turtle","Tyrant Flycatcher","Viper","Vulture","Wallaby","Warbler","Wasp","Waxwing","Weaver","Weaver-finch","Whistler","White-eye","Whydah","Woodswallow","Worm","Wren","Xenops","Yellowjacket","Accentor","African Buffalo","American Black Bear","Anole","Bird","Bison","Boa","Brown Bear","Chipmunk","Common Genet","Copperhead","Coyote","Deer Mouse","Dormouse","Elk","Emu","Fisher","Fox","Garter Snake","Giant Panda","Giant Tortoise","Groundhog","Grouse","Guanaco","Himalayan Tahr","Kangaroo","Koala","Numbat","Quoll","Raccoon dog","Tasmanian Devil","Thornbill","Turkey","Vole","Weasel","Wildcat","Wolf","Wombat","Woodchuck","Woodpecker"],
-          //list of farm animals comes from https://www.buzzle.com/articles/farm-animals-list.html
-          "farm" : ["Alpaca","Buffalo","Banteng","Cow","Cat","Chicken","Carp","Camel","Donkey","Dog","Duck","Emu","Goat","Gayal","Guinea","Goose","Horse","Honey","Llama","Pig","Pigeon","Rhea","Rabbit","Sheep","Silkworm","Turkey","Yak","Zebu"],
-          //list of pet animals comes from https://www.dogbreedinfo.com/pets/pet.htm
-          "pet" : ["Bearded Dragon","Birds","Burro","Cats","Chameleons","Chickens","Chinchillas","Chinese Water Dragon","Cows","Dogs","Donkey","Ducks","Ferrets","Fish","Geckos","Geese","Gerbils","Goats","Guinea Fowl","Guinea Pigs","Hamsters","Hedgehogs","Horses","Iguanas","Llamas","Lizards","Mice","Mule","Peafowl","Pigs and Hogs","Pigeons","Ponies","Pot Bellied Pig","Rabbits","Rats","Sheep","Skinks","Snakes","Stick Insects","Sugar Gliders","Tarantula","Turkeys","Turtles"],
-          //list of zoo animals comes from https://bronxzoo.com/animals
-          "zoo" : ["Aardvark","African Wild Dog","Aldabra Tortoise","American Alligator","American Bison","Amur Tiger","Anaconda","Andean Condor","Asian Elephant","Baby Doll Sheep","Bald Eagle","Barred Owl","Blue Iguana","Boer Goat","California Sea Lion","Caribbean Flamingo","Chinchilla","Collared Lemur","Coquerel's Sifaka","Cuban Amazon Parrot","Ebony Langur","Fennec Fox","Fossa","Gelada","Giant Anteater","Giraffe","Gorilla","Grizzly Bear","Henkel's Leaf-tailed Gecko","Indian Gharial","Indian Rhinoceros","King Cobra","King Vulture","Komodo Dragon","Linne's Two-toed Sloth","Lion","Little Penguin","Madagascar Tree Boa","Magellanic Penguin","Malayan Tapir","Malayan Tiger","Matschies Tree Kangaroo","Mini Donkey","Monarch Butterfly","Nile crocodile","North American Porcupine","Nubian Ibex","Okapi","Poison Dart Frog","Polar Bear","Pygmy Marmoset","Radiated Tortoise","Red Panda","Red Ruffed Lemur","Ring-tailed Lemur","Ring-tailed Mongoose","Rock Hyrax","Small Clawed Asian Otter","Snow Leopard","Snowy Owl","Southern White-faced Owl","Southern White Rhinocerous","Squirrel Monkey","Tufted Puffin","White Cheeked Gibbon","White-throated Bee Eater","Zebra"]
+        animals: {
+            // list of ocean animals comes from https://owlcation.com/stem/list-of-ocean-animals
+            ocean: ["Acantharea","Anemone","Angelfish King","Ahi Tuna","Albacore","American Oyster","Anchovy","Armored Snail","Arctic Char","Atlantic Bluefin Tuna","Atlantic Cod","Atlantic Goliath Grouper","Atlantic Trumpetfish","Atlantic Wolffish","Baleen Whale","Banded Butterflyfish","Banded Coral Shrimp","Banded Sea Krait","Barnacle","Barndoor Skate","Barracuda","Basking Shark","Bass","Beluga Whale","Bluebanded Goby","Bluehead Wrasse","Bluefish","Bluestreak Cleaner-Wrasse","Blue Marlin","Blue Shark","Blue Spiny Lobster","Blue Tang","Blue Whale","Broadclub Cuttlefish","Bull Shark","Chambered Nautilus","Chilean Basket Star","Chilean Jack Mackerel","Chinook Salmon","Christmas Tree Worm","Clam","Clown Anemonefish","Clown Triggerfish","Cod","Coelacanth","Cockscomb Cup Coral","Common Fangtooth","Conch","Cookiecutter Shark","Copepod","Coral","Corydoras","Cownose Ray","Crab","Crown-of-Thorns Starfish","Cushion Star","Cuttlefish","California Sea Otters","Dolphin","Dolphinfish","Dory","Devil Fish","Dugong","Dumbo Octopus","Dungeness Crab","Eccentric Sand Dollar","Edible Sea Cucumber","Eel","Elephant Seal","Elkhorn Coral","Emperor Shrimp","Estuarine Crocodile","Fathead Sculpin","Fiddler Crab","Fin Whale","Flameback","Flamingo Tongue Snail","Flashlight Fish","Flatback Turtle","Flatfish","Flying Fish","Flounder","Fluke","French Angelfish","Frilled Shark","Fugu (also called Pufferfish)","Gar","Geoduck","Giant Barrel Sponge","Giant Caribbean Sea Anemone","Giant Clam","Giant Isopod","Giant Kingfish","Giant Oarfish","Giant Pacific Octopus","Giant Pyrosome","Giant Sea Star","Giant Squid","Glowing Sucker Octopus","Giant Tube Worm","Goblin Shark","Goosefish","Great White Shark","Greenland Shark","Grey Atlantic Seal","Grouper","Grunion","Guineafowl Puffer","Haddock","Hake","Halibut","Hammerhead Shark","Hapuka","Harbor Porpoise","Harbor Seal","Hatchetfish","Hawaiian Monk Seal","Hawksbill Turtle","Hector's Dolphin","Hermit Crab","Herring","Hoki","Horn Shark","Horseshoe Crab","Humpback Anglerfish","Humpback Whale","Icefish","Imperator Angelfish","Irukandji Jellyfish","Isopod","Ivory Bush Coral","Japanese Spider Crab","Jellyfish","John Dory","Juan Fernandez Fur Seal","Killer Whale","Kiwa Hirsuta","Krill","Lagoon Triggerfish","Lamprey","Leafy Seadragon","Leopard Seal","Limpet","Ling","Lionfish","Lions Mane Jellyfish","Lobe Coral","Lobster","Loggerhead Turtle","Longnose Sawshark","Longsnout Seahorse","Lophelia Coral","Marrus Orthocanna","Manatee","Manta Ray","Marlin","Megamouth Shark","Mexican Lookdown","Mimic Octopus","Moon Jelly","Mollusk","Monkfish","Moray Eel","Mullet","Mussel","Megaladon","Napoleon Wrasse","Nassau Grouper","Narwhal","Nautilus","Needlefish","Northern Seahorse","North Atlantic Right Whale","Northern Red Snapper","Norway Lobster","Nudibranch","Nurse Shark","Oarfish","Ocean Sunfish","Oceanic Whitetip Shark","Octopus","Olive Sea Snake","Orange Roughy","Ostracod","Otter","Oyster","Pacific Angelshark","Pacific Blackdragon","Pacific Halibut","Pacific Sardine","Pacific Sea Nettle Jellyfish","Pacific White Sided Dolphin","Pantropical Spotted Dolphin","Patagonian Toothfish","Peacock Mantis Shrimp","Pelagic Thresher Shark","Penguin","Peruvian Anchoveta","Pilchard","Pink Salmon","Pinniped","Plankton","Porpoise","Polar Bear","Portuguese Man o' War","Pycnogonid Sea Spider","Quahog","Queen Angelfish","Queen Conch","Queen Parrotfish","Queensland Grouper","Ragfish","Ratfish","Rattail Fish","Ray","Red Drum","Red King Crab","Ringed Seal","Risso's Dolphin","Ross Seals","Sablefish","Salmon","Sand Dollar","Sandbar Shark","Sawfish","Sarcastic Fringehead","Scalloped Hammerhead Shark","Seahorse","Sea Cucumber","Sea Lion","Sea Urchin","Seal","Shark","Shortfin Mako Shark","Shovelnose Guitarfish","Shrimp","Silverside Fish","Skipjack Tuna","Slender Snipe Eel","Smalltooth Sawfish","Smelts","Sockeye Salmon","Southern Stingray","Sponge","Spotted Porcupinefish","Spotted Dolphin","Spotted Eagle Ray","Spotted Moray","Squid","Squidworm","Starfish","Stickleback","Stonefish","Stoplight Loosejaw","Sturgeon","Swordfish","Tan Bristlemouth","Tasseled Wobbegong","Terrible Claw Lobster","Threespot Damselfish","Tiger Prawn","Tiger Shark","Tilefish","Toadfish","Tropical Two-Wing Flyfish","Tuna","Umbrella Squid","Velvet Crab","Venus Flytrap Sea Anemone","Vigtorniella Worm","Viperfish","Vampire Squid","Vaquita","Wahoo","Walrus","West Indian Manatee","Whale","Whale Shark","Whiptail Gulper","White-Beaked Dolphin","White-Ring Garden Eel","White Shrimp","Wobbegong","Wrasse","Wreckfish","Xiphosura","Yellowtail Damselfish","Yelloweye Rockfish","Yellow Cup Black Coral","Yellow Tube Sponge","Yellowfin Tuna","Zebrashark","Zooplankton"],
+            // list of desert, grassland, and forest animals comes from http://www.skyenimals.com/
+            desert: ["Aardwolf","Addax","African Wild Ass","Ant","Antelope","Armadillo","Baboon","Badger","Bat","Bearded Dragon","Beetle","Bird","Black-footed Cat","Boa","Brown Bear","Bustard","Butterfly","Camel","Caracal","Caracara","Caterpillar","Centipede","Cheetah","Chipmunk","Chuckwalla","Climbing Mouse","Coati","Cobra","Cotton Rat","Cougar","Courser","Crane Fly","Crow","Dassie Rat","Dove","Dunnart","Eagle","Echidna","Elephant","Emu","Falcon","Fly","Fox","Frogmouth","Gecko","Geoffroy's Cat","Gerbil","Grasshopper","Guanaco","Gundi","Hamster","Hawk","Hedgehog","Hyena","Hyrax","Jackal","Kangaroo","Kangaroo Rat","Kestrel","Kowari","Kultarr","Leopard","Lion","Macaw","Meerkat","Mouse","Oryx","Ostrich","Owl","Pronghorn","Python","Rabbit","Raccoon","Rattlesnake","Rhinoceros","Sand Cat","Spectacled Bear","Spiny Mouse","Starling","Stick Bug","Tarantula","Tit","Toad","Tortoise","Tyrant Flycatcher","Viper","Vulture","Waxwing","Xerus","Zebra"],
+            "grassland": ["Aardvark","Aardwolf","Accentor","African Buffalo","African Wild Dog","Alpaca","Anaconda","Ant","Anteater","Antelope","Armadillo","Baboon","Badger","Bandicoot","Barbet","Bat","Bee","Bee-eater","Beetle","Bird","Bison","Black-footed Cat","Black-footed Ferret","Bluebird","Boa","Bowerbird","Brown Bear","Bush Dog","Bushshrike","Bustard","Butterfly","Buzzard","Caracal","Caracara","Cardinal","Caterpillar","Cheetah","Chipmunk","Civet","Climbing Mouse","Clouded Leopard","Coati","Cobra","Cockatoo","Cockroach","Common Genet","Cotton Rat","Cougar","Courser","Coyote","Crane","Crane Fly","Cricket","Crow","Culpeo","Death Adder","Deer","Deer Mouse","Dingo","Dinosaur","Dove","Drongo","Duck","Duiker","Dunnart","Eagle","Echidna","Elephant","Elk","Emu","Falcon","Finch","Flea","Fly","Flying Frog","Fox","Frog","Frogmouth","Garter Snake","Gazelle","Gecko","Geoffroy's Cat","Gerbil","Giant Tortoise","Giraffe","Grasshopper","Grison","Groundhog","Grouse","Guanaco","Guinea Pig","Hamster","Harrier","Hartebeest","Hawk","Hedgehog","Helmetshrike","Hippopotamus","Hornbill","Hyena","Hyrax","Impala","Jackal","Jaguar","Jaguarundi","Kangaroo","Kangaroo Rat","Kestrel","Kultarr","Ladybug","Leopard","Lion","Macaw","Meerkat","Mouse","Newt","Oryx","Ostrich","Owl","Pangolin","Pheasant","Prairie Dog","Pronghorn","Przewalski's Horse","Python","Quoll","Rabbit","Raven","Rhinoceros","Shelduck","Sloth Bear","Spectacled Bear","Squirrel","Starling","Stick Bug","Tamandua","Tasmanian Devil","Thornbill","Thrush","Toad","Tortoise"],
+            "forest": ["Agouti","Anaconda","Anoa","Ant","Anteater","Antelope","Armadillo","Asian Black Bear","Aye-aye","Babirusa","Baboon","Badger","Bandicoot","Banteng","Barbet","Basilisk","Bat","Bearded Dragon","Bee","Bee-eater","Beetle","Bettong","Binturong","Bird-of-paradise","Bongo","Bowerbird","Bulbul","Bush Dog","Bushbaby","Bushshrike","Butterfly","Buzzard","Caecilian","Cardinal","Cassowary","Caterpillar","Centipede","Chameleon","Chimpanzee","Cicada","Civet","Clouded Leopard","Coati","Cobra","Cockatoo","Cockroach","Colugo","Cotinga","Cotton Rat","Cougar","Crane Fly","Cricket","Crocodile","Crow","Cuckoo","Cuscus","Death Adder","Deer","Dhole","Dingo","Dinosaur","Drongo","Duck","Duiker","Eagle","Echidna","Elephant","Finch","Flat-headed Cat","Flea","Flowerpecker","Fly","Flying Frog","Fossa","Frog","Frogmouth","Gaur","Gecko","Gorilla","Grison","Hawaiian Honeycreeper","Hawk","Hedgehog","Helmetshrike","Hornbill","Hyrax","Iguana","Jackal","Jaguar","Jaguarundi","Kestrel","Ladybug","Lemur","Leopard","Lion","Macaw","Mandrill","Margay","Monkey","Mouse","Mouse Deer","Newt","Okapi","Old World Flycatcher","Orangutan","Owl","Pangolin","Peafowl","Pheasant","Possum","Python","Quokka","Rabbit","Raccoon","Red Panda","Red River Hog","Rhinoceros","Sloth Bear","Spectacled Bear","Squirrel","Starling","Stick Bug","Sun Bear","Tamandua","Tamarin","Tapir","Tarantula","Thrush","Tiger","Tit","Toad","Tortoise","Toucan","Trogon","Trumpeter","Turaco","Turtle","Tyrant Flycatcher","Viper","Vulture","Wallaby","Warbler","Wasp","Waxwing","Weaver","Weaver-finch","Whistler","White-eye","Whydah","Woodswallow","Worm","Wren","Xenops","Yellowjacket","Accentor","African Buffalo","American Black Bear","Anole","Bird","Bison","Boa","Brown Bear","Chipmunk","Common Genet","Copperhead","Coyote","Deer Mouse","Dormouse","Elk","Emu","Fisher","Fox","Garter Snake","Giant Panda","Giant Tortoise","Groundhog","Grouse","Guanaco","Himalayan Tahr","Kangaroo","Koala","Numbat","Quoll","Raccoon dog","Tasmanian Devil","Thornbill","Turkey","Vole","Weasel","Wildcat","Wolf","Wombat","Woodchuck","Woodpecker"],
+            // list of farm animals comes from https://www.buzzle.com/articles/farm-animals-list.html
+            farm: ["Alpaca","Buffalo","Banteng","Cow","Cat","Chicken","Carp","Camel","Donkey","Dog","Duck","Emu","Goat","Gayal","Guinea","Goose","Horse","Honey","Llama","Pig","Pigeon","Rhea","Rabbit","Sheep","Silkworm","Turkey","Yak","Zebu"],
+            // list of pet animals comes from https://www.dogbreedinfo.com/pets/pet.htm
+            pet: ["Bearded Dragon","Birds","Burro","Cats","Chameleons","Chickens","Chinchillas","Chinese Water Dragon","Cows","Dogs","Donkey","Ducks","Ferrets","Fish","Geckos","Geese","Gerbils","Goats","Guinea Fowl","Guinea Pigs","Hamsters","Hedgehogs","Horses","Iguanas","Llamas","Lizards","Mice","Mule","Peafowl","Pigs and Hogs","Pigeons","Ponies","Pot Bellied Pig","Rabbits","Rats","Sheep","Skinks","Snakes","Stick Insects","Sugar Gliders","Tarantula","Turkeys","Turtles"],
+            // list of zoo animals comes from https://bronxzoo.com/animals
+            zoo: ["Aardvark","African Wild Dog","Aldabra Tortoise","American Alligator","American Bison","Amur Tiger","Anaconda","Andean Condor","Asian Elephant","Baby Doll Sheep","Bald Eagle","Barred Owl","Blue Iguana","Boer Goat","California Sea Lion","Caribbean Flamingo","Chinchilla","Collared Lemur","Coquerel's Sifaka","Cuban Amazon Parrot","Ebony Langur","Fennec Fox","Fossa","Gelada","Giant Anteater","Giraffe","Gorilla","Grizzly Bear","Henkel's Leaf-tailed Gecko","Indian Gharial","Indian Rhinoceros","King Cobra","King Vulture","Komodo Dragon","Linne's Two-toed Sloth","Lion","Little Penguin","Madagascar Tree Boa","Magellanic Penguin","Malayan Tapir","Malayan Tiger","Matschies Tree Kangaroo","Mini Donkey","Monarch Butterfly","Nile crocodile","North American Porcupine","Nubian Ibex","Okapi","Poison Dart Frog","Polar Bear","Pygmy Marmoset","Radiated Tortoise","Red Panda","Red Ruffed Lemur","Ring-tailed Lemur","Ring-tailed Mongoose","Rock Hyrax","Small Clawed Asian Otter","Snow Leopard","Snowy Owl","Southern White-faced Owl","Southern White Rhinocerous","Squirrel Monkey","Tufted Puffin","White Cheeked Gibbon","White-throated Bee Eater","Zebra"],
         },
         primes: [
             // 1230 first primes, i.e. all primes up to the first one greater than 10000, inclusive.
-            2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71,73,79,83,89,97,101,103,107,109,113,127,131,137,139,149,151,157,163,167,173,179,181,191,193,197,199,211,223,227,229,233,239,241,251,257,263,269,271,277,281,283,293,307,311,313,317,331,337,347,349,353,359,367,373,379,383,389,397,401,409,419,421,431,433,439,443,449,457,461,463,467,479,487,491,499,503,509,521,523,541,547,557,563,569,571,577,587,593,599,601,607,613,617,619,631,641,643,647,653,659,661,673,677,683,691,701,709,719,727,733,739,743,751,757,761,769,773,787,797,809,811,821,823,827,829,839,853,857,859,863,877,881,883,887,907,911,919,929,937,941,947,953,967,971,977,983,991,997,1009,1013,1019,1021,1031,1033,1039,1049,1051,1061,1063,1069,1087,1091,1093,1097,1103,1109,1117,1123,1129,1151,1153,1163,1171,1181,1187,1193,1201,1213,1217,1223,1229,1231,1237,1249,1259,1277,1279,1283,1289,1291,1297,1301,1303,1307,1319,1321,1327,1361,1367,1373,1381,1399,1409,1423,1427,1429,1433,1439,1447,1451,1453,1459,1471,1481,1483,1487,1489,1493,1499,1511,1523,1531,1543,1549,1553,1559,1567,1571,1579,1583,1597,1601,1607,1609,1613,1619,1621,1627,1637,1657,1663,1667,1669,1693,1697,1699,1709,1721,1723,1733,1741,1747,1753,1759,1777,1783,1787,1789,1801,1811,1823,1831,1847,1861,1867,1871,1873,1877,1879,1889,1901,1907,1913,1931,1933,1949,1951,1973,1979,1987,1993,1997,1999,2003,2011,2017,2027,2029,2039,2053,2063,2069,2081,2083,2087,2089,2099,2111,2113,2129,2131,2137,2141,2143,2153,2161,2179,2203,2207,2213,2221,2237,2239,2243,2251,2267,2269,2273,2281,2287,2293,2297,2309,2311,2333,2339,2341,2347,2351,2357,2371,2377,2381,2383,2389,2393,2399,2411,2417,2423,2437,2441,2447,2459,2467,2473,2477,2503,2521,2531,2539,2543,2549,2551,2557,2579,2591,2593,2609,2617,2621,2633,2647,2657,2659,2663,2671,2677,2683,2687,2689,2693,2699,2707,2711,2713,2719,2729,2731,2741,2749,2753,2767,2777,2789,2791,2797,2801,2803,2819,2833,2837,2843,2851,2857,2861,2879,2887,2897,2903,2909,2917,2927,2939,2953,2957,2963,2969,2971,2999,3001,3011,3019,3023,3037,3041,3049,3061,3067,3079,3083,3089,3109,3119,3121,3137,3163,3167,3169,3181,3187,3191,3203,3209,3217,3221,3229,3251,3253,3257,3259,3271,3299,3301,3307,3313,3319,3323,3329,3331,3343,3347,3359,3361,3371,3373,3389,3391,3407,3413,3433,3449,3457,3461,3463,3467,3469,3491,3499,3511,3517,3527,3529,3533,3539,3541,3547,3557,3559,3571,3581,3583,3593,3607,3613,3617,3623,3631,3637,3643,3659,3671,3673,3677,3691,3697,3701,3709,3719,3727,3733,3739,3761,3767,3769,3779,3793,3797,3803,3821,3823,3833,3847,3851,3853,3863,3877,3881,3889,3907,3911,3917,3919,3923,3929,3931,3943,3947,3967,3989,4001,4003,4007,4013,4019,4021,4027,4049,4051,4057,4073,4079,4091,4093,4099,4111,4127,4129,4133,4139,4153,4157,4159,4177,4201,4211,4217,4219,4229,4231,4241,4243,4253,4259,4261,4271,4273,4283,4289,4297,4327,4337,4339,4349,4357,4363,4373,4391,4397,4409,4421,4423,4441,4447,4451,4457,4463,4481,4483,4493,4507,4513,4517,4519,4523,4547,4549,4561,4567,4583,4591,4597,4603,4621,4637,4639,4643,4649,4651,4657,4663,4673,4679,4691,4703,4721,4723,4729,4733,4751,4759,4783,4787,4789,4793,4799,4801,4813,4817,4831,4861,4871,4877,4889,4903,4909,4919,4931,4933,4937,4943,4951,4957,4967,4969,4973,4987,4993,4999,5003,5009,5011,5021,5023,5039,5051,5059,5077,5081,5087,5099,5101,5107,5113,5119,5147,5153,5167,5171,5179,5189,5197,5209,5227,5231,5233,5237,5261,5273,5279,5281,5297,5303,5309,5323,5333,5347,5351,5381,5387,5393,5399,5407,5413,5417,5419,5431,5437,5441,5443,5449,5471,5477,5479,5483,5501,5503,5507,5519,5521,5527,5531,5557,5563,5569,5573,5581,5591,5623,5639,5641,5647,5651,5653,5657,5659,5669,5683,5689,5693,5701,5711,5717,5737,5741,5743,5749,5779,5783,5791,5801,5807,5813,5821,5827,5839,5843,5849,5851,5857,5861,5867,5869,5879,5881,5897,5903,5923,5927,5939,5953,5981,5987,6007,6011,6029,6037,6043,6047,6053,6067,6073,6079,6089,6091,6101,6113,6121,6131,6133,6143,6151,6163,6173,6197,6199,6203,6211,6217,6221,6229,6247,6257,6263,6269,6271,6277,6287,6299,6301,6311,6317,6323,6329,6337,6343,6353,6359,6361,6367,6373,6379,6389,6397,6421,6427,6449,6451,6469,6473,6481,6491,6521,6529,6547,6551,6553,6563,6569,6571,6577,6581,6599,6607,6619,6637,6653,6659,6661,6673,6679,6689,6691,6701,6703,6709,6719,6733,6737,6761,6763,6779,6781,6791,6793,6803,6823,6827,6829,6833,6841,6857,6863,6869,6871,6883,6899,6907,6911,6917,6947,6949,6959,6961,6967,6971,6977,6983,6991,6997,7001,7013,7019,7027,7039,7043,7057,7069,7079,7103,7109,7121,7127,7129,7151,7159,7177,7187,7193,7207,7211,7213,7219,7229,7237,7243,7247,7253,7283,7297,7307,7309,7321,7331,7333,7349,7351,7369,7393,7411,7417,7433,7451,7457,7459,7477,7481,7487,7489,7499,7507,7517,7523,7529,7537,7541,7547,7549,7559,7561,7573,7577,7583,7589,7591,7603,7607,7621,7639,7643,7649,7669,7673,7681,7687,7691,7699,7703,7717,7723,7727,7741,7753,7757,7759,7789,7793,7817,7823,7829,7841,7853,7867,7873,7877,7879,7883,7901,7907,7919,7927,7933,7937,7949,7951,7963,7993,8009,8011,8017,8039,8053,8059,8069,8081,8087,8089,8093,8101,8111,8117,8123,8147,8161,8167,8171,8179,8191,8209,8219,8221,8231,8233,8237,8243,8263,8269,8273,8287,8291,8293,8297,8311,8317,8329,8353,8363,8369,8377,8387,8389,8419,8423,8429,8431,8443,8447,8461,8467,8501,8513,8521,8527,8537,8539,8543,8563,8573,8581,8597,8599,8609,8623,8627,8629,8641,8647,8663,8669,8677,8681,8689,8693,8699,8707,8713,8719,8731,8737,8741,8747,8753,8761,8779,8783,8803,8807,8819,8821,8831,8837,8839,8849,8861,8863,8867,8887,8893,8923,8929,8933,8941,8951,8963,8969,8971,8999,9001,9007,9011,9013,9029,9041,9043,9049,9059,9067,9091,9103,9109,9127,9133,9137,9151,9157,9161,9173,9181,9187,9199,9203,9209,9221,9227,9239,9241,9257,9277,9281,9283,9293,9311,9319,9323,9337,9341,9343,9349,9371,9377,9391,9397,9403,9413,9419,9421,9431,9433,9437,9439,9461,9463,9467,9473,9479,9491,9497,9511,9521,9533,9539,9547,9551,9587,9601,9613,9619,9623,9629,9631,9643,9649,9661,9677,9679,9689,9697,9719,9721,9733,9739,9743,9749,9767,9769,9781,9787,9791,9803,9811,9817,9829,9833,9839,9851,9857,9859,9871,9883,9887,9901,9907,9923,9929,9931,9941,9949,9967,9973,10007
+            2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71,73,79,83,89,97,101,103,107,109,113,127,131,137,139,149,151,157,163,167,173,179,181,191,193,197,199,211,223,227,229,233,239,241,251,257,263,269,271,277,281,283,293,307,311,313,317,331,337,347,349,353,359,367,373,379,383,389,397,401,409,419,421,431,433,439,443,449,457,461,463,467,479,487,491,499,503,509,521,523,541,547,557,563,569,571,577,587,593,599,601,607,613,617,619,631,641,643,647,653,659,661,673,677,683,691,701,709,719,727,733,739,743,751,757,761,769,773,787,797,809,811,821,823,827,829,839,853,857,859,863,877,881,883,887,907,911,919,929,937,941,947,953,967,971,977,983,991,997,1009,1013,1019,1021,1031,1033,1039,1049,1051,1061,1063,1069,1087,1091,1093,1097,1103,1109,1117,1123,1129,1151,1153,1163,1171,1181,1187,1193,1201,1213,1217,1223,1229,1231,1237,1249,1259,1277,1279,1283,1289,1291,1297,1301,1303,1307,1319,1321,1327,1361,1367,1373,1381,1399,1409,1423,1427,1429,1433,1439,1447,1451,1453,1459,1471,1481,1483,1487,1489,1493,1499,1511,1523,1531,1543,1549,1553,1559,1567,1571,1579,1583,1597,1601,1607,1609,1613,1619,1621,1627,1637,1657,1663,1667,1669,1693,1697,1699,1709,1721,1723,1733,1741,1747,1753,1759,1777,1783,1787,1789,1801,1811,1823,1831,1847,1861,1867,1871,1873,1877,1879,1889,1901,1907,1913,1931,1933,1949,1951,1973,1979,1987,1993,1997,1999,2003,2011,2017,2027,2029,2039,2053,2063,2069,2081,2083,2087,2089,2099,2111,2113,2129,2131,2137,2141,2143,2153,2161,2179,2203,2207,2213,2221,2237,2239,2243,2251,2267,2269,2273,2281,2287,2293,2297,2309,2311,2333,2339,2341,2347,2351,2357,2371,2377,2381,2383,2389,2393,2399,2411,2417,2423,2437,2441,2447,2459,2467,2473,2477,2503,2521,2531,2539,2543,2549,2551,2557,2579,2591,2593,2609,2617,2621,2633,2647,2657,2659,2663,2671,2677,2683,2687,2689,2693,2699,2707,2711,2713,2719,2729,2731,2741,2749,2753,2767,2777,2789,2791,2797,2801,2803,2819,2833,2837,2843,2851,2857,2861,2879,2887,2897,2903,2909,2917,2927,2939,2953,2957,2963,2969,2971,2999,3001,3011,3019,3023,3037,3041,3049,3061,3067,3079,3083,3089,3109,3119,3121,3137,3163,3167,3169,3181,3187,3191,3203,3209,3217,3221,3229,3251,3253,3257,3259,3271,3299,3301,3307,3313,3319,3323,3329,3331,3343,3347,3359,3361,3371,3373,3389,3391,3407,3413,3433,3449,3457,3461,3463,3467,3469,3491,3499,3511,3517,3527,3529,3533,3539,3541,3547,3557,3559,3571,3581,3583,3593,3607,3613,3617,3623,3631,3637,3643,3659,3671,3673,3677,3691,3697,3701,3709,3719,3727,3733,3739,3761,3767,3769,3779,3793,3797,3803,3821,3823,3833,3847,3851,3853,3863,3877,3881,3889,3907,3911,3917,3919,3923,3929,3931,3943,3947,3967,3989,4001,4003,4007,4013,4019,4021,4027,4049,4051,4057,4073,4079,4091,4093,4099,4111,4127,4129,4133,4139,4153,4157,4159,4177,4201,4211,4217,4219,4229,4231,4241,4243,4253,4259,4261,4271,4273,4283,4289,4297,4327,4337,4339,4349,4357,4363,4373,4391,4397,4409,4421,4423,4441,4447,4451,4457,4463,4481,4483,4493,4507,4513,4517,4519,4523,4547,4549,4561,4567,4583,4591,4597,4603,4621,4637,4639,4643,4649,4651,4657,4663,4673,4679,4691,4703,4721,4723,4729,4733,4751,4759,4783,4787,4789,4793,4799,4801,4813,4817,4831,4861,4871,4877,4889,4903,4909,4919,4931,4933,4937,4943,4951,4957,4967,4969,4973,4987,4993,4999,5003,5009,5011,5021,5023,5039,5051,5059,5077,5081,5087,5099,5101,5107,5113,5119,5147,5153,5167,5171,5179,5189,5197,5209,5227,5231,5233,5237,5261,5273,5279,5281,5297,5303,5309,5323,5333,5347,5351,5381,5387,5393,5399,5407,5413,5417,5419,5431,5437,5441,5443,5449,5471,5477,5479,5483,5501,5503,5507,5519,5521,5527,5531,5557,5563,5569,5573,5581,5591,5623,5639,5641,5647,5651,5653,5657,5659,5669,5683,5689,5693,5701,5711,5717,5737,5741,5743,5749,5779,5783,5791,5801,5807,5813,5821,5827,5839,5843,5849,5851,5857,5861,5867,5869,5879,5881,5897,5903,5923,5927,5939,5953,5981,5987,6007,6011,6029,6037,6043,6047,6053,6067,6073,6079,6089,6091,6101,6113,6121,6131,6133,6143,6151,6163,6173,6197,6199,6203,6211,6217,6221,6229,6247,6257,6263,6269,6271,6277,6287,6299,6301,6311,6317,6323,6329,6337,6343,6353,6359,6361,6367,6373,6379,6389,6397,6421,6427,6449,6451,6469,6473,6481,6491,6521,6529,6547,6551,6553,6563,6569,6571,6577,6581,6599,6607,6619,6637,6653,6659,6661,6673,6679,6689,6691,6701,6703,6709,6719,6733,6737,6761,6763,6779,6781,6791,6793,6803,6823,6827,6829,6833,6841,6857,6863,6869,6871,6883,6899,6907,6911,6917,6947,6949,6959,6961,6967,6971,6977,6983,6991,6997,7001,7013,7019,7027,7039,7043,7057,7069,7079,7103,7109,7121,7127,7129,7151,7159,7177,7187,7193,7207,7211,7213,7219,7229,7237,7243,7247,7253,7283,7297,7307,7309,7321,7331,7333,7349,7351,7369,7393,7411,7417,7433,7451,7457,7459,7477,7481,7487,7489,7499,7507,7517,7523,7529,7537,7541,7547,7549,7559,7561,7573,7577,7583,7589,7591,7603,7607,7621,7639,7643,7649,7669,7673,7681,7687,7691,7699,7703,7717,7723,7727,7741,7753,7757,7759,7789,7793,7817,7823,7829,7841,7853,7867,7873,7877,7879,7883,7901,7907,7919,7927,7933,7937,7949,7951,7963,7993,8009,8011,8017,8039,8053,8059,8069,8081,8087,8089,8093,8101,8111,8117,8123,8147,8161,8167,8171,8179,8191,8209,8219,8221,8231,8233,8237,8243,8263,8269,8273,8287,8291,8293,8297,8311,8317,8329,8353,8363,8369,8377,8387,8389,8419,8423,8429,8431,8443,8447,8461,8467,8501,8513,8521,8527,8537,8539,8543,8563,8573,8581,8597,8599,8609,8623,8627,8629,8641,8647,8663,8669,8677,8681,8689,8693,8699,8707,8713,8719,8731,8737,8741,8747,8753,8761,8779,8783,8803,8807,8819,8821,8831,8837,8839,8849,8861,8863,8867,8887,8893,8923,8929,8933,8941,8951,8963,8969,8971,8999,9001,9007,9011,9013,9029,9041,9043,9049,9059,9067,9091,9103,9109,9127,9133,9137,9151,9157,9161,9173,9181,9187,9199,9203,9209,9221,9227,9239,9241,9257,9277,9281,9283,9293,9311,9319,9323,9337,9341,9343,9349,9371,9377,9391,9397,9403,9413,9419,9421,9431,9433,9437,9439,9461,9463,9467,9473,9479,9491,9497,9511,9521,9533,9539,9547,9551,9587,9601,9613,9619,9623,9629,9631,9643,9649,9661,9677,9679,9689,9697,9719,9721,9733,9739,9743,9749,9767,9769,9781,9787,9791,9803,9811,9817,9829,9833,9839,9851,9857,9859,9871,9883,9887,9901,9907,9923,9929,9931,9941,9949,9967,9973,10007,
         ],
         emotions: [
             "love",
@@ -7257,37 +7114,37 @@ options,
             "surprise",
             "anger",
             "sadness",
-            "fear"
+            "fear",
         ],
     };
 
     var o_hasOwnProperty = Object.prototype.hasOwnProperty;
-    var o_keys = (Object.keys || function(obj) {
-      var result = [];
-      for (var key in obj) {
-        if (o_hasOwnProperty.call(obj, key)) {
-          result.push(key);
+    var o_keys = (Object.keys || function (obj) {
+        var result = [];
+        for (var key in obj) {
+            if (o_hasOwnProperty.call(obj, key)) {
+                result.push(key);
+            }
         }
-      }
 
-      return result;
+        return result;
     });
 
 
     function _copyObject(source, target) {
-      var keys = o_keys(source);
-      var key;
+        var keys = o_keys(source);
+        var key;
 
-      for (var i = 0, l = keys.length; i < l; i++) {
-        key = keys[i];
-        target[key] = source[key] || target[key];
-      }
+        for (var i = 0, l = keys.length; i < l; i++) {
+            key = keys[i];
+            target[key] = source[key] || target[key];
+        }
     }
 
     function _copyArray(source, target) {
-      for (var i = 0, l = source.length; i < l; i++) {
-        target[i] = source[i];
-      }
+        for (var i = 0, l = source.length; i < l; i++) {
+            target[i] = source[i];
+        }
     }
 
     function copyObject(source, _target) {
@@ -7295,33 +7152,33 @@ options,
         var target = _target || (isArray ? new Array(source.length) : {});
 
         if (isArray) {
-          _copyArray(source, target);
+            _copyArray(source, target);
         } else {
-          _copyObject(source, target);
+            _copyObject(source, target);
         }
 
         return target;
     }
 
-    /** Get the data based on key**/
+    /** Get the data based on key **/
     Chance.prototype.get = function (name) {
         return copyObject(data[name]);
     };
 
     // Mac Address
-    Chance.prototype.mac_address = function(options){
+    Chance.prototype.mac_address = function (options){
         // typically mac addresses are separated by ":"
         // however they can also be separated by "-"
         // the network variant uses a dot every fourth byte
 
         options = initOptions(options);
-        if(!options.separator) {
+        if (!options.separator) {
             options.separator =  options.networkVersion ? "." : ":";
         }
 
-        var mac_pool="ABCDEF1234567890",
+        var mac_pool = "ABCDEF1234567890",
             mac = "";
-        if(!options.networkVersion) {
+        if (!options.networkVersion) {
             mac = this.n(this.string, 6, { pool: mac_pool, length:2 }).join(options.separator);
         } else {
             mac = this.n(this.string, 3, { pool: mac_pool, length:4 }).join(options.separator);
@@ -7372,7 +7229,7 @@ options,
         return dev * norm + mean;
     };
 
-    Chance.prototype.normal_pool = function(options) {
+    Chance.prototype.normal_pool = function (options) {
         var performanceCounter = 0;
         do {
             var idx = Math.round(this.normal({ mean: options.mean, dev: options.dev }));
@@ -7381,7 +7238,7 @@ options,
             } else {
                 performanceCounter++;
             }
-        } while(performanceCounter < 100);
+        } while (performanceCounter < 100);
 
         throw new RangeError("Chance: Your pool is too small for the given mean and standard deviation. Please adjust.");
     };
@@ -7427,15 +7284,33 @@ options,
         var n = this.n(this.natural, 8, { max: 9 });
         var d1 = 2+n[7]*6+n[6]*7+n[5]*8+n[4]*9+n[3]*2+n[2]*3+n[1]*4+n[0]*5;
         d1 = 11 - (d1 % 11);
-        if (d1>=10){
+        if (d1 >= 10){
             d1 = 0;
         }
         var d2 = d1*2+3+n[7]*7+n[6]*8+n[5]*9+n[4]*2+n[3]*3+n[2]*4+n[1]*5+n[0]*6;
         d2 = 11 - (d2 % 11);
-        if (d2>=10){
+        if (d2 >= 10){
             d2 = 0;
         }
         return ''+n[0]+n[1]+'.'+n[2]+n[3]+n[4]+'.'+n[5]+n[6]+n[7]+'/0001-'+d1+d2;
+    };
+
+    Chance.prototype.animal = function (options) {
+        // returns a random animal
+        options = initOptions(options);
+        var animalTypeArray = ["desert", "forest", "ocean", "zoo", "farm", "pet", "grassland"];
+
+        if (typeof options.type !== 'undefined') {
+            // if user does not put in a valid animal type, user will get an error
+            testRange(
+                !this.get("animals")[options.type.toLowerCase()],
+                "Chance: Please pick from " + animalTypeArray.join(", ") + "."
+            );
+            // if user does put in valid animal type, will return a random animal of that type
+            return this.pick(this.get("animals")[options.type.toLowerCase()]);
+        }
+        // if user does not put in any animal type, will return a random animal regardless
+        return this.pick(this.get("animals")[this.pick(animalTypeArray)]);
     };
 
     Chance.prototype.emotion = function () {
@@ -7886,17 +7761,18 @@ options,
         });
     }
 
-    // if there is a importsScrips object define chance for worker
-    // allows worker to use full Chance functionality with seed
+    // If there is an importScripts object, define chance for worker.
+    // Allows worker to use full Chance functionality with seed.
     if (typeof importScripts !== 'undefined') {
         chance = new Chance();
         self.Chance = Chance;
     }
 
     // If there is a window object, that at least has a document property,
-    // instantiate and define chance on the window
+    // instantiate and define chance on the window.
     if (typeof window === "object" && typeof window.document === "object") {
         window.Chance = Chance;
         window.chance = new Chance();
     }
+
 })();

--- a/docs/basics/bool.md
+++ b/docs/basics/bool.md
@@ -16,9 +16,8 @@ The default likelihood of success (returning `true`) is 50%.
 Can optionally specify the likelihood in percent:
 
 ```js
-chance.bool({likelihood: 30});
+chance.bool({ likelihood: 30 });
 => false
 ```
 
 In this case only a 30% likelihood of `true`, and a 70% likelihood of `false`.
-

--- a/docs/basics/character.md
+++ b/docs/basics/character.md
@@ -54,8 +54,8 @@ chance.character({ casing: 'lower' });
 => 'j'
 ```
 
-*Note, wanted to call this key just ```case``` but unfortunately that's a
-reserved word in JavaScript for use in a switch statement*
+<p class="pullquote">Note, wanted to call this key just ```case``` but unfortunately that's a
+reserved word in JavaScript for use in a switch statement.</p>
 
 Optionally return only symbols
 

--- a/docs/basics/falsy.md
+++ b/docs/basics/falsy.md
@@ -3,7 +3,7 @@
 ```js
 // usages
 chance.falsy()
-chance.falsy({ pool: [ NaN, undefined ] })
+chance.falsy({ pool: [NaN, undefined] })
 ```
 Return a random falsy value (`false`, `null`, `undefined`, `0`, `NaN`, `''`).
 
@@ -12,11 +12,9 @@ chance.falsy();
 => false
 ```
 
-The default pool can be changed to better meet the needs:
+The default pool can be changed to better meet the needs.
 
 ```js
-chance.falsy({ pool: [ NaN, undefined ] });
+chance.falsy({ pool: [NaN, undefined] });
 => NaN
 ```
-
-

--- a/docs/basics/letter.md
+++ b/docs/basics/letter.md
@@ -15,7 +15,7 @@ chance.letter();
 
 By default it will return a random lowercase letter.
 
-<p class="pullquote">Note, wanted to call this option just <strong>case</strong> instead of <strong>casing</strong> but unfortunately that's a reserved word in JavaScript for use in a switch statement</p>
+<p class="pullquote">Note, wanted to call this option just <strong>case</strong> instead of <strong>casing</strong> but unfortunately that's a reserved word in JavaScript for use in a switch statement.</p>
 
 It's possible to specify upper case
 

--- a/docs/basics/natural.md
+++ b/docs/basics/natural.md
@@ -18,19 +18,19 @@ _range: 0 to 9007199254740991_
 Can optionally provide min and max.
 
 ```js
-chance.natural({min: 1, max: 20});
+chance.natural({ min: 1, max: 20 });
 => 14
 ```
 
 Can optionally provide numbers you wish to exclude.
 
 ```js
-chance.natural({min: 1, max: 5, exclude: [1, 3]});
+chance.natural({ min: 1, max: 5, exclude: [1, 3] });
 => 2
 ```
 
 These are inclusive, so they are included in the range. This means
-```chance.natural({min: 1, max: 3});``` would return either 1, 2, or 3 or:
+```chance.natural({ min: 1, max: 3 });``` would return either 1, 2, or 3 or:
 
 ```js
 // Specific case
@@ -44,4 +44,3 @@ min <= random number <= max
 [Natural Number on Wikipedia][natural]
 
 [natural]: https://en.wikipedia.org/wiki/Natural_number
-

--- a/docs/basics/prime.md
+++ b/docs/basics/prime.md
@@ -18,13 +18,13 @@ _default range: 0 to 10000_
 Can optionally provide min and max.
 
 ```js
-chance.prime({min: 1, max: 20});
+chance.prime({ min: 1, max: 20 });
 => 13
 ```
 
 
 These are inclusive, so they are included in the range. This means
-```chance.prime({min: 2, max: 5});``` would return either 2, 3, or 5 or:
+```chance.prime({ min: 2, max: 5 });``` would return either 2, 3, or 5 or:
 
 ```js
 // Specific case
@@ -38,4 +38,3 @@ min <= random number <= max
 [Prime Number on Wikipedia][prime]
 
 [prime]: https://en.wikipedia.org/wiki/Prime_number
-

--- a/docs/finance/cc.md
+++ b/docs/finance/cc.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.cc()
-chance.cc({type: 'Mastercard'})
+chance.cc({ type: 'Mastercard' })
 ```
 
 <p class="pullquote" data-pullquote='Somewhat obvious warning: Do not use this to hit live payment gateways...' markdown="1"></p>
@@ -16,17 +16,17 @@ chance.cc();
 => '6304038511073827'
 ```
 
-Optionally specify a particular type of card to return:
+Optionally specify a particular type of card to return.
 
 ```js
-chance.cc({type: 'Mastercard'});
+chance.cc({ type: 'Mastercard' });
 => '5171206237468496'
 ```
 
-The type can be specified by the long name, or by the short name:
+The type can be specified by the long name, or by the short name.
 
 ```js
-chance.cc({type: 'mc'});
+chance.cc({ type: 'mc' });
 => '5103820202214116'
 ```
 

--- a/docs/finance/cc_type.md
+++ b/docs/finance/cc_type.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.cc_type()
-chance.cc_type({raw: true})
+chance.cc_type({ raw: true })
 ```
 
 Return a random credit card type.
@@ -17,8 +17,8 @@ Default returns just the name. To return the entire object (consisting of name,
 short name, numeric prefix, and length), specify so with the raw flag.
 
 ```js
-chance.cc_type({raw: true});
-=> {name: 'Discover Card', short_name: 'discover', prefix: '6011', length: 16}
+chance.cc_type({ raw: true });
+=> { name: 'Discover Card', short_name: 'discover', prefix: '6011', length: 16 }
 ```
 
 The available types are (name - *short_name*):

--- a/docs/finance/dollar.md
+++ b/docs/finance/dollar.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.dollar()
-chance.dollar({max: 250})
+chance.dollar({ max: 250 })
 ```
 
 <p class="pullquote" data-pullquote="Dolla, dolla, bill ya'll" markdown="1"></p>
@@ -22,9 +22,9 @@ By default returns dollar amount no larger than 10000. Optionally specify
 the max to make it larger (or smaller).
 
 ```js
-chance.dollar({max: 20});
+chance.dollar({ max: 20 });
 => "$15.23"
 
-chance.dollar({max: 10000000})
+chance.dollar({ max: 10000000 })
 => "$5051205.49"
 ```

--- a/docs/finance/euro.md
+++ b/docs/finance/euro.md
@@ -3,10 +3,10 @@
 ```js
 // usage
 chance.euro()
-chance.euro({max: 250})
+chance.euro({ max: 250 })
 ```
 
-Return a random euro amount. Formatting depends on the current locale (samples are displayed with european formatting)
+Return a random euro amount. Formatting depends on the current locale (samples are displayed with European formatting).
 
 ```js
 chance.euro();
@@ -20,9 +20,9 @@ By default returns euro amount no larger than 10000. Optionally specify
 the max to make it larger (or smaller).
 
 ```js
-chance.euro({max: 20});
+chance.euro({ max: 20 });
 => "15,23€"
 
-chance.euro({max: 10000000})
+chance.euro({ max: 10000000 })
 => "5.051.205,49€"
 ```

--- a/docs/finance/exp.md
+++ b/docs/finance/exp.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.exp()
-chance.exp({raw: true})
+chance.exp({ raw: true })
 ```
 
 Generate a random credit card expiration.
@@ -13,9 +13,9 @@ chance.exp();
 => '10/2020'
 ```
 
-Optionally specify that a raw object be returned rather than a string
+Optionally specify that a raw object be returned rather than a string.
 
 ```js
-chance.exp({raw: true});
-=> {month: '11', year: '2017'}
+chance.exp({ raw: true });
+=> { month: '11', year: '2017' }
 ```

--- a/docs/finance/exp_month.md
+++ b/docs/finance/exp_month.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.exp_month()
-chance.exp_month({future: true})
+chance.exp_month({ future: true })
 ```
 
 Generate a random credit card expiration month.
@@ -16,7 +16,7 @@ chance.exp_month();
 Optionally specify that it must be a later month than the current month.
 
 ```js
-chance.exp_month({future: true});
+chance.exp_month({ future: true });
 => '10'
 ```
 

--- a/docs/helpers/capitalize.md
+++ b/docs/helpers/capitalize.md
@@ -5,7 +5,7 @@
 chance.capitalize(string)
 ```
 
-Capitalize the first letter of a word
+Capitalize the first letter of a word.
 
 ```js
 chance.capitalize('bread')

--- a/docs/helpers/mixin.md
+++ b/docs/helpers/mixin.md
@@ -25,13 +25,11 @@ For example, let's say I have a user object which consists of first, last,
 and email.
 
 ```js
-
 var user = {
-first: 'John',
-last: 'Smith',
-email: 'john@aol.com'
+  first: 'John',
+  last: 'Smith',
+  email: 'john@aol.com'
 };
-
 ```
 
 Let's say I want to be able to randomly generate these user objects.
@@ -48,19 +46,19 @@ For example, to create a `user` mixin:
 
 ```js
 chance.mixin({
-'user': function() {
-return {
-first: chance.first(),
-last: chance.last(),
-email: chance.email()
-};
-}
+  user: function() {
+    return {
+      first: chance.first(),
+      last: chance.last(),
+      email: chance.email()
+    };
+  }
 });
 
 // Then you can call your mixin
 chance.user();
 
-=> {first: 'Eli', last: 'Benson', email: 'gembibuj@dugesan.com'}
+=> { first: 'Eli', last: 'Benson', email: 'gembibuj@dugesan.com' }
 ```
 
 Mixins can even include other mixins!
@@ -68,18 +66,18 @@ Mixins can even include other mixins!
 For example, to "extend" the user object:
 ```js
 chance.mixin({
-'user': function () {
-return {
-first: chance.first(),
-last: chance.last(),
-email: chance.email()
-};
-},
-'social_user': function () {
-var user = chance.user();
-user.network = chance.pick(['facebook', 'twitter']);
-return user;
-}
+  user: function () {
+    return {
+      first: chance.first(),
+      last: chance.last(),
+      email: chance.email()
+    };
+  },
+  social_user: function () {
+    var user = chance.user();
+    user.network = chance.pick(['facebook', 'twitter']);
+    return user;
+  }
 });
 ```
 

--- a/docs/helpers/pickone.md
+++ b/docs/helpers/pickone.md
@@ -5,7 +5,7 @@
 chance.pickone(array)
 ```
 
-Given an array, pick a random element and return it
+Given an array, pick a random element and return it.
 
 ```js
 chance.pickone(['alpha', 'bravo', 'charlie', 'delta', 'echo']);

--- a/docs/helpers/pickset.md
+++ b/docs/helpers/pickset.md
@@ -5,14 +5,14 @@
 chance.pickset(array, quantity)
 ```
 
-Given an array, pick some random elements and return them in a new array
+Given an array, pick some random elements and return them in a new array.
 
 ```js
 chance.pickset(['alpha', 'bravo', 'charlie', 'delta', 'echo'], 3);
 => ['echo', 'alpha', 'bravo']
 ```
 
-Optionally omit the quantity to retrieve a set with length 1
+Optionally omit the quantity to retrieve a set with length 1.
 
 ```js
 chance.pickset(['alpha', 'bravo', 'charlie', 'delta', 'echo']);

--- a/docs/location/address.md
+++ b/docs/location/address.md
@@ -3,19 +3,19 @@
 ```js
 // usage
 chance.address()
-chance.address({short_suffix: true})
+chance.address({ short_suffix: true })
 ```
 
-Generate a random street address
+Generate a random street address.
 
 ```js
 chance.address();
 => '5447 Bazpe Lane'
 ```
 
-Optionally mandate that it return a short suffix
+Optionally mandate that it return a short suffix.
 
 ```js
-chance.address({short_suffix: true});
+chance.address({ short_suffix: true });
 => '536 Baner Rd'
 ```

--- a/docs/location/areacode.md
+++ b/docs/location/areacode.md
@@ -5,7 +5,7 @@
 chance.areacode()
 ```
 
-Generate a random area code
+Generate a random area code.
 
 ```js
 chance.areacode()

--- a/docs/location/city.md
+++ b/docs/location/city.md
@@ -5,7 +5,7 @@
 chance.city()
 ```
 
-Generate a random city name
+Generate a random city name.
 
 ```js
 chance.city();

--- a/docs/location/coordinates.md
+++ b/docs/location/coordinates.md
@@ -3,8 +3,8 @@
 ```js
 // usage
 chance.coordinates()
-chance.coordinates({fixed: 2})
-chance.coordinates({format: 'dms'})
+chance.coordinates({ fixed: 2 })
+chance.coordinates({ format: 'dms' })
 ```
 
 Generate random coordinates, which are latitude and longitude, comma separated.
@@ -17,18 +17,18 @@ chance.coordinates();
 By default includes 5 fixed digits after decimal, can specify otherwise.
 
 ```js
-chance.coordinates({fixed: 2});
+chance.coordinates({ fixed: 2 });
 => "-49.16, 68.81"
 ```
 
-By default cooridnates' format is dd, can specify otherwise.
+By default coordinates' format is `dd`, can specify otherwise.
 
 ```js
-chance.coordinates({format: 'ddm'});
+chance.coordinates({ format: 'ddm' });
 => "41°44.9592, 25°56.2622"
 ```
 
 ```js
-chance.coordinates({format: 'dms'});
+chance.coordinates({ format: 'dms' });
 => "56°2’9.8187”, 79°55’40.6812”"
 ```

--- a/docs/location/depth.md
+++ b/docs/location/depth.md
@@ -7,7 +7,7 @@ chance.depth({ fixed: 2 })
 chance.depth({ min: -1000 })
 ```
 
-Generate a random depth, in meters. Depths are always negative
+Generate a random depth, in meters. Depths are always negative.
 
 ```js
 chance.depth()

--- a/docs/location/latitude.md
+++ b/docs/location/latitude.md
@@ -3,8 +3,8 @@
 ```js
 // usage
 chance.latitude()
-chance.latitude({fixed: 7})
-chance.latitude({format: 'dms'})
+chance.latitude({ fixed: 7 })
+chance.latitude({ format: 'dms' })
 ```
 
 Generate a random latitude.
@@ -19,25 +19,25 @@ _range: -90 to 90_
 By default includes 5 fixed digits after decimal, can specify otherwise.
 
 ```js
-chance.latitude({fixed: 7});
+chance.latitude({ fixed: 7 });
 => -29.6443133
 ```
 
-By default includes entire range of allowed latitudes, can specify a min and/or max to bound it
+By default includes entire range of allowed latitudes, can specify a min and/or max to bound it.
 
 ```js
-chance.latitude({min: 38.7, max: 38.9});
+chance.latitude({ min: 38.7, max: 38.9 });
 => 38.82358
 ```
 
-By default latitudes' format is dd, can specify otherwise.
+By default latitudes' format is `dd`, can specify otherwise.
 
 ```js
-chance.latitude({format: 'ddm'});
+chance.latitude({ format: 'ddm' });
 => "41°44.9592"
 ```
 
 ```js
-chance.latitude({format: 'dms'});
+chance.latitude({ format: 'dms' });
 => "56°2’9.8187”"
 ```

--- a/docs/location/locale.md
+++ b/docs/location/locale.md
@@ -3,20 +3,20 @@
 ```js
 // usage
 chance.locale()
-chance.locale({region: true})
+chance.locale({ region: true })
 ```
 
-Generate a random ISO-639-1 language code
+Generate a random ISO-639-1 language code.
 
 ```js
 chance.locale();
 => 'ca'
 ```
 
-Generate a random IETF region code
+Generate a random IETF region code.
 
 ```js
-chance.locale({region: true});
+chance.locale({ region: true });
 => 'es-EA'
 ```
 

--- a/docs/location/longitude.md
+++ b/docs/location/longitude.md
@@ -3,8 +3,8 @@
 ```js
 // usage
 chance.longitude()
-chance.longitude({fixed: 7})
-chance.longitude({format: 'dms'})
+chance.longitude({ fixed: 7 })
+chance.longitude({ format: 'dms' })
 ```
 
 Generate a random longitude.
@@ -19,25 +19,25 @@ _range: -180 to 180_
 By default includes 5 fixed digits after decimal, can specify otherwise.
 
 ```js
-chance.longitude({fixed: 7});
+chance.longitude({ fixed: 7 });
 => 51.4549925
 ```
 
-By default includes entire range of allowed longitudes, can specify a min and/or max to bound it
+By default includes entire range of allowed longitudes, can specify a min and/or max to bound it.
 
 ```js
-chance.longitude({min: -78, max: -77});
+chance.longitude({ min: -78, max: -77 });
 => -77.22644
 ```
 
-By default longitude' format is dd, can specify otherwise.
+By default longitude' format is `dd`, can specify otherwise.
 
 ```js
-chance.longitude({format: 'ddm'});
+chance.longitude({ format: 'ddm' });
 => "41°44.9592"
 ```
 
 ```js
-chance.longitude({format: 'dms'});
+chance.longitude({ format: 'dms' });
 => "56°2’9.8187”"
 ```

--- a/docs/location/province.md
+++ b/docs/location/province.md
@@ -3,8 +3,8 @@
 ```js
 // usage
 chance.province()
-chance.province({full: true})
-chance.province({full: true})
+chance.province({ full: true })
+chance.province({ full: true })
 ```
 
 Return a random province.
@@ -14,19 +14,19 @@ chance.province();
 => 'ON'
 ```
 
-By default, returns only the 2 letter abbreviation for province.
+By default, returns only the 2 letter abbreviation for a Canadian province.
 
 Optionally specify that it ought to return a full province name.
 
 ```js
-chance.province({full: true});
+chance.province({ full: true });
 => 'Nova Scotia'
 ```
 
 Optionally specify the country from which it should return the province name.
 
 ```js
-chance.province({country: 'it', full: true});
+chance.province({ country: 'it', full: true });
 => 'Vicenza'
 ```
 

--- a/docs/location/state.md
+++ b/docs/location/state.md
@@ -17,7 +17,7 @@ chance.state();
 => 'AK'
 ```
 
-By default, returns only the 2 letter abbreviation for state.
+By default, returns only the 2 letter abbreviation for a U.S. state.
 
 Optionally specify that it ought to return a full state name.
 

--- a/docs/location/street.md
+++ b/docs/location/street.md
@@ -3,34 +3,34 @@
 ```js
 // usage
 chance.street()
-chance.street({country:it})
+chance.street({ country: 'it' })
 ```
 
-Generate a random street
+Generate a random street.
 
 ```js
 chance.street();
 => 'Tesca Circle'
 ```
 
-Optionally mandate that it returns a short suffix
+Optionally mandate that it returns a short suffix.
 
 ```js
-chance.street({short_suffix: true});
+chance.street({ short_suffix: true });
 => 'Jiled St'
 ```
 
-Optionally specify the number of syllables used to generate the street name
+Optionally specify the number of syllables used to generate the street name.
 
 ```js
-chance.street({syllables: 8});
+chance.street({ syllables: 8 });
 => 'Teniefitinusewjircor Junction'
 ```
 
-Optionally specify a country to localize street prefixes
+Optionally specify a country to localize street prefixes.
 
 ```js
-chance.street({country: 'it'});
+chance.street({ country: 'it' });
 => 'Via Nefba'
 ```
 

--- a/docs/location/zip.md
+++ b/docs/location/zip.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.zip()
-chance.zip({plusfour: true})
+chance.zip({ plusfour: true })
 ```
 
 Generate a random (U.S.) zip code.
@@ -13,7 +13,7 @@ chance.zip();
 => '90210'
 ```
 
-Can optionally specify that it ought to return a [Zip+4][zip+4]:
+Can optionally specify that it ought to return a [Zip+4][zip+4].
 
 ```js
 chance.zip({plusfour: true});

--- a/docs/miscellaneous/guid.md
+++ b/docs/miscellaneous/guid.md
@@ -3,14 +3,14 @@
 ```js
 // usage
 chance.guid()
-chance.guid({version: 5})
+chance.guid({ version: 5 })
 ```
 
-Return a random guid, version 5 by default.
+Return a random GUID, version 5 by default.
 
 ```js
 chance.guid();
 => 'f0d8368d-85e2-54fb-73c4-2d60374295e3'
-chance.guid({version: 4});
+chance.guid({ version: 4 });
 => 'c71f58e3-34af-43c0-b405-2764d6947d21'
 ```

--- a/docs/miscellaneous/hash.md
+++ b/docs/miscellaneous/hash.md
@@ -3,8 +3,8 @@
 ```js
 // usage
 chance.hash()
-chance.hash({length: 25})
-chance.hash({casing: 'upper'})
+chance.hash({ length: 25 })
+chance.hash({ casing: 'upper' })
 ```
 
 Return a random hex hash
@@ -25,11 +25,9 @@ chance.hash({length: 15})
 ```
 
 Optionally specify casing to get a hash with only uppercase letters
-rather than the default lowercase
+rather than the default lowercase.
 
 ```js
 chance.hash({casing: 'upper'})
 => '3F2EB3FB85D88984C1EC4F46A3DBE740B5E0E56E'
 ```
-
-

--- a/docs/miscellaneous/hidden.md
+++ b/docs/miscellaneous/hidden.md
@@ -17,10 +17,9 @@ These aren't really hidden per se, but just utility methods intended to be used
 internally but exposed externally in case they're useful to anyone.
 
 ```js
-
 // Return the list of cc types
 chance.cc_types()
-=> [{name: "American Express", short_name: 'amex', prefix: '34', length: 15}, ...]
+=> [{ name: "American Express", short_name: 'amex', prefix: '34', length: 15 }, ...]
 
 // Return a new Mersenne Twister
 chance.mersenne_twister()
@@ -30,30 +29,28 @@ chance.mersenne_twister()
 chance.mersenne_twister(12345)
 => [object Object] // An instance of a twister with seed 12345
 
-// Return our list of name prefixes
+// Return our list of months
 chance.months();
-=> [{name: 'January', short_name 'Jan', numeric: '01'}, ...]
+=> [{ name: 'January', short_name 'Jan', numeric: '01' }, ...]
 
 // Return our list of name prefixes
 chance.name_prefixes();
-=> [{name: 'Doctor', abbreviation: 'Dr.'}, {name: 'Miss', abbreviation: 'Miss'}, ...]
+=> [{ name: 'Doctor', abbreviation: 'Dr.' }, { name: 'Miss', abbreviation: 'Miss' }, ...]
 
 // Return the list of provinces
 chance.provinces();
-=> [{name: 'Alberta', abbreviation: 'AB'}, {name: 'British Columbia', abbreviation: 'BC'}, ...]
+=> [{ name: 'Alberta', abbreviation: 'AB' }, { name: 'British Columbia', abbreviation: 'BC' }, ...]
 
 // Return the list of states
 chance.states();
-=> [{name: 'Alabama', abbreviation: 'AL'}, {name: 'Alaska', abbreviation: 'AK'}, ...]
+=> [{ name: 'Alabama', abbreviation: 'AL' }, { name: 'Alaska', abbreviation: 'AK' }, ...]
 
 // Return a random street suffix
 chance.street_suffix();
-=> {name: 'Street', abbreviation: 'St'}
+=> { name: 'Street', abbreviation: 'St' }
 
 // Return the list of street suffixes
 chance.street_suffixes();
-=> [{name: 'Avenue', abbreviation: 'Ave'}, {name: 'Boulevard', abbreviation: 'Blvd'}, ...]
+=> [{ name: 'Avenue', abbreviation: 'Ave' }, { name: 'Boulevard', abbreviation: 'Blvd' }, ...]
 
 ```
-
-

--- a/docs/miscellaneous/normal.md
+++ b/docs/miscellaneous/normal.md
@@ -3,8 +3,8 @@
 ```js
 // usage
 chance.normal()
-chance.normal({mean: 100})
-chance.normal({mean: 100, dev: 15})
+chance.normal({ mean: 100 })
+chance.normal({ mean: 100, dev: 15 })
 ```
 
 Return a normally-distributed random variate.

--- a/docs/miscellaneous/radio.md
+++ b/docs/miscellaneous/radio.md
@@ -5,7 +5,7 @@
 chance.radio()
 ```
 
-<p class="pullquote" data-pullquote='Broadcast call signs start with a W if east of the Mississippi River and K if west.' markdown="1"></p>
+<p class="pullquote" data-pullquote='Broadcast call signs start with a W if East of the Mississippi River and K if West.' markdown="1"></p>
 
 Generate a random radio call sign.
 
@@ -19,9 +19,9 @@ Optionally specify a side of the Mississippi River to limit stations to that sid
 See [K and W](http://en.wikipedia.org/wiki/Call_signs_in_North_America#K_and_W) for more details
 
 ```js
-chance.radio({side: 'east'});
+chance.radio({ side: 'east' });
 => 'WKOQ'
 
-chance.radio({side: 'east'});
+chance.radio({ side: 'east' });
 => 'WNOW'
 ```

--- a/docs/miscellaneous/rpg.md
+++ b/docs/miscellaneous/rpg.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.rpg('#d#')
-chance.rpg('#d#', {sum: true})
+chance.rpg('#d#', { sum: true })
 ```
 
 Given an input looking like #d#, where the first # is the number of dice to

--- a/docs/miscellaneous/tv.md
+++ b/docs/miscellaneous/tv.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.tv()
-chance.tv({side: 'west'})
+chance.tv({ side: 'west' })
 ```
 
 Generate a TV station call sign. This is an alias for `radio()` since they both
@@ -17,9 +17,9 @@ chance.radio();
 Optionally specify a side of the Mississippi River to limit stations to that side.
 
 ```js
-chance.radio({side: 'west'});
+chance.radio({ side: 'west' });
 => 'KCYL'
 
-chance.radio({side: 'west'});
+chance.radio({ side: 'west' });
 => 'KQDV'
 ```

--- a/docs/miscellaneous/unique.md
+++ b/docs/miscellaneous/unique.md
@@ -19,11 +19,11 @@ Optionally specify the comparator used to determine whether a generated item is 
 
 ```js
 chance.unique(chance.currency, 2, {
-comparator: function(arr, val) {
-return arr.reduce(function(acc, item) {
-return acc || (item.code === val.code);
-}, false);
-}
+  comparator: function (arr, val) {
+    return arr.reduce(function (acc, item) {
+      return acc || (item.code === val.code);
+    }, false);
+  }
 });
 => [{ code: "KYF", name: "Cayman Islands Dollar" }, { code: "CDF", name: "Congo/Kinshasa Franc" }]
 ```
@@ -33,7 +33,7 @@ You can also specify any arbitrary options in this third argument and they'll be
 For example, let's say you want to retrieve 10 unique integers between 0 and 100. This is easily achievable by specifying `chance.integer` as hte function, 10 as the number to retrieve, and a min/max in the options.
 
 ```js
-chance.unique(chance.integer, 10, {min: 0, max: 100});
+chance.unique(chance.integer, 10, { min: 0, max: 100 });
 => [78, 49, 7, 87, 59, 89, 84, 62, 60, 63]
 ```
 
@@ -43,5 +43,3 @@ Note, there could be cases where it is impossible to generate the unique number.
 chance.unique(chance.state, 55);
 => RangeError: Chance: num is likely too large for sample set
 ```
-
-

--- a/docs/miscellaneous/weighted.md
+++ b/docs/miscellaneous/weighted.md
@@ -8,25 +8,21 @@ chance.weighted(['a', 'b', 'c', 'd'], [1, 2, 3, 4])
 
 Provide an array of items, and another array of items specifying the relative weights and **Chance** will select one of those items, obeying the specified weight.
 
-For example, the following code:
-
+For example, the following code
 ```js
 chance.weighted(['a', 'b'], [100, 1]);
 => 'a'
 ```
-
-Will generate `'a'` 100 times more often than `'b'` but still choose one or the other randomly.
+will generate `'a'` 100 times more often than `'b'` but still choose one or the other randomly.
 
 The weights are all relative, so if you have more than just two it will ensure that all items are generated relative to all of the weights.
 
-For example, the following code:
-
+For example, the following code
 ```js
 chance.weighted(['a', 'b', 'c', 'd'], [1, 2, 3, 4]);
 => 'c'
 ```
-
-Will generate a letter from the array but will pick `'b'` twice as often as it picks `'a'` and will pick `'c'` three times as often as it picks `'a'` and will pick `'d'` four times as often as it will pick `'a'` and will pick `'d'` two times as often as it will pick `'b'`.
+will generate a letter from the array but will pick `'b'` twice as often as it picks `'a'` and will pick `'c'` three times as often as it picks `'a'` and will pick `'d'` four times as often as it will pick `'a'` and will pick `'d'` two times as often as it will pick `'b'`.
 
 The weights can be whole numbers as shown above or fractions.
 

--- a/docs/mobile/apple_token.md
+++ b/docs/mobile/apple_token.md
@@ -5,7 +5,7 @@
 chance.apple_token()
 ```
 
-Return a random Apple Push Token
+Return a random Apple Push Token.
 
 ```js
 chance.apple_token()

--- a/docs/mobile/bb_pin.md
+++ b/docs/mobile/bb_pin.md
@@ -5,7 +5,7 @@
 chance.bb_pin()
 ```
 
-Return a random BlackBerry Device PIN
+Return a random BlackBerry Device PIN.
 
 ```js
 chance.bb_pin()

--- a/docs/mobile/wp7_anid.md
+++ b/docs/mobile/wp7_anid.md
@@ -5,7 +5,7 @@
 chance.wp7_anid()
 ```
 
-Return a random Windows Phone 7 ANID
+Return a random Windows Phone 7 ANID.
 
 ```js
 chance.wp7_anid()

--- a/docs/mobile/wp8_anid2.md
+++ b/docs/mobile/wp8_anid2.md
@@ -5,7 +5,7 @@
 chance.wp8_anid2()
 ```
 
-Return a random Windows Phone 8 ANID2
+Return a random Windows Phone 8 ANID2.
 
 ```js
 chance.wp8_anid2()

--- a/docs/music/note.md
+++ b/docs/music/note.md
@@ -25,9 +25,9 @@ naturals - just natural notes
 all - naturals, sharps and flats
 
 ```js
-chance.note({notes: 'flats' });
+chance.note({ notes: 'flats' });
 => 'A'
 
-chance.note({notes: 'sharps' });
+chance.note({ notes: 'sharps' });
 => 'F♯'
 ```

--- a/docs/music/tempo.md
+++ b/docs/music/tempo.md
@@ -2,7 +2,7 @@
 
 ```js
 // usage
-chance.tempo(); //default between 40 to 320
+chance.tempo(); // default between 40 to 320
 chance.tempo({ min: 60, max: 120 });
 ```
 
@@ -20,5 +20,4 @@ chance.tempo({ max: 80 });
 
 chance.tempo({ min: 120 });
 => 172
-
 ```

--- a/docs/person/aadhar.md
+++ b/docs/person/aadhar.md
@@ -16,14 +16,14 @@ chance.aadhar();
 => '8506 7820 9696'
 ```
 
-Optionally provide option of getting only the last four
+Optionally provide option of getting only the last four digits.
 
 ```js
 chance.aadhar({ onlyLastFour: true });
 => '1851'
 ```
 
-Optionally specify dashes be removed
+Optionally specify separators be removed.
 
 ```js
 chance.aadhar({ separatedByWhiteSpace: false });

--- a/docs/person/age.md
+++ b/docs/person/age.md
@@ -6,20 +6,20 @@ chance.age()
 chance.age({ type: 'child' })
 ```
 
-Generate a random age
+Generate a random age.
 
 ```js
 chance.age();
 => 45
 ```
 
-Default range is between 1 and 120
+Default range is between 18 and 65.
 
-Optionally specify one of a handful of enumerated age types:
+Optionally specify one of a handful of enumerated age types.
 
 ```js
-chance.age({type: 'child'});
+chance.age({ type: 'child' });
 => 9
 ```
 
-Allowed types are: `child`, `teen`, `adult`, `senior`
+Allowed types are: `child` (0-12), `teen` (13-19), `adult` (18-65), `senior` (65-100) and `all` (0-100).

--- a/docs/person/birthday.md
+++ b/docs/person/birthday.md
@@ -19,7 +19,7 @@ By default, returns an actual JavaScript [Date][Date] object.
 Optionally specify it be returned as a string.
 
 ```js
-chance.birthday({string: true});
+chance.birthday({ string: true });
 => '4/1/1968'
 ```
 
@@ -35,7 +35,7 @@ For more complex date formats, use the [Moment][Moment] library.
 Can also specify the type, same types as with [age](#age).
 
 ```js
-chance.birthday({type: 'child'});
+chance.birthday({ type: 'child' });
 => Sat Sep 08 2001 00:00:00 GMT-0400 (EDT)
 ```
 

--- a/docs/person/cf.md
+++ b/docs/person/cf.md
@@ -14,10 +14,10 @@ chance.cf();
 Optionally specify any or all components: first name, last name, gender, birth date, place of birth (using ISTAT geocodes for Italian cities).
 
 ```js
-chance.cf({first: 'Sergio', last: 'Leone'});
+chance.cf({ first: 'Sergio', last: 'Leone' });
 => 'LNESRG93P28F067V'
 
-chance.cf({first: 'Sophia', last: 'Loren', gender: 'Female', birthday: new Date(1934,8,20), city: 'h501'});
+chance.cf({ first: 'Sophia', last: 'Loren', gender: 'Female', birthday: new Date(1934,8,20), city: 'h501 '});
 
 => 'LRNSPH34P60H501G'
 ```

--- a/docs/person/first.md
+++ b/docs/person/first.md
@@ -6,26 +6,25 @@ chance.first()
 chance.first({ nationality: 'en' })
 ```
 
-Generate a random first name
+Generate a random first name.
 
 ```js
 Chance.first();
 => 'Leila'
 ```
 
-Optionally specify a gender to limit first names to that gender
+Optionally specify a gender to limit first names to that gender.
 
 ```js
-Chance.first({ gender: "female" });
+Chance.first({ gender: 'female' });
 => 'Emma'
 ```
 
 Optionally specify a nationality to limit first names to those most common of that nationality
 
 ```js
-Chance.first({ nationality: "it" });
+Chance.first({ nationality: 'it' });
 => 'Alberto'
 ```
 
 Note, currently support for nationality is limited to: `'en', 'it', 'nl', 'fr'`.
-

--- a/docs/person/gender.md
+++ b/docs/person/gender.md
@@ -5,14 +5,14 @@
 chance.gender()
 ```
 
-Generate a random gender
+Generate a random gender.
 
 ```js
   Chance.gender();
   => 'Female'
 ```
 
-Extra genders can be provided using the `extraGenders` key in the optional options argument:
+Extra genders can be provided using the `extraGenders` key in the optional options argument.
 
 ```js
   Chance.gender({

--- a/docs/person/last.md
+++ b/docs/person/last.md
@@ -6,7 +6,7 @@ chance.last()
 chance.last({ nationality: 'en' })
 ```
 
-Generate a random last name
+Generate a random last name.
 
 ```js
 Chance.last();

--- a/docs/person/name.md
+++ b/docs/person/name.md
@@ -16,43 +16,42 @@ Generate a random name
   => 'Dafi Vatemi'
 ```
 
-Optionally include the middle name
+Optionally include the middle name.
 
 ```js
   chance.name({ middle: true });
   => 'Nelgatwu Powuku Heup'
 ```
 
-
-Optionally include the middle initial
+Optionally include the middle initial.
 
 ```js
   chance.name({ middle_initial: true });
   => 'Ezme I Iza'
 ```
 
-Optionally include the prefix
+Optionally include the prefix.
 
 ```js
   chance.name({ prefix: true });
   => 'Doctor Suosat Am'
 ```
 
-Optionally include the suffix
+Optionally include the suffix.
 
 ```js
   chance.name({ suffix: true });
   => 'Fanny Baker Esq.'
 ```
 
-Optionally specify a gender
+Optionally specify a gender.
 
 ```js
   chance.name({ gender: 'male' });
   => "Patrick Copeland"
 ```
 
-Optionally specify a nationality
+Optionally specify a nationality.
 
 ```js
   chance.name({ nationality: 'it' });
@@ -60,4 +59,3 @@ Optionally specify a nationality
 ```
 
 Note, currently support for nationality is limited to: `'en', 'it'`.
-

--- a/docs/person/ssn.md
+++ b/docs/person/ssn.md
@@ -7,21 +7,21 @@ chance.ssn({ ssnFour: true })
 chance.ssn({ dashes: false })
 ```
 
-Generate a random social security number.
+Generate a random U.S. social security number.
 
 ```js
 chance.ssn();
 => '411-90-0070'
 ```
 
-Optionally provide option of getting only the last four
+Optionally provide option of getting only the last four digits.
 
 ```js
 chance.ssn({ ssnFour: true });
 => '2938'
 ```
 
-Optionally specify dashes be removed
+Optionally specify dashes be removed.
 
 ```js
 chance.ssn({ dashes: false });

--- a/docs/person/suffix.md
+++ b/docs/person/suffix.md
@@ -6,7 +6,7 @@ chance.suffix()
 chance.suffix({ full: true })
 ```
 
-Generate a random name suffix
+Generate a random name suffix.
 
 ```js
 chance.suffix();

--- a/docs/text/syllable.md
+++ b/docs/text/syllable.md
@@ -5,7 +5,7 @@
 chance.syllable()
 ```
 
-Return a semi-speakable syllable, 2 or 3 letters
+Return a semi-speakable syllable, 2 or 3 letters.
 
 ```js
 chance.syllable();

--- a/docs/thing/animal.md
+++ b/docs/thing/animal.md
@@ -3,10 +3,10 @@
 ```js
 // usage
 chance.animal()
-chance.animal({type: 'zoo'})
+chance.animal({ type: 'zoo' })
 ```
 
-Generate a random animal
+Generate a random animal.
 
 ```js
 chance.animal();
@@ -15,11 +15,11 @@ chance.animal();
 
 Default is any type of animal.
 
-Optionally specify a specific type of animal
+Optionally specify a specific type of animal.
 
 ```js
-chance.animal({type: 'zoo'});
+chance.animal({ type: 'zoo' });
 => 'Lion'
 ```
 
-Allowed types are: `ocean`, `desert`, `grassland`, `forest`, `farm`, `pet`, and `zoo`
+Allowed types are: `ocean`, `desert`, `grassland`, `forest`, `farm`, `pet`, and `zoo`.

--- a/docs/time/date.md
+++ b/docs/time/date.md
@@ -8,19 +8,19 @@ chance.date({string: true, american: false})
 chance.date({year: 1983})
 ```
 
-Generate a random date
+Generate a random date.
 
 ```js
 chance.date();
 => Sat Apr 09 2072 00:00:00 GMT-0400 (EDT)
 ```
 
-By default, returns an actual [Date][Date] object
+By default, returns an actual [Date][Date] object.
 
-Can optionally specify that a date be returned as a string
+Can optionally specify that a date be returned as a string.
 
 ```js
-chance.date({string: true});
+chance.date({ string: true });
 => "5/27/2078"
 ```
 
@@ -35,7 +35,7 @@ However, we support returning dates in DD/MM/YYYY format as well when requesting
 a date by a string and passing `american: false`.
 
 ```js
-chance.date({string: true, american: false});
+chance.date({ string: true, american: false });
 => "13/2/2017"
 ```
 
@@ -46,21 +46,20 @@ core competency to offer dates in a myriad of formats.
 Can optionally specify defaults for any of day, month, or year.
 
 ```js
-chance.date({year: 1983});
+chance.date({ year: 1983 });
 => Wed May 04 1983 00:00:00 GMT-0400 (EDT)
 
-chance.date({month: 0});
+chance.date({ month: 0 });
 => Tue Jan 18 2084 00:00:00 GMT-0500 (EST)
 
-chance.date({day: 21});
+chance.date({ day: 21 });
 => Sun Oct 21 2103 00:00:00 GMT-0400 (EDT)
 ```
 
 A random date is generated, but the default you specify is kept constant.
 
 Note, month is 0-indexed. This is a carryover from the core JavaScript
-[Date][Date] object which we use internally to generate the date. We
-considered
+[Date][Date] object which we use internally to generate the date.
 
 [Date]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
 [FB]: https://developers.facebook.com/docs/reference/api/user/

--- a/docs/time/hour.md
+++ b/docs/time/hour.md
@@ -3,10 +3,10 @@
 ```js
 // usage
 chance.hour()
-chance.hour({twentyfour: true})
+chance.hour({ twentyfour: true })
 ```
 
-Generate a random hour
+Generate a random hour.
 
 ```js
 chance.hour();
@@ -15,10 +15,10 @@ chance.hour();
 
 By default, returns an hour from 1 to 12 for a standard [12-hour clock][12h].
 
-Can optionally specify a full twenty-four.
+Can optionally specify a full twenty-four hour.
 
 ```js
-chance.hour({twentyfour: true});
+chance.hour({ twentyfour: true });
 => 21
 ```
 

--- a/docs/time/millisecond.md
+++ b/docs/time/millisecond.md
@@ -5,7 +5,7 @@
 chance.millisecond()
 ```
 
-Generate a random millisecond
+Generate a random millisecond.
 
 ```js
 chance.millisecond();

--- a/docs/time/minute.md
+++ b/docs/time/minute.md
@@ -5,7 +5,7 @@
 chance.minute()
 ```
 
-Generate a random minute
+Generate a random minute.
 
 ```js
 chance.minute();

--- a/docs/time/month.md
+++ b/docs/time/month.md
@@ -18,6 +18,6 @@ Optionally specify raw to get the whole month object consisting of name,
 short_name, and numeric.
 
 ```js
-chance.month({raw: true});
-=> {name: 'October', short_name: 'Oct', numeric: '10'}
+chance.month({ raw: true });
+=> { name: 'October', short_name: 'Oct', numeric: '10' }
 ```

--- a/docs/time/second.md
+++ b/docs/time/second.md
@@ -5,7 +5,7 @@
 chance.second()
 ```
 
-Generate a random second
+Generate a random second.
 
 ```js
 chance.second();

--- a/docs/time/timezone.md
+++ b/docs/time/timezone.md
@@ -5,7 +5,7 @@
 chance.timezone()
 ```
 
-Return a random timezone
+Return a random timezone.
 
 ```js
 chance.timezone();

--- a/docs/time/weekday.md
+++ b/docs/time/weekday.md
@@ -3,10 +3,10 @@
 ```js
 // usage
 chance.weekday()
-chance.weekday({weekday_only: true})
+chance.weekday({ weekday_only: true })
 ```
 
-Return a weekday
+Return a weekday.
 
 ```js
 chance.weekday();

--- a/docs/time/year.md
+++ b/docs/time/year.md
@@ -6,7 +6,7 @@ chance.year()
 chance.year({min: 1900, max: 2100})
 ```
 
-Generate a random year
+Generate a random year.
 
 ```js
 chance.year();
@@ -26,6 +26,6 @@ parseInt(chance.year());
 Optionally specify min, max, or both to limit the range.
 
 ```js
-chance.year({min: 1900, max: 2100});
+chance.year({ min: 1900, max: 2100 });
 => '1983'
 ```

--- a/docs/usage/function.md
+++ b/docs/usage/function.md
@@ -4,7 +4,7 @@ Instead of providing a seed, which will be used to seed our [Mersenne Twister](h
 you can also specify an arbitrary function to generate random numbers which the
 rest of the library will utilize when generating everything else.
 
-A rather simple example, simply using Math.random() instead of our Mersenne Twister
+A rather simple example, simply using `Math.random()` instead of our Mersenne Twister
 
 ```js
 // Use Math.random() instead of our Mersenne Twister
@@ -12,7 +12,7 @@ var chance = new Chance(Math.random);
 
 chance.address()
 => '131 Asmun Pike'
-chance.address() 
+chance.address()
 => '261 Pawnaf Highway'
 ```
 

--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -1,12 +1,12 @@
 # node
 
-It can also be used in [Node.js](http://nodejs.org)
+It can also be used in [Node.js](http://nodejs.org).
 
 ```bash
 npm install chance
 ```
 
-then in your app
+then in your app:
 
 ```js
 // Load Chance
@@ -20,7 +20,7 @@ var my_random_string = chance.string();
 ```
 
 As of version 0.5.5, the following is also offered as a convenience for getting
-an instance of Chance
+an instance of Chance.
 
 ```js
 // Load and instantiate Chance

--- a/docs/usage/requirejs.md
+++ b/docs/usage/requirejs.md
@@ -1,9 +1,9 @@
 # requirejs
 
-Load Chance with <a href="http://requirejs.org">RequireJS</a>
+Load Chance with <a href="http://requirejs.org">RequireJS</a>.
 
 ```js
-  require(['Chance'], function(Chance) {
+  require(['Chance'], function (Chance) {
     // Instantiate
     var chance = new Chance();
 

--- a/docs/web/avatar.md
+++ b/docs/web/avatar.md
@@ -3,9 +3,9 @@
 ```js
 // usage
 chance.avatar()
-chance.avatar({protocol: 'https'})
-chance.avatar({fileExtension: 'jpg'})
-chance.avatar({email: 'mail@victorquinn.com'})
+chance.avatar({ protocol: 'https' })
+chance.avatar({ fileExtension: 'jpg' })
+chance.avatar({ email: 'mail@victorquinn.com' })
 ```
 
 Return a URL to a random avatar from Gravatar.
@@ -15,15 +15,15 @@ chance.avatar()
 => '//www.gravatar.com/avatar/41f84bab4a852971eb1d26a287acb763'
 ```
 
-By default, a url is returned without a protocol. Specify one to get a random
-url but with a known protocol
+By default, a URL is returned without a protocol. Specify one to get a random
+url but with a known protocol.
 
 ```js
-chance.avatar({protocol: 'https'})
+chance.avatar({ protocol: 'https' })
 => 'https://www.gravatar.com/avatar/f40260c4058cc904b7db652c26099966'
 ```
 
-Optionally specify a file extension to get one of a known type
+Optionally specify a file extension to get one of a known type.
 
 ```js
 chance.avatar({fileExtension: 'jpg'})
@@ -33,10 +33,9 @@ chance.avatar({fileExtension: 'jpg'})
 You can also use it with a known email address to just get that gravatar.
 
 However, note this, of course, no longer makes it random, just more of a helper
-function:
+function.
 
 ```js
 chance.avatar({email: 'mail@victorquinn.com'})
 => 'www.gravatar.com/avatar/8595c2591b0bca22e736813af33fa7c3'
 ```
-

--- a/docs/web/color.md
+++ b/docs/web/color.md
@@ -3,9 +3,9 @@
 ```js
 // usage
 chance.color()
-chance.color({format: 'hex'})
-chance.color({grayscale: true})
-chance.color({casing: 'upper'})
+chance.color({ format: 'hex' })
+chance.color({ grayscale: true })
+chance.color({c asing: 'upper' })
 ```
 
 Return a random color.
@@ -20,29 +20,29 @@ Colors have four base types: `hex`, `shorthex`, `rgb`, `0x`
 These are the kinds usable in HTML or CSS. The type can optionally be specified
 
 ```js
-chance.color({format: 'hex'})
+chance.color({ format: 'hex' })
 => '#d67118'
 
-chance.color({format: 'shorthex'})
+chance.color({ format: 'shorthex' })
 => '#60f'
 
-chance.color({format: 'rgb'})
+chance.color({ format: 'rgb' })
 => 'rgb(110,52,164)'
 
-chance.color({format: '0x'})
+chance.color({ format: '0x' })
 => '0x67ae0b'
 ```
 
-Can optionally specify that only grayscale colors be generated
+Can optionally specify that only grayscale colors be generated.
 
 ```js
-chance.color({grayscale: true})
+chance.color({ grayscale: true })
 => '#e2e2e2'
 ```
 
-Optionally specify casing to get only uppercase letters in the color
+Optionally specify casing to get only uppercase letters in the color.
 
 ```js
-chance.color({casing: 'upper'})
+chance.color({ casing: 'upper' })
 => '#29CFA7'
 ```

--- a/docs/web/domain.md
+++ b/docs/web/domain.md
@@ -3,20 +3,19 @@
 ```js
 // usage
 chance.domain()
-chance.domain({tld: 'com'})
+chance.domain({ tld: 'com' })
 ```
 
-Return a random domain with a random [tld](#tld).
+Return a random domain with a random [TLD](#tld).
 
 ```js
 chance.domain()
 => 'onaro.net'
 ```
 
-Optionally specify a tld and the domain will be random but the tld will not.
+Optionally specify a TLD and the domain will be random but the TLD will not.
 
 ```js
-chance.domain({tld: 'ie'})
+chance.domain({ tld: 'ie' })
 => 'gotaujo.ie'
 ```
-

--- a/docs/web/email.md
+++ b/docs/web/email.md
@@ -3,7 +3,7 @@
 ```js
 // usage
 chance.email()
-chance.email({domain: "example.com"})
+chance.email({ domain: "example.com" })
 ```
 
 Return a random email with a random domain.

--- a/docs/web/google_analytics.md
+++ b/docs/web/google_analytics.md
@@ -5,7 +5,7 @@
 chance.google_analytics()
 ```
 
-Return a random [Google Analytics](https://support.google.com/analytics/answer/1032385?hl=en) tracking code. Takes the form `'UA-123456-01'`
+Return a random [Google Analytics](https://support.google.com/analytics/answer/1032385?hl=en) tracking code. Takes the form `'UA-123456-01'`.
 
 ```js
 chance.google_analytics()

--- a/docs/web/tld.md
+++ b/docs/web/tld.md
@@ -5,7 +5,7 @@
 chance.tld()
 ```
 
-Return a random tld ([Top Level Domain][tld]) from the set:
+Return a random TLD ([Top Level Domain][tld]) from the set:
 
 ```js
 ['com', 'org', 'edu', 'gov', 'uk', 'net', 'io']

--- a/docs/web/url.md
+++ b/docs/web/url.md
@@ -3,51 +3,51 @@
 ```js
 // usage
 chance.url()
-chance.url({protocol: 'ftp'})
-chance.url({domain: 'www.socialradar.com'})
-chance.url({domain_prefix: 'docs'})
-chance.url({path: 'images'})
-chance.url({extensions: ['gif', 'jpg', 'png']})
+chance.url({ protocol: 'ftp' })
+chance.url({ domain: 'www.socialradar.com' })
+chance.url({ domain_prefix: 'docs' })
+chance.url({ path: 'images' })
+chance.url({ extensions: ['gif', 'jpg', 'png'] })
 ```
 
-Return a random url.
+Return a random URL.
 
 ```js
 chance.url()
 => 'http://vanogsi.io/pateliivi'
 ```
 
-Optionally specify a protocol and the url will be random but the protocol will not.
+Optionally specify a protocol and the URL will be random but the protocol will not.
 
 ```js
-chance.url({protocol: 'ftp'})
+chance.url({ protocol: 'ftp' })
 => 'ftp://mibfu.nr/kardate'
 ```
 
-Optionally specify a domain and the url will be random but the domain will not.
+Optionally specify a domain and the URL will be random but the domain will not.
 
 ```js
-chance.url({domain: 'www.socialradar.com'})
+chance.url({ domain: 'www.socialradar.com' })
 => 'http://www.socialradar.com/hob'
 ```
 
 Optionally specify a domain prefix and domain will be random, and domain prefix will not.
 
 ```js
-chance.url({domain_prefix: 'docs'})
+chance.url({ domain_prefix: 'docs' })
 => 'http://docs.tuos.ni/itecabup'
 ```
 
 Optionally specify a path and it will be obeyed.
 
 ```js
-chance.url({path: 'images'})
+chance.url({ path: 'images' })
 => 'http://tainvoz.net/images'
 ```
 
 Optionally specify an array of extensions and one will be picked at random.
 
 ```js
-chance.url({extensions: ['gif', 'jpg', 'png']})
+chance.url({ extensions: ['gif', 'jpg', 'png'] })
 => 'http://vagjiup.gov/udmopke.png'
 ```

--- a/test/test.animal.js
+++ b/test/test.animal.js
@@ -35,6 +35,6 @@ test('throws an error if the type is not part of the animals object', t => {
     const fn = () => chance.animal({
       type: "banana"
     })
-    t.throws(fn, "Please pick from desert, ocean, grassland, forest, zoo, pets, farm.")
+    t.throws(fn, "Chance: Please pick from desert, forest, ocean, zoo, farm, pet, grassland.")
   })
 })

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -198,12 +198,12 @@ test('floating() can take both a max and min and obey them both', t => {
 
 test('floating() will not take fixed + min that would be out of range', t => {
     const fn = () => chance.floating({ fixed: 13, min: -9007199254740992 })
-    t.throws(fn, "Chance: Min specified is out of range with fixed. Min should be, at least, -900.7199254740992")
+    t.throws(fn, "Chance: Min is out of range with fixed. Min should be, at least, -900.7199254740992")
 })
 
 test('floating() will not take fixed + max that would be out of range', t => {
     const fn = () => chance.floating({ fixed: 13, max: 9007199254740992 })
-    t.throws(fn, "Chance: Max specified is out of range with fixed. Max should be, at most, 900.7199254740992")
+    t.throws(fn, "Chance: Max is out of range with fixed. Max should be, at most, 900.7199254740992")
 })
 
 test('floating() obeys the fixed parameter, when present', t => {


### PR DESCRIPTION
Like no spaces inside soft braces (seemed the initial/base/majority),
except in doc, where the reverse was the majority.
Fixing indentation (very long lists less indented for saving space).
Uniformize error messages.
Spaces around operators.
Else on previous closing soft brace.
Etc.
Didn't try to uniformize quotes, though.
Manual fixes, some stuff might have been missed.