### PR TITLE
chance.birthday() is giving a second rounded date

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -932,8 +932,27 @@
             });
         }
 
+        if (options.hasMilliseconds === false) {
+            console.log(this.formatDateNoMilliseconds(this.date(options)))
+            return 'ASd'
+        } 
+
         return this.date(options);
     };
+
+    Chance.prototype.formatDateNoMilliseconds = function (options) {
+        const year = options.getFullYear();
+        const month = this.padTo2Digits(options.getMonth() + 1);
+        const day = this.padTo2Digits(options.getDate());
+        const hour = this.padTo2Digits(options.getHours());
+        const minute = this.padTo2Digits(options.getMinutes());
+        const second = this.padTo2Digits(options.getSeconds());
+        return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
+    }
+
+    Chance.prototype.padTo2Digits = function (options) {
+        return options > 9 ? `${options}` : `0${options}`;
+    }
 
     // CPF; ID to identify taxpayers in Brazil
     Chance.prototype.cpf = function (options) {

--- a/chance.js
+++ b/chance.js
@@ -932,15 +932,14 @@
             });
         }
 
-        if (options.hasMilliseconds === false) {
-            console.log(this.formatDateNoMilliseconds(this.date(options)))
-            return 'ASd'
+        if (options.roundSeconds === true) {
+            return this.formatDateRoundSeconds(this.date(options));
         } 
 
         return this.date(options);
     };
 
-    Chance.prototype.formatDateNoMilliseconds = function (options) {
+    Chance.prototype.formatDateRoundSeconds = function (options) {
         const year = options.getFullYear();
         const month = this.padTo2Digits(options.getMonth() + 1);
         const day = this.padTo2Digits(options.getDate());

--- a/docs/person/birthday.md
+++ b/docs/person/birthday.md
@@ -5,6 +5,7 @@
 chance.birthday()
 chance.birthday({ string: true })
 chance.birthday({ type: 'child' })
+chance.birthday({ hasMilliseconds: false })
 ```
 
 Generate a random birthday
@@ -28,6 +29,13 @@ By default returns in MM/DD/YYYY format. Can specify DD/MM/YYYY as follows:
 ```js
 chance.birthday({string: true, american: false});
 => '28/6/1993'
+```
+
+If you want a response with no milliseconds you can specify this parameter as a flag, it is useful if you want to save this date as a string on a database:
+
+```js
+chance.birthday({hasMilliseconds: false});
+=> '1963-01-04T07:33:47'
 ```
 
 For more complex date formats, use the [Moment][Moment] library.

--- a/docs/person/birthday.md
+++ b/docs/person/birthday.md
@@ -31,10 +31,10 @@ chance.birthday({string: true, american: false});
 => '28/6/1993'
 ```
 
-If you want a response with no milliseconds you can specify this parameter as a flag, it is useful if you want to save this date as a string on a database:
+If you want a response with seconds rounded, without milliseconds you can specify this parameter as a flag, it is useful if you want to save this date as a string on a database:
 
 ```js
-chance.birthday({hasMilliseconds: false});
+chance.birthday({roundSeconds: true});
 => '1963-01-04T07:33:47'
 ```
 

--- a/test/test.person.js
+++ b/test/test.person.js
@@ -142,9 +142,10 @@ test('birthday() can have an age range specified for a senior', t => {
 
 test('birthday() can return a date as a string without milliseconds', t => {
     _.times(1000, () => {
-        let birthday = chance.birthday({ hasMilliseconds: false })
+        let birthday = chance.birthday({ roundSeconds: true })
         t.true(_.isString(birthday))
         t.false(_.isDate(birthday))
+        t.true(/^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])T([01]?\d|2[0-3]):([0-5]?\d):([0-5]?\d)$/m.test(birthday))
     })
 })
 

--- a/test/test.person.js
+++ b/test/test.person.js
@@ -140,6 +140,14 @@ test('birthday() can have an age range specified for a senior', t => {
     })
 })
 
+test('birthday() can return a date as a string without milliseconds', t => {
+    _.times(1000, () => {
+        let birthday = chance.birthday({ hasMilliseconds: false })
+        t.true(_.isString(birthday))
+        t.false(_.isDate(birthday))
+    })
+})
+
 // chance.cnpj()
 test('cnpj() returns a random cnpj', t => {
     _.times(1000, () => {


### PR DESCRIPTION
This PR follows the suggest in [#539](https://github.com/chancejs/chancejs/pull/539). 

In a nutshell, set a parameter in the .birthday function that returns the date from '1989-10-11T00:38:03.072' (this is what it is currently returning) to '1989-10-11T00:38:03' omitting the milliseconds for some validations in inserts in some databases.