### PR TITLE
[BUG FIX] Fix exclusion of values in chance.natural()

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -311,7 +311,7 @@
             }
 
             var random = options.min + this.natural({max: options.max - options.min - options.exclude.length})
-            var sortedExclusions = options.exclude.sort();
+            var sortedExclusions = options.exclude.sort((a, b) => a - b);
             for (var sortedExclusionIndex in sortedExclusions) {
                 if (random < sortedExclusions[sortedExclusionIndex]) {
                     break

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -379,6 +379,16 @@ test('natural() works with excluded numbers', t => {
     })
 })
 
+test('natural() works with excluded numbers2', t => {
+    _.times(1000, () => {
+        let natural = chance.natural({ min: 3, max: 20, exclude: [9, 18] })
+        t.true(natural <= 20)
+        t.true(natural >= 3)
+        t.true(natural !== 9)
+        t.true(natural !== 18)
+    })
+})
+
 test('natural() works within empty exclude option', t => {
     _.times(1000, () => {
         let natural = chance.natural({ min: 1, max: 5, exclude: [] })

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -379,7 +379,7 @@ test('natural() works with excluded numbers', t => {
     })
 })
 
-test('natural() works with excluded numbers2', t => {
+test('natural() works with excluded numbers with double digits', t => {
     _.times(1000, () => {
         let natural = chance.natural({ min: 3, max: 20, exclude: [9, 18] })
         t.true(natural <= 20)


### PR DESCRIPTION
# ✨ Chance.js Pull Request 💻

![Chance Logo](https://camo.githubusercontent.com/a648d5d39e61ee9e6b38c4e6b5f04139e2aa45325a8a012f0e108ada29c9f983/687474703a2f2f6368616e63656a732e636f6d2f6c6f676f2e706e67)

## Pull Request details

* Added a test that did not pass using the existing code. Using a double digit value in the exclude array broke the sorting logic in the chance.natural code.
* Fixed the sorting logic in chance.natural() and verified that the code works as intended.

## Any Breaking changes

* None

## Associated Screenshots

Acceptance Criteria:
If a number is included in the `exclude` array, then that number should not be returned from chance.natural().

For example: `chance.natural({ min: 3, max: 20, exclude: [9, 18]})`, should never return 9.

Before changes were made, 9 was returned from chance.natural():

![image](https://github.com/user-attachments/assets/c0f5e9c5-dfbb-49ba-93ea-246ff1b7838e)

After changes were made, 9 is never returned from chance.natural():

![image](https://github.com/user-attachments/assets/85cb0c98-1c07-4eb7-a7cd-503e47f55c66)

