### PR TITLE
Add license plate generator

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -7442,6 +7442,51 @@ options,
         return this.pick(this.get("emotions"));
     };
 
+    // License Plate
+    Chance.prototype.license_plate = function (options) {
+        options = initOptions(options, {pattern: "LLLNLNN"});
+
+        testRange(
+            typeof options.pattern !== 'string',
+            "Chance: Pattern must be a string"
+        );
+
+        var digits = options.pattern
+            .toUpperCase()
+            .split("")
+
+        testRange(
+            !digits.every((c) => ["L", "N", " ", "-"].includes(c)),
+            "Chance: Pattern accepts only 'N' for numbers, 'L' for letters. Case does not matter. Spaces or hyphens will be kept."
+        );
+
+        var number_of_letters = digits.filter((c) => c === "L").length
+        var number_of_numbers = digits.filter((c) => c === "N").length
+
+        if (!number_of_letters && !number_of_numbers) {
+            return ""
+        }
+
+        var letters = this.n(this.letter, number_of_letters, {casing: "upper"})
+        var numbers = this.n(this.natural, number_of_numbers, {max: 9})
+
+        let number_index = 0
+        let letter_index = 0
+
+        return digits
+            .map((d) => {
+                switch (d) {
+                    case "L":
+                        return letters[letter_index++]
+                    case "N":
+                        return numbers[number_index++]
+                    default:
+                        return d
+                }
+            })
+            .join("")
+    };
+
     // -- End Miscellaneous --
 
     Chance.prototype.mersenne_twister = function (seed) {

--- a/docs/chance.js
+++ b/docs/chance.js
@@ -486,8 +486,8 @@
         }
         if (!count || count === 1) {
             return [ this.pickone(arr) ];
-	}		
-	return this.shuffle(arr).slice(0, count);        
+	}
+	return this.shuffle(arr).slice(0, count);
     };
 
     Chance.prototype.shuffle = function (arr) {
@@ -2491,7 +2491,7 @@
     };
 
     var data = {
-     
+
 
 
         firstNames: {
@@ -6847,7 +6847,7 @@
              "Joy",
              "Surprise",
              "Anger",
-             "Sadness", 
+             "Sadness",
              "Fear"
         ],
     };
@@ -7031,6 +7031,51 @@
 
     Chance.prototype.emotion = function () {
         return this.pick(this.get("emotions"));
+    };
+
+    // License Plate
+    Chance.prototype.license_plate = function (options) {
+        options = initOptions(options, {pattern: "LLLNLNN"});
+
+        testRange(
+            typeof options.pattern !== 'string',
+            "Chance: Pattern must be a string"
+        );
+
+        var digits = options.pattern
+            .toUpperCase()
+            .split("")
+
+        testRange(
+            !digits.every((c) => ["L", "N", " ", "-"].includes(c)),
+            "Chance: Pattern accepts only 'N' for numbers, 'L' for letters. Case does not matter. Spaces or hyphens will be kept."
+        );
+
+        var number_of_letters = digits.filter((c) => c === "L").length
+        var number_of_numbers = digits.filter((c) => c === "N").length
+
+        if (!number_of_letters && !number_of_numbers) {
+            return ""
+        }
+
+        var letters = this.n(this.letter, number_of_letters, {casing: "upper"})
+        var numbers = this.n(this.natural, number_of_numbers, {max: 9})
+
+        let number_index = 0
+        let letter_index = 0
+
+        return digits
+            .map((d) => {
+                switch (d) {
+                    case "L":
+                        return letters[letter_index++]
+                    case "N":
+                        return numbers[number_index++]
+                    default:
+                        return d
+                }
+            })
+            .join("")
     };
 
     // -- End Miscellaneous --

--- a/docs/miscellaneous/license_plate.md
+++ b/docs/miscellaneous/license_plate.md
@@ -1,0 +1,30 @@
+# license plate
+
+```js
+// usage
+chance.license_plate()
+chance.license_plate({pattern: "LLLNLNN"})
+chance.license_plate({pattern: "LLL NNNN-LNL"})
+```
+
+Returns a random vehicle license plate that matches the pattern, where 'L' stands for letter and 'N' for number.
+
+```js
+chance.license_plate({pattern: "LLLNLNN"})
+=> "ITL 8M86"
+```
+
+```js
+chance.license_plate({pattern: "LLL NNNN-LNL"})
+=> "EPR 0331-D5N"
+```
+
+- Does not matter the patterns characters case.
+- Only spaces and hyphens will be kept. All others character will be removed.
+- Pattern must be a string.
+- Default pattern is "LLLNLNN" (Brazil Mercosur Pattern)
+
+```js
+chance.license_plate({pattern: "LlL-NnNXN9"})
+=> "OHD-4916"
+```

--- a/test/test.misc.js
+++ b/test/test.misc.js
@@ -296,3 +296,40 @@ test('tv() works as expected', t => {
         t.true(/^[KW][A-Z][A-Z][A-Z]/.test(tv))
     })
 })
+
+
+// chance.license_plate()
+test('license_plate() returns a random Brazilian valid license plate by default', t => {
+    _.times(1000, () => {
+        let plate = chance.license_plate()
+        t.true(_.isString(plate))
+        t.true(/^\S{3}\d\S\d{2}$/m.test(plate))
+        t.is(plate.length, 7)
+    })
+})
+
+test('license_plate() returns a random valid license plate that match the pattern', t => {
+    _.times(1000, () => {
+        let plate = chance.license_plate({pattern: "LLL NNNN-LNL"})
+        t.true(_.isString(plate))
+        t.true(/^\S{3}\s\d{4}-\S\d\S$/m.test(plate))
+        t.is(plate.length, 12)
+    })
+})
+
+test('license_plate() throws errors where it should', t => {
+    const errorFns = [
+        () => chance.license_plate({pattern: 3}),
+        () => chance.license_plate({pattern: [1,2,3]}),
+        () => chance.license_plate({pattern: 1.2}),
+        () => chance.license_plate({pattern: {}}),
+        () => chance.license_plate({pattern: null}),
+    ]
+    errorFns.map((fn) => {
+        t.throws(fn, 'Chance: Pattern must be a string')
+    })
+})
+
+test('license_plate() throws errors if includes any character regardless case but "N", "L", spaces or hyphens', t => {
+    t.throws(() => chance.license_plate({pattern: "A"}), "Chance: Pattern accepts only 'N' for numbers, 'L' for letters. Case does not matter. Spaces or hyphens will be kept.")
+})


### PR DESCRIPTION
Add license plate generator with an optional pattern string parameter.
Returns a random vehicle license plate that matches the pattern.

Pattern:

- For pattern 'L' stands for a letter and 'N' a for number.
- Does not matter the patterns characters case.
- Only spaces and hyphens will be kept. All others character will be removed.
- Pattern must be a string.
- Default pattern is "LLLNLNN" (Brazil Mercosur Pattern)