### PR TITLE
:bug: Fix string issue with zero length.

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -414,7 +414,7 @@
     Chance.prototype.string = function (options) {
         options = initOptions(options, { min: 5, max: 20 });
 
-        if (!options.length) {
+        if (options.length !== 0 && !options.length) {
             options.length = this.natural({ min: options.min, max: options.max })
         }
 

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -516,6 +516,10 @@ test('string() can take just a max and obey it', t => {
     })
 })
 
+test('string() returns an empty string with zero length', t => {
+    t.is(chance.string({length: 0}), '')
+})
+
 test('falsy() should return a falsy value', t => {
     _.times(1000, () => {
         const value = chance.falsy()


### PR DESCRIPTION
Previously, when passing zero length in the string as an option, it would generate a random length since zero is a falsy value. However, now, it will check if the length is zero, and returns an empty string with zero length.

Fixes: #537