### PR TITLE
Consolidate National Identification Number (NIN) Functions

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -1276,7 +1276,20 @@
      Chance.prototype.zodiac = function () {
         const zodiacSymbols = ["Aries","Taurus","Gemini","Cancer","Leo","Virgo","Libra","Scorpio","Sagittarius","Capricorn","Aquarius","Pisces"];
         return this.pickone(zodiacSymbols);
-    };
+    }; 
+    // Generate random  National Identification Number (NIN)
+    Chance.prototype.nin = function(options){
+       options = initOptions(options, {nationality:'us',})
+    
+    let nin ;
+    if(options.nationality === ("us"|| "uk")) nin = this.string({ pool: '0123456789', length: 9})
+    else if(options.nationality ===("br" ||"gr")) nin = this.string({ pool: '0123456789', length: 11})
+    else if(options.nationality ===("jp" ||"ca")) nin = this.string({ pool: '0123456789', length: 12})
+    else if(options.nationality ==="ru") nin = this.string({ pool: '0123456789', length: 14})
+    else if(options.nationality ==="it") nin = this.string({ pool: '0123456789', length: 16})
+    else if(options.nationality ==="ch") nin = this.string({ pool: '0123456789', length: 18})
+    return nin
+    }
 
 
     // -- End Person --

--- a/chance.js
+++ b/chance.js
@@ -1284,7 +1284,7 @@
     let nin ;
     if(options.nationality === ("us"|| "uk")) nin = this.string({ pool: '0123456789', length: 9})
     else if(options.nationality ===("br" ||"gr")) nin = this.string({ pool: '0123456789', length: 11})
-    else if(options.nationality ===("jp" ||"ca")) nin = this.string({ pool: '0123456789', length: 12})
+    else if(options.nationality ===("jp" ||"ca"||"in")) nin = this.string({ pool: '0123456789', length: 12})
     else if(options.nationality ==="ru") nin = this.string({ pool: '0123456789', length: 14})
     else if(options.nationality ==="it") nin = this.string({ pool: '0123456789', length: 16})
     else if(options.nationality ==="ch") nin = this.string({ pool: '0123456789', length: 18})

--- a/docs/person/nin.md
+++ b/docs/person/nin.md
@@ -1,0 +1,11 @@
+Generate a random National identification number.
+
+By default the nationality is set to `'us'`
+```js
+chance.nin();
+```
+you can explicitly specify the nationality
+```js
+chance.nin({nationality:'ca'}) 
+``` 
+Note, currently support for nationality is limited to: `'en', 'uk', 'br' , 'gr' , 'jp' ,'ch' ,'in' ,'ru', 'it'`. 


### PR DESCRIPTION
The National identification numbers has different names across countries. 
The library currently has separate functions for National Identification Numbers (NINs) from different countries, making it unsustainable as the number of NINs grows. There are currently four NINs (ssn, aadhar, cf, cpf), and this list may expand. To address this, I propose consolidating them into a single nin function. 
However I didn't delete the old functions as we may need them for formatting purposes.

After researching NIN formats for various countries, here's the data I've collected for reference: (I'd be happy if it gets checked before accepting the PR)
Country | NIN Format | Example
-- | -- | --
United Kingdom | 9 digits | 12345678901
United States | 9 digits | 12345678
China | 18 digits | 123456789012345678
Italy | 16 digits | AA000000AA00AA
Russia | 14 digits | 123456789000
France | 13 digits | 123456789012
Canada | 12 digits | 12345678901
Japan | 12 digits | 123456789012
India | 12 digits | 123456789012
Germany | 11 digits | 9999999999
Brazil | 11 digits | 999.999.999-99

Consolidating the NIN functions will enhance maintainability and future-proof the library as new NINs are introduced.
* closes #570