### PR TITLE
Add Brazilian Federation Units (states)

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1985,6 +1985,7 @@ options,
                 break;
             case 'it':
             case 'mx':
+            case 'br':
                 states = this.get("country_regions")[options.country.toLowerCase()];
                 break;
             case 'uk':
@@ -4122,6 +4123,35 @@ options,
                 { name: 'Veracruz', abbreviation: 'VER' },
                 { name: 'Yucatán', abbreviation: 'YUC' },
                 { name: 'Zacatecas', abbreviation: 'ZAC' }
+            ],
+            br: [
+                { name: "Espírito Santo", abbreviation: "ES" },
+                { name: "Acre", abbreviation: "AC" },
+                { name: "Alagoas", abbreviation: "AL" },
+                { name: "Amapá", abbreviation: "AP" },
+                { name: "Amazonas", abbreviation: "AM" },
+                { name: "Bahia", abbreviation: "BA" },
+                { name: "Ceará", abbreviation: "CE" },
+                { name: "Distrito Federal", abbreviation: "DF" },
+                { name: "Goiás", abbreviation: "GO" },
+                { name: "Maranhão", abbreviation: "MA" },
+                { name: "Mato Grosso", abbreviation: "MT" },
+                { name: "Mato Grosso do Sul", abbreviation: "MS" },
+                { name: "Minas Gerais", abbreviation: "MG" },
+                { name: "Pará", abbreviation: "PA" },
+                { name: "Paraíba", abbreviation: "PB" },
+                { name: "Paraná", abbreviation: "PR" },
+                { name: "Pernambuco", abbreviation: "PE" },
+                { name: "Piauí", abbreviation: "PI" },
+                { name: "Rio de Janeiro", abbreviation: "RJ" },
+                { name: "Rio Grande do Norte", abbreviation: "RN" },
+                { name: "Rio Grande do Sul", abbreviation: "RS" },
+                { name: "Rondônia", abbreviation: "RO" },
+                { name: "Roraima", abbreviation: "RR" },
+                { name: "Santa Catarina", abbreviation: "SC" },
+                { name: "São Paulo", abbreviation: "SP" },
+                { name: "Sergipe", abbreviation: "SE" },
+                { name: "Tocantins", abbreviation: "TO" },
             ]
         },
 

--- a/docs/location/state.md
+++ b/docs/location/state.md
@@ -8,6 +8,7 @@ chance.state({ territories: true })
 chance.state({ armed_forces: true })
 chance.state({ us_states_and_dc: false })
 chance.state({ country: 'us' })
+chance.state({ country: 'br' })
 ```
 
 Return a random state.

--- a/test/test.address.js
+++ b/test/test.address.js
@@ -90,7 +90,7 @@ test('coordinates() looks right', t => {
 test('coordinates() returns coordinates in DD format as default', t => {
     _.times(1000, () => {
         const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
-        
+
         let coordinates = chance.coordinates()
         let [ latitude, longitude ] = coordinates.split(',')
 
@@ -104,7 +104,7 @@ test('coordinates() returns coordinates in DD format as default', t => {
 test('coordinates() will obey DD format', t => {
     _.times(1000, () => {
         const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
-        
+
         let coordinates = chance.coordinates({format: 'dd'})
         let [ latitude, longitude ] = coordinates.split(',')
 
@@ -119,7 +119,7 @@ test('coordinates() will obey DDM format', t => {
     _.times(1000, () => {
         const CHARS_TO_CONTAIN = ['°']
         const CHARS_NOT_TO_CONTAIN = ['’', '”']
-        
+
         let coordinates = chance.coordinates({format: 'ddm'})
         let [ latitude, longitude ] = coordinates.split(',')
 
@@ -135,7 +135,7 @@ test('coordinates() will obey DDM format', t => {
 test('coordinates() will obey DMS format', t => {
     _.times(1000, () => {
         const CHARS_TO_CONTAIN = ['°', '’', '”']
-        
+
         let coordinates = chance.coordinates({format: 'dms'})
         let [ latitude, longitude ] = coordinates.split(',')
 
@@ -272,7 +272,7 @@ test('latitude() will accept a max and obey it', t => {
 test('latitude() returns latitude in DD format as default', t => {
     _.times(1000, () => {
         const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
-        
+
         let latitude = chance.latitude()
 
         t.is(typeof latitude, 'number')
@@ -283,7 +283,7 @@ test('latitude() returns latitude in DD format as default', t => {
 test('latitude() will obey DD format', t => {
     _.times(1000, () => {
         const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
-        
+
         let latitude = chance.latitude({format: 'dd'})
 
         t.is(typeof latitude, 'number')
@@ -295,7 +295,7 @@ test('latitude() will obey DDM format', t => {
     _.times(1000, () => {
         const CHARS_TO_CONTAIN = ['°']
         const CHARS_NOT_TO_CONTAIN = ['’', '”']
-        
+
         let latitude = chance.latitude({format: 'ddm'})
 
         t.true(_.isString(latitude))
@@ -307,7 +307,7 @@ test('latitude() will obey DDM format', t => {
 test('latitude() will obey DMS format', t => {
     _.times(1000, () => {
         const CHARS_TO_CONTAIN = ['°', '’', '”']
-        
+
         let latitude = chance.latitude({format: 'dms'})
 
         t.true(_.isString(latitude))
@@ -349,7 +349,7 @@ test('longitude() will accept a max and obey it', t => {
 test('longitude() returns longitude in DD format as default', t => {
     _.times(1000, () => {
         const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
-        
+
         let longitude = chance.longitude()
 
         t.is(typeof longitude, 'number')
@@ -360,7 +360,7 @@ test('longitude() returns longitude in DD format as default', t => {
 test('longitude() will obey DD format', t => {
     _.times(1000, () => {
         const CHARS_NOT_TO_CONTAIN = ['°', '’', '”']
-        
+
         let longitude = chance.longitude({format: 'dd'})
 
         t.is(typeof longitude, 'number')
@@ -372,7 +372,7 @@ test('longitude() will obey DDM format', t => {
     _.times(1000, () => {
         const CHARS_TO_CONTAIN = ['°']
         const CHARS_NOT_TO_CONTAIN = ['’', '”']
-        
+
         let longitude = chance.longitude({format: 'ddm'})
 
         t.true(_.isString(longitude))
@@ -384,7 +384,7 @@ test('longitude() will obey DDM format', t => {
 test('longitude() will obey DMS format', t => {
     _.times(1000, () => {
         const CHARS_TO_CONTAIN = ['°', '’', '”']
-        
+
         let longitude = chance.longitude({format: 'dms'})
 
         t.true(_.isString(longitude))
@@ -604,6 +604,10 @@ test('state() can take a country and return a state', t => {
     _.times(1000, () => t.true(chance.state({ country: 'it' }).length === 3))
 })
 
+test('state() can take a country and return a state', t => {
+    _.times(1000, () => t.true(chance.state({ country: 'br' }).length === 2))
+})
+
 test('state() can return full state name', t => {
     _.times(1000, () => {
         t.true(chance.state({
@@ -622,6 +626,12 @@ test('state() with country returns a long state name', t => {
     _.times(1000, () => {
         t.true(chance.state({
             country: 'uk',
+            full: true
+        }).length > 2)
+    })
+    _.times(1000, () => {
+        t.true(chance.state({
+            country: 'br',
             full: true
         }).length > 2)
     })
@@ -693,6 +703,12 @@ test('states() with country of "mx" returns 32 MX states', t => {
     t.is(chance.states({
         country: 'mx'
     }).length, 32)
+})
+
+test('states() with country of "br" returns 27 BR states', t => {
+    t.is(chance.states({
+        country: 'br'
+    }).length, 27)
 })
 
 // chance.street()


### PR DESCRIPTION
Add to the state generator Brazil option (br)
```js
const br: [
                { name: "Espírito Santo", abbreviation: "ES" },
                { name: "Acre", abbreviation: "AC" },
                { name: "Alagoas", abbreviation: "AL" },
                { name: "Amapá", abbreviation: "AP" },
                { name: "Amazonas", abbreviation: "AM" },
                { name: "Bahia", abbreviation: "BA" },
                { name: "Ceará", abbreviation: "CE" },
                { name: "Distrito Federal", abbreviation: "DF" },
                { name: "Goiás", abbreviation: "GO" },
                { name: "Maranhão", abbreviation: "MA" },
                { name: "Mato Grosso", abbreviation: "MT" },
                { name: "Mato Grosso do Sul", abbreviation: "MS" },
                { name: "Minas Gerais", abbreviation: "MG" },
                { name: "Pará", abbreviation: "PA" },
                { name: "Paraíba", abbreviation: "PB" },
                { name: "Paraná", abbreviation: "PR" },
                { name: "Pernambuco", abbreviation: "PE" },
                { name: "Piauí", abbreviation: "PI" },
                { name: "Rio de Janeiro", abbreviation: "RJ" },
                { name: "Rio Grande do Norte", abbreviation: "RN" },
                { name: "Rio Grande do Sul", abbreviation: "RS" },
                { name: "Rondônia", abbreviation: "RO" },
                { name: "Roraima", abbreviation: "RR" },
                { name: "Santa Catarina", abbreviation: "SC" },
                { name: "São Paulo", abbreviation: "SP" },
                { name: "Sergipe", abbreviation: "SE" },
                { name: "Tocantins", abbreviation: "TO" },
            ]
```