### PR TITLE
fix: duplicate devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-jshint": "^2.0.4",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^2.6.1",
+    "gulp-uglify-es": "^3.0.0",
     "jshint-stylish": "^2.2.1",
     "lodash": "^4.17.4",
     "nyc": "^10.3.2",
@@ -77,8 +78,5 @@
     "css": [
       "docs/chance.css"
     ]
-  },
-  "devDependencies": {
-    "gulp-uglify-es": "^3.0.0"
   }
 }


### PR DESCRIPTION
I'm using `chance` inside of [Bun](https://bun.sh/) and it complains about:

```
81 |   "devDependencies": {
       ^
warn: Duplicate key "devDependencies" in object literal
   at /myproject/node_modules/.pnpm/chance@1.1.11/node_modules/chance/package.json:81:3
```

And looks like indeed there are currently two duplicate `devDependencies` keys in the `package.json`. This PR fixes that.